### PR TITLE
Fixes UI

### DIFF
--- a/src/domains/app/features/product-form/basic-info/basic-info.component.test.tsx
+++ b/src/domains/app/features/product-form/basic-info/basic-info.component.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import BasicInfo from './basic-info.component';
+
+jest.mock('@shared/ui', () => ({
+  __esModule: true,
+  Input: ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <input
+      data-testid="basic-info-title"
+      value={value ?? ''}
+      onChange={onChange}
+    />
+  ),
+  Textarea: ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  }) => (
+    <textarea
+      data-testid="basic-info-description"
+      value={value ?? ''}
+      onChange={onChange}
+    />
+  ),
+}));
+
+jest.mock('domains/app/components', () => ({
+  __esModule: true,
+  GalBoxSelector: ({
+    availableOptions,
+    onSelect,
+  }: {
+    availableOptions?: string[];
+    onSelect: (value: any) => void;
+  }) => (
+    <div data-testid="product-type-selector">
+      {availableOptions?.map((option) => (
+        <button
+          key={option}
+          type="button"
+          data-testid={`product-type-${option}`}
+          onClick={() => onSelect(option)}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+describe('<BasicInfo />', () => {
+  it('shows all product type options outside edit mode', () => {
+    render(
+      <BasicInfo
+        formData={
+          {
+            type: 'COURSE',
+            name: 'How to cook',
+            description: 'desc',
+          } as any
+        }
+        setField={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('product-type-COURSE')).toBeInTheDocument();
+    expect(screen.getByTestId('product-type-CONSULTATION')).toBeInTheDocument();
+    expect(screen.getByTestId('product-type-DOWNLOAD')).toBeInTheDocument();
+  });
+
+  it('shows only the current product type option in edit mode', () => {
+    render(
+      <BasicInfo
+        formData={
+          {
+            type: 'COURSE',
+            name: 'How to cook',
+            description: 'desc',
+          } as any
+        }
+        setField={jest.fn()}
+        showOnlyCurrentType
+      />,
+    );
+
+    expect(screen.getByTestId('product-type-COURSE')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('product-type-CONSULTATION'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('product-type-DOWNLOAD')).not.toBeInTheDocument();
+  });
+
+  it('still routes selection through setField for the current type', () => {
+    const setField = jest.fn();
+
+    render(
+      <BasicInfo
+        formData={
+          {
+            type: 'DOWNLOAD',
+            name: 'Asset pack',
+            description: 'desc',
+          } as any
+        }
+        setField={setField}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('product-type-DOWNLOAD'));
+
+    expect(setField).toHaveBeenCalledWith('type', 'DOWNLOAD');
+  });
+});

--- a/src/domains/app/features/product-form/basic-info/basic-info.component.tsx
+++ b/src/domains/app/features/product-form/basic-info/basic-info.component.tsx
@@ -9,6 +9,7 @@ import './basic-info.styles.scss';
 
 interface BasicInfoProps {
   formData: ProductDraft;
+  showOnlyCurrentType?: boolean;
   setField: <K extends keyof ProductDraft>(
     // eslint-disable-next-line no-unused-vars
     field: K,
@@ -17,38 +18,48 @@ interface BasicInfoProps {
   ) => void;
 }
 
-const BasicInfo: React.FC<BasicInfoProps> = ({ formData, setField }) => (
-  <div className="basic-info">
-    <Input
-      type="text"
-      name="name"
-      label="Title"
-      value={formData.name ?? ''}
-      className="title-input"
-      onChange={(e: { target: { value: string } }) =>
-        setField('name', e.target.value)
-      }
-    />
+const BasicInfo: React.FC<BasicInfoProps> = ({
+  formData,
+  setField,
+  showOnlyCurrentType = false,
+}) => {
+  const availableProductTypes: ProductType[] = showOnlyCurrentType
+    ? [formData.type]
+    : ['CONSULTATION', 'COURSE', 'DOWNLOAD'];
 
-    <div className="product-type-selectors">
-      <span className="type-selectors-label">Product Type</span>
-      <GalBoxSelector<ProductType>
-        selectedOption={formData.type}
-        selectFor="product"
-        onSelect={(type) => setField('type', type)}
-        availableOptions={['CONSULTATION', 'COURSE', 'DOWNLOAD']} // Example lesson types
-        disabledOptions={[]} // Add any disabled options if needed
+  return (
+    <div className="basic-info">
+      <Input
+        type="text"
+        name="name"
+        label="Title"
+        value={formData.name ?? ''}
+        className="title-input"
+        onChange={(e: { target: { value: string } }) =>
+          setField('name', e.target.value)
+        }
+      />
+
+      <div className="product-type-selectors">
+        <span className="type-selectors-label">Product Type</span>
+        <GalBoxSelector<ProductType>
+          selectedOption={formData.type}
+          selectFor="product"
+          onSelect={(type) => setField('type', type)}
+          availableOptions={availableProductTypes}
+          disabledOptions={[]} // Add any disabled options if needed
+        />
+      </div>
+      <Textarea
+        label="Description"
+        name="description"
+        value={formData.description ?? ''}
+        onChange={(e: { target: { value: string } }) =>
+          setField('description', e.target.value)
+        }
       />
     </div>
-    <Textarea
-      label="Description"
-      name="description"
-      value={formData.description ?? ''}
-      onChange={(e: { target: { value: string } }) =>
-        setField('description', e.target.value)
-      }
-    />
-  </div>
-);
+  );
+};
 
 export default BasicInfo;

--- a/src/domains/app/features/product-form/editors/editable-title/editable-title.component.test.tsx
+++ b/src/domains/app/features/product-form/editors/editable-title/editable-title.component.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import EditableTitle from './editable-title.component';
+
+describe('<EditableTitle />', () => {
+  it('renders the initial value on first mount', () => {
+    render(
+      <EditableTitle value="Gather ingredients" onChange={jest.fn()} small />,
+    );
+
+    expect(screen.getByText('Gather ingredients')).toBeInTheDocument();
+  });
+
+  it('emits the edited value on blur', () => {
+    const onChange = jest.fn();
+
+    render(<EditableTitle value="Original" onChange={onChange} />);
+
+    const title = screen.getByText('Original');
+
+    title.textContent = 'Updated';
+    fireEvent.blur(title);
+
+    expect(onChange).toHaveBeenCalledWith('Updated');
+  });
+});

--- a/src/domains/app/features/product-form/editors/editable-title/editable-title.component.tsx
+++ b/src/domains/app/features/product-form/editors/editable-title/editable-title.component.tsx
@@ -23,23 +23,23 @@ const EditableTitle: React.FC<EditableTitleProps> = ({
   const lastPropValueRef = useRef<string>(value);
   const [isFocused, setFocused] = useState(false);
 
-  // Initialize / update text ONLY when the prop value changes from outside
   useEffect(() => {
     if (!ref.current) {
       return;
     }
 
-    if (value !== lastPropValueRef.current) {
-      ref.current.innerText = value;
-      lastPropValueRef.current = value;
+    if (ref.current.textContent !== value) {
+      ref.current.textContent = value;
     }
+
+    lastPropValueRef.current = value;
   }, [value]);
 
   const handleBlur = () => {
     if (!ref.current) {
       return;
     }
-    const text = ref.current.innerText;
+    const text = ref.current.textContent ?? '';
     lastPropValueRef.current = text;
     onChange(text);
   };

--- a/src/domains/app/features/product-form/editors/section-editor/section-editor.component.tsx
+++ b/src/domains/app/features/product-form/editors/section-editor/section-editor.component.tsx
@@ -148,7 +148,7 @@ const SectionEditor: React.FC<SectionEditorProps> = ({
   return (
     <ExpansionPanel
       className="section-editor"
-      id={`lesson-${sectionDomId}`}
+      id={`section-${sectionDomId}`}
       defaultExpanded={true}
       hideToggle={!section.id}
       header={

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
@@ -121,7 +121,11 @@ const ProductForm: React.FC = () => {
 
             <div className="product-create-section">
               {activeTab === 'basics' && (
-                <BasicInfo formData={formData} setField={setField} />
+                <BasicInfo
+                  formData={formData}
+                  setField={setField}
+                  showOnlyCurrentType={isEditMode}
+                />
               )}
 
               {activeTab === 'pricing' && (

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
@@ -47,6 +47,10 @@ const ProductForm: React.FC = () => {
 
   const [activeTab, setActiveTab] = useState<BuilderTab | null>(null);
   const [hasHeroCollapsed, setHasHeroCollapsed] = useState(false);
+  const [pendingSidebarScrollTarget, setPendingSidebarScrollTarget] = useState<{
+    id: string;
+    type: 'section' | 'lesson';
+  } | null>(null);
 
   const container = useRef<HTMLDivElement>(null);
 
@@ -61,6 +65,49 @@ const ProductForm: React.FC = () => {
       setActiveTab(tab);
     }
   }, [formData.type, showRestOfForm]);
+
+  useEffect(() => {
+    if (activeTab !== 'sections' || !pendingSidebarScrollTarget) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      if (pendingSidebarScrollTarget.type === 'section') {
+        handleSidebarSectionClick(pendingSidebarScrollTarget.id);
+      } else {
+        handleSidebarLessonClick(pendingSidebarScrollTarget.id);
+      }
+
+      setPendingSidebarScrollTarget(null);
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    activeTab,
+    pendingSidebarScrollTarget,
+    handleSidebarLessonClick,
+    handleSidebarSectionClick,
+  ]);
+
+  const handleSidebarSectionNavigation = (sectionId: string) => {
+    if (activeTab === 'sections') {
+      handleSidebarSectionClick(sectionId);
+      return;
+    }
+
+    setPendingSidebarScrollTarget({ id: sectionId, type: 'section' });
+    setActiveTab('sections');
+  };
+
+  const handleSidebarLessonNavigation = (lessonId: string) => {
+    if (activeTab === 'sections') {
+      handleSidebarLessonClick(lessonId);
+      return;
+    }
+
+    setPendingSidebarScrollTarget({ id: lessonId, type: 'lesson' });
+    setActiveTab('sections');
+  };
 
   useProductFormAnimation(container, showRestOfForm, () => {
     setHasHeroCollapsed(true);
@@ -114,8 +161,8 @@ const ProductForm: React.FC = () => {
                 activeTab={activeTab}
                 sections={sidebarSections} // your sections + lessons summary
                 onChange={(tab) => setActiveTab(tab)}
-                onSectionClick={handleSidebarSectionClick}
-                onLessonClick={handleSidebarLessonClick}
+                onSectionClick={handleSidebarSectionNavigation}
+                onLessonClick={handleSidebarLessonNavigation}
               />
             </div>
 

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
@@ -91,9 +91,13 @@ jest.mock('domains/app/features/product-form', () => ({
   BuilderSidebar: ({
     activeTab,
     onChange,
+    onSectionClick,
+    onLessonClick,
   }: {
     activeTab: string | null;
     onChange: (tab: any) => void;
+    onSectionClick?: (id: string) => void;
+    onLessonClick?: (id: string) => void;
   }) => (
     <div data-testid="builder-sidebar">
       <span data-testid="active-tab">{activeTab ?? 'none'}</span>
@@ -114,6 +118,18 @@ jest.mock('domains/app/features/product-form', () => ({
       </button>
       <button data-testid="tab-media" onClick={() => onChange('media')}>
         Media
+      </button>
+      <button
+        data-testid="sidebar-section-link"
+        onClick={() => onSectionClick?.('section-1')}
+      >
+        Go section
+      </button>
+      <button
+        data-testid="sidebar-lesson-link"
+        onClick={() => onLessonClick?.('lesson-1')}
+      >
+        Go lesson
       </button>
     </div>
   ),
@@ -335,5 +351,51 @@ describe('<ProductForm />', () => {
     fireEvent.submit(form!);
 
     expect(handleSubmitMock).toHaveBeenCalled();
+  });
+
+  it('switches to Sections before triggering section navigation from the sidebar', async () => {
+    const state = makeFacadeState();
+
+    mockUseProductFormFacade.mockReturnValue(state);
+
+    render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('builder-sidebar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('tab-pricing'));
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('pricing');
+
+    fireEvent.click(screen.getByTestId('sidebar-section-link'));
+
+    await waitFor(() => {
+      expect(state.handleSidebarSectionClick).toHaveBeenCalledWith('section-1');
+    });
+
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('sections');
+  });
+
+  it('switches to Sections before triggering lesson navigation from the sidebar', async () => {
+    const state = makeFacadeState();
+
+    mockUseProductFormFacade.mockReturnValue(state);
+
+    render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('builder-sidebar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('tab-media'));
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('media');
+
+    fireEvent.click(screen.getByTestId('sidebar-lesson-link'));
+
+    await waitFor(() => {
+      expect(state.handleSidebarLessonClick).toHaveBeenCalledWith('lesson-1');
+    });
+
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('sections');
   });
 });

--- a/src/shared/ui/expansion-panel/expansion-panel.component.test.tsx
+++ b/src/shared/ui/expansion-panel/expansion-panel.component.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ExpansionPanel from './expansion-panel.component';
+
+describe('<ExpansionPanel />', () => {
+  it('forwards the id prop to the root element', () => {
+    render(
+      <ExpansionPanel id="section-section-1" header={<span>Header</span>}>
+        <div>Body</div>
+      </ExpansionPanel>,
+    );
+
+    expect(screen.getByText('Header').closest('#section-section-1')).toBeInTheDocument();
+  });
+});

--- a/src/shared/ui/expansion-panel/expansion-panel.component.tsx
+++ b/src/shared/ui/expansion-panel/expansion-panel.component.tsx
@@ -26,6 +26,7 @@ const ExpansionPanel: React.FC<ExpansionPanelProps> = ({
   hideToggle = false,
   className,
   onPanelToggle,
+  ...divProps
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(defaultExpanded);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -42,7 +43,10 @@ const ExpansionPanel: React.FC<ExpansionPanelProps> = ({
   };
 
   return (
-    <div className={clsx('expansion-panel', className, { disabled })}>
+    <div
+      {...divProps}
+      className={clsx('expansion-panel', className, { disabled })}
+    >
       <header className="expansion-panel-header">
         <div className="panel-header-content">{header}</div>
         {!hideToggle && (


### PR DESCRIPTION
### What changed

fix: render existing section and lesson titles in product editor 
fix: restore sidebar scrolling to course sections and lessons on edit page
fix: show only the current product type when editing products 
-

### Checklist

- [x] Updated docs if behavior/routes changed
  - [x] `docs/docs/routing-map.md`
  - [x] Relevant guide/playbook page(s)
- [x] Added/updated tests (unit/e2e) if applicable
- [ ] Screens checked for a11y basics (keyboard/focus)

### Screenshots / notes
