### PR TITLE
Add dev role switcher and shared dashboard access

### DIFF
--- a/src/core/api/services/user/user-api.test.ts
+++ b/src/core/api/services/user/user-api.test.ts
@@ -2,7 +2,11 @@
 import httpClient from '../../http-client';
 import { UpdateUserRequest } from '../../models/user/update-user-request';
 import { User, UserRole } from '../../models/user/user';
-import { getUserProfileAPI, updateUserDetailsAPI } from './user-api';
+import {
+  changeDevUserRoleAPI,
+  getUserProfileAPI,
+  updateUserDetailsAPI,
+} from './user-api';
 
 jest.mock('../../http-client');
 
@@ -84,6 +88,28 @@ describe('User API', () => {
         'Update failed',
       );
       expect(errorLogSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('changeDevUserRoleAPI', () => {
+    it('PUTs the requested role and returns the updated user', async () => {
+      const response: User = {
+        firstName: 'Mock',
+        lastName: 'Creator',
+        email: 'mock@creator.test',
+        roles: [UserRole.CREATOR],
+      };
+
+      mockedHttpClient.put.mockResolvedValueOnce({ data: response });
+
+      const result = await changeDevUserRoleAPI(UserRole.CREATOR);
+
+      expect(result).toEqual(response);
+      expect(mockedHttpClient.put).toHaveBeenCalledWith(
+        'api/user/dev/role',
+        { role: UserRole.CREATOR },
+        { withCredentials: true },
+      );
     });
   });
 });

--- a/src/core/api/services/user/user-api.tsx
+++ b/src/core/api/services/user/user-api.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import httpClient from '../../http-client';
 import { UpdateUserRequest } from '../../models/user/update-user-request';
-import { User } from '../../models/user/user';
+import { User, UserRole } from '../../models/user/user';
 
 export const getUserProfileAPI = async () => {
   try {
@@ -23,6 +23,20 @@ export const updateUserDetailsAPI = async (payload: UpdateUserRequest) => {
     return response.data;
   } catch (error) {
     console.error('Error updating user details:', error);
+    throw error;
+  }
+};
+
+export const changeDevUserRoleAPI = async (role: UserRole) => {
+  try {
+    const response = await httpClient.put<User>(
+      'api/user/dev/role',
+      { role },
+      { withCredentials: true },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error changing dev user role:', error);
     throw error;
   }
 };

--- a/src/core/store/auth-store/auth-slice.test.ts
+++ b/src/core/store/auth-store/auth-slice.test.ts
@@ -6,6 +6,7 @@ import authReducer, {
   signupUser,
   verifyEmail,
   signinUser,
+  changeDevUserRole,
 } from './auth.slice';
 
 // Define an initial state matching your AuthState interface
@@ -110,5 +111,25 @@ describe('auth slice async thunks', () => {
     const state = authReducer({ ...initialState, loading: true }, action);
     expect(state.loading).toBe(false);
     expect(state.error).toBe('Signin failed');
+  });
+
+  it('should handle changeDevUserRole.fulfilled', () => {
+    const user = {
+      firstName: 'Alice',
+      lastName: 'Creator',
+      email: 'alice@example.com',
+      roles: [UserRole.CREATOR],
+    } as User;
+
+    const action = {
+      type: changeDevUserRole.fulfilled.type,
+      payload: user,
+    };
+
+    const state = authReducer({ ...initialState, loading: true }, action);
+
+    expect(state.loading).toBe(false);
+    expect(state.user).toEqual(user);
+    expect(state.isUserLoggedIn).toBe(true);
   });
 });

--- a/src/core/store/auth-store/auth.slice.ts
+++ b/src/core/store/auth-store/auth.slice.ts
@@ -6,6 +6,7 @@ import {
   RegisterRequest,
   UpdateUserRequest,
   User,
+  UserRole,
 } from 'core/api/models';
 import {
   registerUser,
@@ -15,6 +16,7 @@ import {
   getUserProfileAPI,
   logoutAPI,
   updateUserDetailsAPI,
+  changeDevUserRoleAPI,
 } from 'core/api/services';
 import { extractErrorMessage } from '@shared/utils';
 
@@ -129,6 +131,18 @@ export const updateUserDetails = createAsyncThunk<
   try {
     const response = await updateUserDetailsAPI(userData);
     return response; // API returns user info with token
+  } catch (error: unknown) {
+    return rejectWithValue(extractErrorMessage(error));
+  }
+});
+
+export const changeDevUserRole = createAsyncThunk<
+  User,
+  UserRole,
+  { rejectValue: string }
+>('auth/changeDevUserRole', async (role, { rejectWithValue }) => {
+  try {
+    return await changeDevUserRoleAPI(role);
   } catch (error: unknown) {
     return rejectWithValue(extractErrorMessage(error));
   }
@@ -249,6 +263,22 @@ const authSlice = createSlice({
       .addCase(updateUserDetails.rejected, (state) => {
         state.loading = false;
         state.error = 'Update user details failed';
+      })
+      .addCase(changeDevUserRole.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(
+        changeDevUserRole.fulfilled,
+        (state, action: PayloadAction<User>) => {
+          state.loading = false;
+          state.user = action.payload;
+          state.isUserLoggedIn = true;
+        },
+      )
+      .addCase(changeDevUserRole.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload || 'Change dev user role failed';
       });
   },
 });

--- a/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.component.tsx
+++ b/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.component.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { AppDispatch, getPrimaryRole } from 'core/api/models';
+import {
+  AppDispatch,
+  getPrimaryRole,
+  rolePrecedence,
+  UserRole,
+} from 'core/api/models';
 import { GalDropdown, UserAvatar } from '@shared/ui';
 import {
   selectAuthUser,
+  changeDevUserRole,
   logout,
   logoutUser,
 } from 'core/store/auth-store';
@@ -17,6 +23,13 @@ const GalUserDropdown: React.FC = () => {
   const user = useSelector(selectAuthUser);
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
+  const primaryRole = getPrimaryRole(user?.roles);
+  const roleOptions = rolePrecedence.filter((role) => role !== primaryRole);
+  const showDevRoleSwitch = process.env.NODE_ENV !== 'production';
+
+  const handleRoleChange = (role: UserRole) => {
+    dispatch(changeDevUserRole(role));
+  };
 
   // Log the user out
   const handleLogout = () => {
@@ -67,8 +80,25 @@ const GalUserDropdown: React.FC = () => {
               <span>{user.email}</span>
             </div>
             <div className="dropdown-item">
-              <span>Role: {getPrimaryRole(user.roles)}</span>
+              <span>Role: {primaryRole}</span>
             </div>
+            {showDevRoleSwitch && (
+              <div className="dropdown-item dev-role-switch">
+                <span>Change Role (for dev):</span>
+                <div className="role-selector">
+                  {roleOptions.map((role) => (
+                    <button
+                      key={role}
+                      type="button"
+                      className="role-button"
+                      onClick={() => handleRoleChange(role)}
+                    >
+                      {role}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
             <div className="dropdown-item dev-items">
               <Link to="/dev-dashboard">Dev Dashboard</Link>
               <Link

--- a/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.styles.scss
+++ b/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.styles.scss
@@ -26,18 +26,24 @@
       cursor: pointer;
     }
 
+    .dev-role-switch {
+      align-items: flex-start;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
     .role-selector {
       display: flex;
       align-items: center;
+      gap: 8px;
 
       .role-button {
         padding: 0.4rem 0.8rem;
         background: #fff;
+        border: 1px solid var(--border-color, #d0d0d0);
+        border-radius: 4px;
         cursor: pointer;
-
-        &.selected {
-          font-weight: bold;
-        }
 
         &:hover {
           background: #f0f0f0;

--- a/src/domains/app/components/gal-user-dropdown/gal-user.dropdown.test.tsx
+++ b/src/domains/app/components/gal-user-dropdown/gal-user.dropdown.test.tsx
@@ -75,7 +75,23 @@ describe('GalUserDropdown component', () => {
     fireEvent.click(profileButton);
     expect(screen.getByText(/john\.doe@example\.com/i)).toBeInTheDocument();
     expect(screen.getByText(/role: admin/i)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: UserRole.CREATOR })).toBeNull();
+    expect(screen.getByText(/change role \(for dev\):/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: UserRole.CREATOR })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: UserRole.USER })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: UserRole.ADMIN })).toBeNull();
+  });
+
+  it('dispatches backend-backed dev role changes from the role switcher', () => {
+    render(
+      <MemoryRouter>
+        <GalUserDropdown />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /jd/i }));
+    fireEvent.click(screen.getByRole('button', { name: UserRole.CREATOR }));
+
+    expect(mockDispatch).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it('closes the dropdown when clicking outside', () => {

--- a/src/domains/app/components/product-card/product-card.component.tsx
+++ b/src/domains/app/components/product-card/product-card.component.tsx
@@ -44,7 +44,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
   };
 
   return (
-    <div className="product-card">
+    <div className="vp-product-card">
       <img src={imgSrc} alt={productName} className="product-card-image" />
       <div className="product-card-details">
         <div className="product-card-header">

--- a/src/domains/app/components/product-card/product-card.test.tsx
+++ b/src/domains/app/components/product-card/product-card.test.tsx
@@ -38,10 +38,11 @@ describe('ProductCard', () => {
       updatedAt: new Date('2026-03-02T00:00:00.000Z'),
     };
 
-    render(
+    const { container } = render(
       <ProductCard product={product} />,
     );
 
+    expect(container.firstChild).toHaveClass('vp-product-card');
     expect(
       screen.getByRole('heading', { level: 2, name: 'Masterclass' }),
     ).toBeInTheDocument();

--- a/src/domains/app/features/product-form/hooks/use-product-form.facade.test.tsx
+++ b/src/domains/app/features/product-form/hooks/use-product-form.facade.test.tsx
@@ -1,0 +1,131 @@
+import { renderHook } from '@testing-library/react';
+
+import { useProductFormFacade } from './use-product-form.facade';
+
+const mockDispatch = jest.fn();
+const mockNavigate = jest.fn();
+const mockUseProductLoader = jest.fn();
+const mockUseProductAutosave = jest.fn();
+const mockUseProductFormState = jest.fn();
+const mockUseProductActions = jest.fn();
+const mockUseSidebarSections = jest.fn();
+const mockUseSidebarScroll = jest.fn();
+
+let mockParams = { id: 'product-1', type: 'COURSE' as string | undefined };
+let mockFormName = 'Initial product';
+
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  useDispatch: () => mockDispatch,
+  useSelector: () => ({ id: 'user-1' }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: () => mockNavigate,
+  useParams: () => mockParams,
+}));
+
+jest.mock('./use-product-loader.hooks', () => ({
+  __esModule: true,
+  useProductLoader: (...args: unknown[]) => mockUseProductLoader(...args),
+}));
+
+jest.mock('./use-product-autosave.hook', () => ({
+  __esModule: true,
+  useProductAutosave: (...args: unknown[]) => mockUseProductAutosave(...args),
+}));
+
+jest.mock('./use-product-form-state.hook', () => ({
+  __esModule: true,
+  useProductFormState: (...args: unknown[]) =>
+    mockUseProductFormState(...args),
+}));
+
+jest.mock('./use-product.actions.hook', () => ({
+  __esModule: true,
+  useProductActions: (...args: unknown[]) => mockUseProductActions(...args),
+}));
+
+jest.mock('./use-sidebar-scroll.hook', () => ({
+  __esModule: true,
+  useSidebarSections: (...args: unknown[]) => mockUseSidebarSections(...args),
+  useSidebarScroll: (...args: unknown[]) => mockUseSidebarScroll(...args),
+}));
+
+const setFormData = jest.fn();
+const setErrors = jest.fn();
+const setShowRestOfForm = jest.fn();
+
+const mockFormState = () => {
+  mockUseProductFormState.mockImplementation(() => ({
+    formData: {
+      id: 'product-1',
+      name: mockFormName,
+      description: '',
+      type: 'COURSE',
+      price: 'free',
+      sections: [],
+    },
+    setFormData,
+    setField: jest.fn(),
+    errors: {},
+    setErrors,
+    validateForm: jest.fn(),
+    handleSetPrice: jest.fn(),
+    productImage: null,
+    handleImageChange: jest.fn(),
+    showRestOfForm: true,
+    setShowRestOfForm,
+    showLoadingRestOfForm: false,
+    setShowLoadingRestOfForm: jest.fn(),
+  }));
+};
+
+describe('useProductFormFacade', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { id: 'product-1', type: 'COURSE' };
+    mockFormName = 'Initial product';
+    mockFormState();
+    mockUseProductLoader.mockReturnValue({ lastSavedSnapshot: { current: null } });
+    mockUseProductAutosave.mockReturnValue({
+      isAutosaving: false,
+      lastSavedAt: null,
+    });
+    mockUseProductActions.mockReturnValue({
+      handleSubmit: jest.fn(),
+      handleProductRemove: jest.fn(),
+    });
+    mockUseSidebarSections.mockReturnValue([]);
+    mockUseSidebarScroll.mockReturnValue({
+      handleSidebarSectionClick: jest.fn(),
+      handleSidebarLessonClick: jest.fn(),
+    });
+  });
+
+  it('keeps the product-loaded callback stable across form-only rerenders', () => {
+    const { rerender } = renderHook(() => useProductFormFacade());
+
+    const firstCallback = mockUseProductLoader.mock.calls[0][0].onProductLoaded;
+
+    mockFormName = 'Typed locally';
+    rerender();
+
+    const secondCallback = mockUseProductLoader.mock.calls[1][0].onProductLoaded;
+    expect(secondCallback).toBe(firstCallback);
+  });
+
+  it('redirects once when the loaded product type does not match the route type', () => {
+    renderHook(() => useProductFormFacade());
+
+    const onProductLoaded =
+      mockUseProductLoader.mock.calls[0][0].onProductLoaded;
+
+    onProductLoaded({ id: 'product-1', type: 'DOWNLOAD' });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/products/edit/product-1', {
+      replace: true,
+    });
+  });
+});

--- a/src/domains/app/features/product-form/hooks/use-product-form.facade.ts
+++ b/src/domains/app/features/product-form/hooks/use-product-form.facade.ts
@@ -1,7 +1,8 @@
 import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { AppDispatch } from 'core/api/models';
+import { AbstractProduct, AppDispatch } from 'core/api/models';
 import { selectAuthUser } from 'core/store/auth-store';
 import { UseProductFormFacadeResult } from '../models/product-form';
 import { useProductAutosave } from './use-product-autosave.hook';
@@ -37,6 +38,15 @@ export const useProductFormFacade = (): UseProductFormFacadeResult => {
     setShowLoadingRestOfForm,
   } = useProductFormState();
 
+  const handleProductLoaded = useCallback(
+    (product: AbstractProduct) => {
+      if (type && product.type !== type) {
+        navigate(`/app/products/edit/${product.id}`, { replace: true });
+      }
+    },
+    [navigate, type],
+  );
+
   // 2) load existing product
   useProductLoader({
     isEditMode,
@@ -45,11 +55,7 @@ export const useProductFormFacade = (): UseProductFormFacadeResult => {
     setFormData,
     setErrors,
     setShowRestOfForm,
-    onProductLoaded: (product) => {
-      if (type && product.type !== type) {
-        navigate(`/app/products/edit/${product.id}`, { replace: true });
-      }
-    },
+    onProductLoaded: handleProductLoaded,
   });
 
   // 3) autosave

--- a/src/domains/app/pages/app-layout/app-layout.component.tsx
+++ b/src/domains/app/pages/app-layout/app-layout.component.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import clsx from 'clsx';
 
 import { selectAuthUser } from 'core/store/auth-store';
-import { isCreatorOrAdmin } from 'core/api/models';
+import { hasRole, UserRole } from 'core/api/models';
 import {
   SidebarLayoutProvider,
   SidebarNav,
@@ -43,7 +43,7 @@ const Shell: React.FC = () => {
 
   const user = useSelector(selectAuthUser);
 
-  const isUserCreator = isCreatorOrAdmin(user?.roles);
+  const isUserCreator = hasRole(user?.roles, UserRole.CREATOR);
 
   const inCreatorArea = CREATOR_ROUTES.some((pattern) =>
     Boolean(matchPath(pattern, location.pathname)),

--- a/src/domains/app/pages/creator-specific/creator-dashboard/creator-dashboard.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/creator-dashboard/creator-dashboard.component.test.tsx
@@ -63,6 +63,7 @@ jest.mock('@shared/ui', () => ({
 }));
 
 import CreatorDashboard from './creator-dashboard.component';
+import { UserRole } from 'core/api/models';
 
 describe('<CreatorDashboard />', () => {
   const mockedUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
@@ -89,6 +90,7 @@ describe('<CreatorDashboard />', () => {
           firstName: 'Ada',
           lastName: 'Lovelace',
           email: 'ada@example.com',
+          roles: [UserRole.CREATOR],
         };
       }
       if (selector === selectTopThreeProducts) {
@@ -144,6 +146,7 @@ describe('<CreatorDashboard />', () => {
           firstName: 'Ada',
           lastName: 'Lovelace',
           email: 'ada@example.com',
+          roles: [UserRole.CREATOR],
         };
       }
       if (selector === selectTopThreeProducts) {
@@ -159,5 +162,34 @@ describe('<CreatorDashboard />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Create Product' }));
     expect(mockNavigate).toHaveBeenCalledWith('products/create');
+  });
+
+  it('renders the shared dashboard for non-creators without creator actions', () => {
+    mockedUseSelector.mockImplementation((selector: any) => {
+      if (selector === selectAuthUser) {
+        return {
+          id: 'user-1',
+          firstName: 'Normal',
+          lastName: 'User',
+          email: 'normal@example.com',
+          roles: [UserRole.USER],
+        };
+      }
+      if (selector === selectTopThreeProducts) {
+        return [];
+      }
+      return undefined;
+    });
+
+    render(<CreatorDashboard />);
+
+    expect(screen.getByText(/user account/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/creator tools are available when your active role is creator/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Create Product' })).toBeNull();
+    expect(mockedGetProductSummariesByOwner).not.toHaveBeenCalled();
+    expect(mockedGetAllProductsByUserId).not.toHaveBeenCalled();
   });
 });

--- a/src/domains/app/pages/creator-specific/creator-dashboard/creator-dashboard.component.tsx
+++ b/src/domains/app/pages/creator-specific/creator-dashboard/creator-dashboard.component.tsx
@@ -11,7 +11,7 @@ import {
   selectTopThreeProducts,
   getProductSummariesByOwner,
 } from 'core/store/product-store';
-import { AppDispatch } from 'core/api/models';
+import { AppDispatch, getPrimaryRole, hasRole, UserRole } from 'core/api/models';
 
 import './creator-dashboard.styles.scss';
 
@@ -20,13 +20,14 @@ const CreatorDashboard: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const user = useSelector(selectAuthUser);
   const topThreeProducts = useSelector(selectTopThreeProducts);
+  const isCreator = hasRole(user?.roles, UserRole.CREATOR);
 
   useEffect(() => {
-    if (user && user.id) {
+    if (isCreator && user && user.id) {
       dispatch(getProductSummariesByOwner(user.id));
       dispatch(getAllProductsByUserId(user.id));
     }
-  }, [dispatch, user]);
+  }, [dispatch, isCreator, user]);
 
   return (
     <div className="user-dashboard-container">
@@ -39,28 +40,36 @@ const CreatorDashboard: React.FC = () => {
               {user?.firstName} {user?.lastName}
             </h2>
             <span>{user?.email}</span>
-            <span>Content Creator</span>
+            <span>
+              {isCreator
+                ? 'Content Creator'
+                : `${getPrimaryRole(user?.roles)} account`}
+            </span>
             <span>
               Member since: <strong>12 March 2025</strong>
             </span>
           </div>
         </div>
 
-        <div className="action-buttons-container">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => navigate('my-page-preview')}
-          >
-            Preview
-          </Button>
-        </div>
+        {isCreator && (
+          <div className="action-buttons-container">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => navigate('my-page-preview')}
+            >
+              Preview
+            </Button>
+          </div>
+        )}
       </div>
 
       <div className="producs-section">
         <h2>Most successful products</h2>
         <div className="product-cards">
-          {topThreeProducts && topThreeProducts.length > 0 ? (
+          {!isCreator ? (
+            <p>Creator tools are available when your active role is CREATOR.</p>
+          ) : topThreeProducts && topThreeProducts.length > 0 ? (
             topThreeProducts.map((item) => (
               <GalProductCard key={item.id} product={item} />
             ))

--- a/src/domains/app/routes/app-router.tsx
+++ b/src/domains/app/routes/app-router.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Route, Routes, Navigate, Outlet } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 
 import {
-  AdminPage,
   AllProductsTab,
   AppLayout,
   Cart,
@@ -12,7 +10,6 @@ import {
   CreatorDashboard,
   DownloadPackagesTab,
   ExplorePage,
-  GalacticaHome,
   LibraryPage,
   MarketingPage,
   Onboarding,
@@ -26,122 +23,106 @@ import {
   UserPagePreview,
   WishlistTab,
 } from '../pages';
-import { selectAuthUser } from '@core/store';
 import { ProtectedRoute } from '@core/providers';
-import { getPrimaryRole, UserRole } from '@core/api';
+import { UserRole } from '@core/api';
 
-const AppRouter: React.FC = () => {
-  const user = useSelector(selectAuthUser);
+const AppRouter: React.FC = () => (
+  <Routes>
+    {/* Onboarding lives at root (same as your current setup) */}
+    <Route
+      path="/onboarding"
+      element={
+        <ProtectedRoute
+          allowedRoles={[UserRole.ADMIN, UserRole.CREATOR, UserRole.USER]}
+        >
+          <Onboarding />
+        </ProtectedRoute>
+      }
+    />
 
-  return (
-    <Routes>
-      {/* Onboarding lives at root (same as your current setup) */}
+    {/* /app englobes the whole app part (public + protected routes) */}
+    <Route path="/" element={<AppLayout />}>
+      {/* Public routes under /app */}
+      <Route path="explore" element={<ExplorePage />} />
+      <Route path="explore/search" element={<SearchResultsPage />} />
+      <Route path="product/:id" element={<ProductPage />} />
+      <Route path="product/:id/:type" element={<ProductPage />} />
+      <Route path="store/:creatorId" element={<StorefrontPage />} />
+
+      {/* Protected wrapper */}
       <Route
-        path="/onboarding"
         element={
           <ProtectedRoute
             allowedRoles={[UserRole.ADMIN, UserRole.CREATOR, UserRole.USER]}
           >
-            <Onboarding />
+            <Outlet />
           </ProtectedRoute>
         }
-      />
+      >
+        {/* Shared dashboard home */}
+        <Route index element={<CreatorDashboard />} />
 
-      {/* /app englobes the whole app part (public + protected routes) */}
-      <Route path="/" element={<AppLayout />}>
-        {/* Public routes under /app */}
-        <Route path="explore" element={<ExplorePage />} />
-        <Route path="explore/search" element={<SearchResultsPage />} />
-        <Route path="product/:id" element={<ProductPage />} />
-        <Route path="product/:id/:type" element={<ProductPage />} />
-        <Route path="store/:creatorId" element={<StorefrontPage />} />
-
-        {/* Protected wrapper */}
+        {/* Creator/Admin: products */}
         <Route
+          path="products"
           element={
-            <ProtectedRoute
-              allowedRoles={[UserRole.ADMIN, UserRole.CREATOR, UserRole.USER]}
-            >
+            <ProtectedRoute allowedRoles={[UserRole.CREATOR, UserRole.ADMIN]}>
               <Outlet />
             </ProtectedRoute>
           }
         >
-          {/* Role-based home */}
-          <Route
-            index
-            element={
-              getPrimaryRole(user?.roles) === UserRole.ADMIN ? (
-                <AdminPage />
-              ) : getPrimaryRole(user?.roles) === UserRole.CREATOR ? (
-                <CreatorDashboard />
-              ) : (
-                <GalacticaHome />
-              )
-            }
-          />
-
-          {/* Creator/Admin: products */}
-          <Route
-            path="products"
-            element={
-              <ProtectedRoute allowedRoles={[UserRole.CREATOR, UserRole.ADMIN]}>
-                <Outlet />
-              </ProtectedRoute>
-            }
-          >
-            <Route index element={<ProductsList />} />
-            <Route path="create" element={<ProductForm />} />
-            <Route path="edit/:id" element={<ProductForm />} />
-            <Route path="edit/:type/:id" element={<ProductForm />} />
-          </Route>
-
-          <Route
-            path="sales"
-            element={
-              <ProtectedRoute allowedRoles={[UserRole.CREATOR, UserRole.ADMIN]}>
-                <SalesPage />
-              </ProtectedRoute>
-            }
-          />
-
-          <Route
-            path="marketing"
-            element={
-              <ProtectedRoute allowedRoles={[UserRole.CREATOR, UserRole.ADMIN]}>
-                <MarketingPage />
-              </ProtectedRoute>
-            }
-          />
-
-          {/* User/Admin: library */}
-          <Route
-            path="library"
-            element={
-              <ProtectedRoute allowedRoles={[UserRole.USER, UserRole.ADMIN]}>
-                <LibraryPage />
-              </ProtectedRoute>
-            }
-          >
-            <Route path="all-products" element={<AllProductsTab />} />
-            <Route path="my-courses" element={<CoursesTab />} />
-            <Route
-              path="my-download-packages"
-              element={<DownloadPackagesTab />}
-            />
-            <Route path="my-consultation" element={<ConsultationTab />} />
-            <Route path="my-wishlist" element={<WishlistTab />} />
-          </Route>
-
-          <Route path="settings" element={<SettingsPage />} />
-          <Route path="my-page-preview" element={<UserPagePreview />} />
-          <Route path="cart" element={<Cart />} />
-
-          {/* Fallback inside /app */}
-          <Route path="*" element={<Navigate to="/app" replace />} />
+          <Route index element={<ProductsList />} />
+          <Route path="create" element={<ProductForm />} />
+          <Route path="edit/:id" element={<ProductForm />} />
+          <Route path="edit/:type/:id" element={<ProductForm />} />
         </Route>
+
+        <Route
+          path="sales"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.CREATOR, UserRole.ADMIN]}>
+              <SalesPage />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="marketing"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.CREATOR, UserRole.ADMIN]}>
+              <MarketingPage />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* User/Admin: library */}
+        <Route
+          path="library"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.USER, UserRole.ADMIN]}>
+              <LibraryPage />
+            </ProtectedRoute>
+          }
+        >
+          <Route path="all-products" element={<AllProductsTab />} />
+          <Route path="my-courses" element={<CoursesTab />} />
+          <Route
+            path="my-download-packages"
+            element={<DownloadPackagesTab />}
+          />
+          <Route path="my-consultation" element={<ConsultationTab />} />
+          <Route path="my-wishlist" element={<WishlistTab />} />
+        </Route>
+
+        <Route path="settings" element={<SettingsPage />} />
+        <Route path="my-page-preview" element={<UserPagePreview />} />
+        <Route path="cart" element={<Cart />} />
+
+        {/* Fallback inside /app */}
+        <Route path="*" element={<Navigate to="/app" replace />} />
       </Route>
-    </Routes>
-  );
-};
+    </Route>
+  </Routes>
+);
 
 export default AppRouter;

--- a/src/domains/app/widgets/top-navbar/top-navbar.component.tsx
+++ b/src/domains/app/widgets/top-navbar/top-navbar.component.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { selectAuthUser } from 'core/store/auth-store';
-import { isCreatorOrAdmin } from 'core/api/models';
+import { hasRole, UserRole } from 'core/api/models';
 import { Button } from '@shared/ui';
 import { SmartSearch } from 'domains/app/features/smart-search';
 import {
@@ -19,7 +19,7 @@ const TopNavbar: React.FC = () => {
   const navigate = useNavigate();
   const user = useSelector(selectAuthUser);
   const location = useLocation();
-  const isUserCreator = isCreatorOrAdmin(user?.roles);
+  const isUserCreator = hasRole(user?.roles, UserRole.CREATOR);
   const isPathDashboard = location.pathname.startsWith('/app') && isUserCreator;
 
   return (


### PR DESCRIPTION
- Allow all roles to access the app dashboard
- Show creator sidebar only for CREATOR users
- Add profile dropdown role switcher for dev use
- Wire role switching through backend API and auth store
- Add tests for role switching and non-creator dashboard behavior

fix: stabilize product editor loading and restore product card layout

### What changed

-

### Checklist

- [ ] Updated docs if behavior/routes changed
  - [ ] `docs/docs/routing-map.md`
  - [ ] Relevant guide/playbook page(s)
- [ ] Added/updated tests (unit/e2e) if applicable
- [ ] Screens checked for a11y basics (keyboard/focus)

### Screenshots / notes
