### PR TITLE
Add admin management UI and role-based routing

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,12 @@
 /* eslint-env node */
-module.exports = {
-  presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
-    '@babel/preset-react',
-    '@babel/preset-typescript'
-  ]
+module.exports = (api) => {
+  const isTest = api.env('test');
+
+  return {
+    presets: [
+      ['@babel/preset-env', { targets: { node: isTest ? '12' : 'current' } }],
+      '@babel/preset-react',
+      '@babel/preset-typescript',
+    ],
+  };
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,16 +16,16 @@ module.exports = {
   // Defines transformations for your source files
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
-    '^.+\\.(js|jsx|mjs)$': 'babel-jest',
+    '^.+\\.(js|jsx|mjs|cjs)$': 'babel-jest',
   },
 
   // Tells Jest explicitly which node_modules need transformation
   transformIgnorePatterns: [
-    '/node_modules/(?!(axios|@testing-library|@uppy|nanoid|preact|exifr|p-queue|p-timeout|companion-client|p-retry|retry|is-network-error|react-icons|pretty-bytes|aria-query|dom-accessibility-api)/)',
+    '/node_modules/(?!(axios|@testing-library|@uppy|nanoid|preact|exifr|p-queue|p-timeout|companion-client|p-retry|retry|is-network-error|react-icons|pretty-bytes|aria-query|dom-accessibility-api|react-redux|uuid)/)',
   ],
 
   // File extensions Jest recognizes during module resolution
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'mjs', 'cjs'],
 
   // Allows importing CSS/SCSS files into Jest tests
   moduleNameMapper: {

--- a/src/core/api/models/admin/admin.ts
+++ b/src/core/api/models/admin/admin.ts
@@ -1,0 +1,70 @@
+import { ProductMinimised } from '../product/product';
+import { ProductStatus, ProductType } from '../product/products.types';
+import { UserRole } from '../user/user';
+
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}
+
+export interface AdminUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  roles: UserRole[];
+  enabled?: boolean;
+  authProvider?: string;
+  onboardingCompleted?: boolean;
+  createdAt?: string;
+}
+
+export interface AdminRoleUpdateRequest {
+  role: UserRole;
+}
+
+export interface AdminAuditLog {
+  id: number;
+  actorUserId: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  beforeSummary?: string;
+  afterSummary?: string;
+  createdAt: string;
+}
+
+export interface AdminUserQuery {
+  search?: string;
+  role?: UserRole | '';
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export interface AdminProductQuery {
+  search?: string;
+  ownerId?: string;
+  type?: ProductType | '';
+  status?: ProductStatus | '';
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export interface AdminAuditQuery {
+  actorId?: string;
+  targetType?: string;
+  targetId?: string;
+  action?: string;
+  page?: number;
+  size?: number;
+}
+
+export type AdminProductsPage = PageResponse<ProductMinimised>;

--- a/src/core/api/models/admin/index.ts
+++ b/src/core/api/models/admin/index.ts
@@ -1,0 +1,1 @@
+export * from './admin';

--- a/src/core/api/models/index.ts
+++ b/src/core/api/models/index.ts
@@ -1,3 +1,4 @@
+export * from './admin';
 export * from './auth';
 export * from './calendars';
 export * from './cancellation';

--- a/src/core/api/services/admin/admin-api.test.ts
+++ b/src/core/api/services/admin/admin-api.test.ts
@@ -1,0 +1,95 @@
+import httpClient from 'core/api/http-client';
+import { ProductType, UserRole } from 'core/api/models';
+import {
+  getAdminAuditAPI,
+  getAdminProductsAPI,
+  getAdminUsersAPI,
+  updateAdminUserRoleAPI,
+} from './admin-api';
+
+jest.mock('core/api/http-client');
+
+const mockedHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+describe('Admin API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads admin users with search and role filters', async () => {
+    mockedHttpClient.get.mockResolvedValueOnce({
+      data: { content: [], totalElements: 0, totalPages: 0 },
+    });
+
+    await getAdminUsersAPI({
+      search: 'ada',
+      role: UserRole.CREATOR,
+      page: 1,
+      size: 10,
+    });
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      'api/admin/users?page=1&size=10&sort=createdAt%2Cdesc&search=ada&role=CREATOR',
+      { withCredentials: true },
+    );
+  });
+
+  it('updates a user role through the admin endpoint', async () => {
+    const response = {
+      id: 'user-1',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.test',
+      roles: [UserRole.ADMIN],
+    };
+    mockedHttpClient.patch.mockResolvedValueOnce({ data: response });
+
+    await expect(
+      updateAdminUserRoleAPI('user-1', { role: UserRole.ADMIN }),
+    ).resolves.toEqual(response);
+
+    expect(mockedHttpClient.patch).toHaveBeenCalledWith(
+      'api/admin/users/user-1/role',
+      { role: UserRole.ADMIN },
+      { withCredentials: true },
+    );
+  });
+
+  it('loads admin products with owner and product filters', async () => {
+    mockedHttpClient.get.mockResolvedValueOnce({
+      data: {
+        content: [{ id: 'p1', title: 'Course', type: 'COURSE' as ProductType }],
+        totalElements: 1,
+        totalPages: 1,
+      },
+    });
+
+    const result = await getAdminProductsAPI({
+      search: 'course',
+      ownerId: 'creator-1',
+      type: 'COURSE',
+      status: 'DRAFT',
+      page: 2,
+      size: 5,
+    });
+
+    expect(result.content[0].id).toBe('p1');
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      'api/admin/products?page=2&size=5&sort=createdAt%2Cdesc&search=course&ownerId=creator-1&type=COURSE&status=DRAFT',
+      { withCredentials: true },
+    );
+  });
+
+  it('loads audit entries with filters', async () => {
+    mockedHttpClient.get.mockResolvedValueOnce({
+      data: { content: [], totalElements: 0, totalPages: 0 },
+    });
+
+    await getAdminAuditAPI({ action: 'ROLE_CHANGE', targetType: 'USER' });
+
+    expect(mockedHttpClient.get).toHaveBeenCalledWith(
+      'api/admin/audit?page=0&size=20&action=ROLE_CHANGE&targetType=USER',
+      { withCredentials: true },
+    );
+  });
+});

--- a/src/core/api/services/admin/admin-api.ts
+++ b/src/core/api/services/admin/admin-api.ts
@@ -1,0 +1,88 @@
+import httpClient from 'core/api/http-client';
+import {
+  AdminAuditLog,
+  AdminAuditQuery,
+  AdminProductQuery,
+  AdminProductsPage,
+  AdminRoleUpdateRequest,
+  AdminUser,
+  AdminUserQuery,
+  PageResponse,
+  ProductMinimised,
+} from 'core/api/models';
+import { normalizeProductSummary } from '../products/utils/product-normalizers.util';
+
+const buildQueryString = (params: Record<string, unknown>) => {
+  const query = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
+    query.set(key, String(value));
+  });
+
+  return query.toString();
+};
+
+export const getAdminUsersAPI = async (
+  params: AdminUserQuery = {},
+): Promise<PageResponse<AdminUser>> => {
+  const query = buildQueryString({
+    page: 0,
+    size: 20,
+    sort: 'createdAt,desc',
+    ...params,
+  });
+  const response = await httpClient.get<PageResponse<AdminUser>>(
+    `api/admin/users?${query}`,
+    { withCredentials: true },
+  );
+  return response.data;
+};
+
+export const updateAdminUserRoleAPI = async (
+  userId: string,
+  payload: AdminRoleUpdateRequest,
+): Promise<AdminUser> => {
+  const response = await httpClient.patch<AdminUser>(
+    `api/admin/users/${userId}/role`,
+    payload,
+    { withCredentials: true },
+  );
+  return response.data;
+};
+
+export const getAdminProductsAPI = async (
+  params: AdminProductQuery = {},
+): Promise<AdminProductsPage> => {
+  const query = buildQueryString({
+    page: 0,
+    size: 20,
+    sort: 'createdAt,desc',
+    ...params,
+  });
+  const response = await httpClient.get<PageResponse<ProductMinimised>>(
+    `api/admin/products?${query}`,
+    { withCredentials: true },
+  );
+  return {
+    ...response.data,
+    content: response.data.content.map(normalizeProductSummary),
+  };
+};
+
+export const getAdminAuditAPI = async (
+  params: AdminAuditQuery = {},
+): Promise<PageResponse<AdminAuditLog>> => {
+  const query = buildQueryString({
+    page: 0,
+    size: 20,
+    ...params,
+  });
+  const response = await httpClient.get<PageResponse<AdminAuditLog>>(
+    `api/admin/audit?${query}`,
+    { withCredentials: true },
+  );
+  return response.data;
+};

--- a/src/core/api/services/admin/index.ts
+++ b/src/core/api/services/admin/index.ts
@@ -1,0 +1,1 @@
+export * from './admin-api';

--- a/src/core/api/services/index.ts
+++ b/src/core/api/services/index.ts
@@ -1,3 +1,4 @@
+export * from './admin';
 export * from './auth';
 export * from './calendar';
 export * from './products';

--- a/src/core/constants/routes.ts
+++ b/src/core/constants/routes.ts
@@ -7,6 +7,7 @@ import {
 } from 'react-icons/io5';
 import { FaMoneyBillTrendUp } from 'react-icons/fa6';
 import { TiMessages } from 'react-icons/ti';
+import { MdAdminPanelSettings } from 'react-icons/md';
 
 import { Route } from '../api';
 
@@ -22,6 +23,11 @@ export const appRoutes: Route[] = [
     label: 'Products',
     icon: RxDashboard,
     collapseSidebarOnLoad: true,
+  },
+  {
+    path: '/app/admin',
+    label: 'Admin',
+    icon: MdAdminPanelSettings,
   },
   {
     path: '/app/sales',

--- a/src/core/store/admin-store/admin-slice.test.ts
+++ b/src/core/store/admin-store/admin-slice.test.ts
@@ -1,0 +1,105 @@
+import { UserRole } from 'core/api/models';
+import adminReducer, {
+  fetchAdminProducts,
+  fetchAdminUsers,
+  updateAdminUserRole,
+} from './admin.slice';
+
+const initialState = {
+  usersPage: null,
+  productsPage: null,
+  auditPage: null,
+  loading: false,
+  roleUpdatingUserId: null,
+  error: null,
+};
+
+describe('admin slice', () => {
+  it('stores loaded users', () => {
+    const usersPage = {
+      content: [
+        {
+          id: 'user-1',
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          email: 'ada@example.test',
+          roles: [UserRole.USER],
+        },
+      ],
+      totalElements: 1,
+      totalPages: 1,
+      size: 20,
+      number: 0,
+      first: true,
+      last: true,
+      empty: false,
+    };
+
+    const state = adminReducer(initialState, {
+      type: fetchAdminUsers.fulfilled.type,
+      payload: usersPage,
+    });
+
+    expect(state.usersPage).toEqual(usersPage);
+    expect(state.loading).toBe(false);
+  });
+
+  it('replaces a user after role update', () => {
+    const stateWithUsers = {
+      ...initialState,
+      usersPage: {
+        content: [
+          {
+            id: 'user-1',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            email: 'ada@example.test',
+            roles: [UserRole.USER],
+          },
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        size: 20,
+        number: 0,
+        first: true,
+        last: true,
+        empty: false,
+      },
+      roleUpdatingUserId: 'user-1',
+    };
+
+    const state = adminReducer(stateWithUsers, {
+      type: updateAdminUserRole.fulfilled.type,
+      payload: {
+        id: 'user-1',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        email: 'ada@example.test',
+        roles: [UserRole.CREATOR],
+      },
+    });
+
+    expect(state.roleUpdatingUserId).toBeNull();
+    expect(state.usersPage?.content[0].roles).toEqual([UserRole.CREATOR]);
+  });
+
+  it('stores loaded admin products', () => {
+    const productsPage = {
+      content: [{ id: 'product-1', title: 'Course', type: 'COURSE' }],
+      totalElements: 1,
+      totalPages: 1,
+      size: 20,
+      number: 0,
+      first: true,
+      last: true,
+      empty: false,
+    };
+
+    const state = adminReducer(initialState, {
+      type: fetchAdminProducts.fulfilled.type,
+      payload: productsPage,
+    });
+
+    expect(state.productsPage).toEqual(productsPage);
+  });
+});

--- a/src/core/store/admin-store/admin.slice.ts
+++ b/src/core/store/admin-store/admin.slice.ts
@@ -1,0 +1,179 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import {
+  AdminAuditLog,
+  AdminAuditQuery,
+  AdminProductQuery,
+  AdminProductsPage,
+  AdminUser,
+  AdminUserQuery,
+  PageResponse,
+  RootState,
+  UserRole,
+} from 'core/api/models';
+import {
+  getAdminAuditAPI,
+  getAdminProductsAPI,
+  getAdminUsersAPI,
+  updateAdminUserRoleAPI,
+} from 'core/api/services';
+import { extractErrorMessage } from '@shared/utils';
+
+interface AdminState {
+  usersPage: PageResponse<AdminUser> | null;
+  productsPage: AdminProductsPage | null;
+  auditPage: PageResponse<AdminAuditLog> | null;
+  loading: boolean;
+  roleUpdatingUserId: string | null;
+  error: string | null;
+}
+
+const initialState: AdminState = {
+  usersPage: null,
+  productsPage: null,
+  auditPage: null,
+  loading: false,
+  roleUpdatingUserId: null,
+  error: null,
+};
+
+export const fetchAdminUsers = createAsyncThunk<
+  PageResponse<AdminUser>,
+  AdminUserQuery | undefined,
+  { rejectValue: string }
+>('admin/fetchUsers', async (params, { rejectWithValue }) => {
+  try {
+    return await getAdminUsersAPI(params);
+  } catch (error: unknown) {
+    return rejectWithValue(extractErrorMessage(error));
+  }
+});
+
+export const updateAdminUserRole = createAsyncThunk<
+  AdminUser,
+  { userId: string; role: UserRole },
+  { rejectValue: string }
+>('admin/updateUserRole', async ({ userId, role }, { rejectWithValue }) => {
+  try {
+    return await updateAdminUserRoleAPI(userId, { role });
+  } catch (error: unknown) {
+    return rejectWithValue(extractErrorMessage(error));
+  }
+});
+
+export const fetchAdminProducts = createAsyncThunk<
+  AdminProductsPage,
+  AdminProductQuery | undefined,
+  { rejectValue: string }
+>('admin/fetchProducts', async (params, { rejectWithValue }) => {
+  try {
+    return await getAdminProductsAPI(params);
+  } catch (error: unknown) {
+    return rejectWithValue(extractErrorMessage(error));
+  }
+});
+
+export const fetchAdminAuditLogs = createAsyncThunk<
+  PageResponse<AdminAuditLog>,
+  AdminAuditQuery | undefined,
+  { rejectValue: string }
+>('admin/fetchAuditLogs', async (params, { rejectWithValue }) => {
+  try {
+    return await getAdminAuditAPI(params);
+  } catch (error: unknown) {
+    return rejectWithValue(extractErrorMessage(error));
+  }
+});
+
+const adminSlice = createSlice({
+  name: 'admin',
+  initialState,
+  reducers: {
+    clearAdminError(state) {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchAdminUsers.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(
+        fetchAdminUsers.fulfilled,
+        (state, action: PayloadAction<PageResponse<AdminUser>>) => {
+          state.loading = false;
+          state.usersPage = action.payload;
+        },
+      )
+      .addCase(fetchAdminUsers.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? 'Failed to load users';
+      })
+
+      .addCase(updateAdminUserRole.pending, (state, action) => {
+        state.roleUpdatingUserId = action.meta.arg.userId;
+        state.error = null;
+      })
+      .addCase(
+        updateAdminUserRole.fulfilled,
+        (state, action: PayloadAction<AdminUser>) => {
+          state.roleUpdatingUserId = null;
+          if (state.usersPage) {
+            state.usersPage.content = state.usersPage.content.map((user) =>
+              user.id === action.payload.id ? action.payload : user,
+            );
+          }
+        },
+      )
+      .addCase(updateAdminUserRole.rejected, (state, action) => {
+        state.roleUpdatingUserId = null;
+        state.error = action.payload ?? 'Failed to update role';
+      })
+
+      .addCase(fetchAdminProducts.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(
+        fetchAdminProducts.fulfilled,
+        (state, action: PayloadAction<AdminProductsPage>) => {
+          state.loading = false;
+          state.productsPage = action.payload;
+        },
+      )
+      .addCase(fetchAdminProducts.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? 'Failed to load products';
+      })
+
+      .addCase(fetchAdminAuditLogs.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(
+        fetchAdminAuditLogs.fulfilled,
+        (state, action: PayloadAction<PageResponse<AdminAuditLog>>) => {
+          state.loading = false;
+          state.auditPage = action.payload;
+        },
+      )
+      .addCase(fetchAdminAuditLogs.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? 'Failed to load audit logs';
+      });
+  },
+});
+
+export const { clearAdminError } = adminSlice.actions;
+
+export const selectAdminUsersPage = (state: RootState) => state.admin.usersPage;
+export const selectAdminProductsPage = (state: RootState) =>
+  state.admin.productsPage;
+export const selectAdminAuditPage = (state: RootState) => state.admin.auditPage;
+export const selectAdminLoading = (state: RootState) => state.admin.loading;
+export const selectAdminError = (state: RootState) => state.admin.error;
+export const selectRoleUpdatingUserId = (state: RootState) =>
+  state.admin.roleUpdatingUserId;
+
+export default adminSlice.reducer;

--- a/src/core/store/admin-store/index.ts
+++ b/src/core/store/admin-store/index.ts
@@ -1,0 +1,2 @@
+export { default as adminReducer } from './admin.slice';
+export * from './admin.slice';

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -1,3 +1,4 @@
+export * from './admin-store';
 export * from './auth-store';
 export * from './notifications';
 export * from './product-store';

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -1,5 +1,6 @@
 import { configureStore, createListenerMiddleware } from '@reduxjs/toolkit';
 import authReducer from './auth-store/auth.slice';
+import adminReducer from './admin-store/admin.slice';
 import productsReducer from './product-store/product.slice';
 import notificationsReducer from './notifications/notifications.slice';
 import shopCartReducer, {
@@ -20,6 +21,7 @@ const preloadedCart = loadCartFromStorage();
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    admin: adminReducer,
     products: productsReducer,
     notifications: notificationsReducer,
     shopCart: shopCartReducer,

--- a/src/domains/app/features/product-form/editors/create-product-step-one/create-product-step-one.component.tsx
+++ b/src/domains/app/features/product-form/editors/create-product-step-one/create-product-step-one.component.tsx
@@ -64,6 +64,7 @@ const CreateProductStepOne: React.FC<CreateProductStepOneProps> = ({
           if (data) {
             // formData.id = data.id; // Set the product ID in formData
             setField('id', data.id ?? ''); // Ensure the formData is updated with the new ID
+            setField('userId', data.userId ?? userId);
             // formData.sections = data.sections || []; // Initialize sections if they exist
             if (data.type !== 'CONSULTATION') {
               setField('sections', data.sections || []); // Update sections in formData

--- a/src/domains/app/features/product-form/hooks/use-product-form.facade.test.tsx
+++ b/src/domains/app/features/product-form/hooks/use-product-form.facade.test.tsx
@@ -17,13 +17,14 @@ let mockFormName = 'Initial product';
 jest.mock('react-redux', () => ({
   __esModule: true,
   useDispatch: () => mockDispatch,
-  useSelector: () => ({ id: 'user-1' }),
+  useSelector: () => ({ id: 'user-1', roles: ['CREATOR'] }),
 }));
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,
   useNavigate: () => mockNavigate,
   useParams: () => mockParams,
+  useSearchParams: () => [new URLSearchParams()],
 }));
 
 jest.mock('./use-product-loader.hooks', () => ({

--- a/src/domains/app/features/product-form/hooks/use-product-form.facade.ts
+++ b/src/domains/app/features/product-form/hooks/use-product-form.facade.ts
@@ -1,8 +1,13 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
-import { AbstractProduct, AppDispatch } from 'core/api/models';
+import {
+  AbstractProduct,
+  AppDispatch,
+  hasRole,
+  UserRole,
+} from 'core/api/models';
 import { selectAuthUser } from 'core/store/auth-store';
 import { UseProductFormFacadeResult } from '../models/product-form';
 import { useProductAutosave } from './use-product-autosave.hook';
@@ -16,10 +21,13 @@ import {
 
 export const useProductFormFacade = (): UseProductFormFacadeResult => {
   const { type, id } = useParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
   const user = useSelector(selectAuthUser);
   const isEditMode = Boolean(id);
+  const selectedAdminOwnerId = searchParams.get('ownerId') ?? undefined;
+  const isAdmin = hasRole(user?.roles, UserRole.ADMIN);
 
   // 1) core form state
   const {
@@ -84,6 +92,10 @@ export const useProductFormFacade = (): UseProductFormFacadeResult => {
   return {
     user,
     isEditMode,
+    productOwnerId:
+      !isEditMode && isAdmin && selectedAdminOwnerId
+        ? selectedAdminOwnerId
+        : formData.userId ?? user?.id,
     formData,
     setFormData,
     setField,

--- a/src/domains/app/features/product-form/hooks/use-product-loader.hooks.ts
+++ b/src/domains/app/features/product-form/hooks/use-product-loader.hooks.ts
@@ -45,6 +45,7 @@ export const useProductLoader = ({
           description: product.description ?? '',
           type: product.type ?? 'COURSE',
           price: product.price ?? 'free',
+          userId: product.userId,
         };
 
         let newData: ProductDraft = baseData;

--- a/src/domains/app/features/product-form/models/product-form.ts
+++ b/src/domains/app/features/product-form/models/product-form.ts
@@ -37,6 +37,7 @@ export type SectionDraft = ProductSection;
 export interface UseProductFormFacadeResult {
   user: ReturnType<typeof selectAuthUser> | null;
   isEditMode: boolean;
+  productOwnerId?: string;
   formData: ProductDraft;
   setFormData: React.Dispatch<React.SetStateAction<ProductDraft>>;
   setField: <K extends keyof ProductDraft>(

--- a/src/domains/app/features/product-form/utils/form-data-mapper.utils.ts
+++ b/src/domains/app/features/product-form/utils/form-data-mapper.utils.ts
@@ -13,7 +13,7 @@ export const mapFormDataToProductPayload = (
     description: formData.description,
     price: formData.price,
     status: 'DRAFT' as const,
-    userId: user?.id,
+    userId: formData.userId ?? user?.id,
   };
 
   const consDetails = formData.consultationDetails;

--- a/src/domains/app/pages/admin-page/admin-audit-page.component.tsx
+++ b/src/domains/app/pages/admin-page/admin-audit-page.component.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { AppDispatch } from 'core/api/models';
+import {
+  fetchAdminAuditLogs,
+  selectAdminAuditPage,
+  selectAdminError,
+  selectAdminLoading,
+} from 'core/store/admin-store';
+
+import './admin-page.styles.scss';
+
+const AdminAuditPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const auditPage = useSelector(selectAdminAuditPage);
+  const loading = useSelector(selectAdminLoading);
+  const error = useSelector(selectAdminError);
+  const [action, setAction] = useState('');
+  const [targetType, setTargetType] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    dispatch(
+      fetchAdminAuditLogs({ action, targetType, targetId, page, size: 20 }),
+    );
+  }, [dispatch, action, targetType, targetId, page]);
+
+  return (
+    <section className="admin-page">
+      <header className="admin-page__header">
+        <h1>Audit</h1>
+        <p>Admin role changes and admin product actions.</p>
+      </header>
+
+      <div className="admin-toolbar">
+        <input
+          aria-label="Action"
+          placeholder="Action"
+          value={action}
+          onChange={(event) => {
+            setPage(0);
+            setAction(event.target.value);
+          }}
+        />
+        <input
+          aria-label="Target type"
+          placeholder="Target type"
+          value={targetType}
+          onChange={(event) => {
+            setPage(0);
+            setTargetType(event.target.value);
+          }}
+        />
+        <input
+          aria-label="Target id"
+          placeholder="Target id"
+          value={targetId}
+          onChange={(event) => {
+            setPage(0);
+            setTargetId(event.target.value);
+          }}
+        />
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+      {loading && <p>Loading...</p>}
+
+      <div className="admin-table-wrap">
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Actor</th>
+              <th>Action</th>
+              <th>Target</th>
+              <th>Before</th>
+              <th>After</th>
+            </tr>
+          </thead>
+          <tbody>
+            {auditPage?.content.map((entry) => (
+              <tr key={entry.id}>
+                <td>{new Date(entry.createdAt).toLocaleString()}</td>
+                <td>{entry.actorUserId}</td>
+                <td>{entry.action}</td>
+                <td>
+                  <span>{entry.targetType}</span>
+                  <small>{entry.targetId}</small>
+                </td>
+                <td>{entry.beforeSummary ?? '-'}</td>
+                <td>{entry.afterSummary ?? '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="admin-pagination">
+        <button disabled={page === 0} onClick={() => setPage((value) => value - 1)}>
+          Previous
+        </button>
+        <span>
+          Page {auditPage ? auditPage.number + 1 : page + 1} of{' '}
+          {auditPage?.totalPages || 1}
+        </span>
+        <button
+          disabled={Boolean(auditPage?.last)}
+          onClick={() => setPage((value) => value + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default AdminAuditPage;

--- a/src/domains/app/pages/admin-page/admin-page.component.tsx
+++ b/src/domains/app/pages/admin-page/admin-page.component.tsx
@@ -1,7 +1,30 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
+import './admin-page.styles.scss';
 
 const AdminPage: React.FC = () => (
-  <div>YOU ARE A GOD AND HAVE ALL THE POWER</div>
+  <section className="admin-page">
+    <header className="admin-page__header">
+      <h1>Admin</h1>
+      <p>Manage platform users, products, and admin audit history.</p>
+    </header>
+
+    <div className="admin-page__grid">
+      <Link className="admin-page__tile" to="/app/admin/users">
+        <span>Users</span>
+        <small>Search users and change their single platform role.</small>
+      </Link>
+      <Link className="admin-page__tile" to="/app/admin/products">
+        <span>Products</span>
+        <small>View, edit, delete, and create products for creators.</small>
+      </Link>
+      <Link className="admin-page__tile" to="/app/admin/audit">
+        <span>Audit</span>
+        <small>Review admin role and product management actions.</small>
+      </Link>
+    </div>
+  </section>
 );
 
 export default AdminPage;

--- a/src/domains/app/pages/admin-page/admin-page.styles.scss
+++ b/src/domains/app/pages/admin-page/admin-page.styles.scss
@@ -1,0 +1,139 @@
+.admin-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+
+.admin-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  h1 {
+    margin: 0;
+    font-size: 28px;
+    font-weight: 700;
+  }
+
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+  }
+}
+
+.admin-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.admin-page__tile {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px;
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  color: inherit;
+  text-decoration: none;
+  background: var(--surface-primary);
+
+  span {
+    font-weight: 700;
+  }
+
+  small {
+    color: var(--text-secondary);
+  }
+}
+
+.admin-toolbar,
+.admin-create-row,
+.admin-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.admin-toolbar input,
+.admin-toolbar select,
+.admin-create-row select {
+  min-height: 36px;
+  min-width: 180px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--surface-primary);
+  color: var(--text-primary);
+}
+
+.admin-create-row button,
+.admin-pagination button,
+.admin-table button {
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.admin-create-row button:disabled,
+.admin-pagination button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.admin-table-wrap {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  font-size: 14px;
+
+  th,
+  td {
+    padding: 12px;
+    border-bottom: 1px solid var(--border-primary);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    font-weight: 700;
+    color: var(--text-secondary);
+  }
+
+  small {
+    display: block;
+    max-width: 220px;
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+  }
+
+  select {
+    min-height: 32px;
+    padding: 6px 8px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--surface-primary);
+    color: var(--text-primary);
+  }
+}
+
+.admin-table__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-error {
+  margin: 0;
+  color: var(--error-primary, #b42318);
+}

--- a/src/domains/app/pages/admin-page/admin-products-page.component.tsx
+++ b/src/domains/app/pages/admin-page/admin-products-page.component.tsx
@@ -1,0 +1,215 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  AdminUser,
+  AppDispatch,
+  ProductStatus,
+  ProductType,
+  UserRole,
+} from 'core/api/models';
+import { getAdminUsersAPI } from 'core/api/services';
+import {
+  fetchAdminProducts,
+  selectAdminError,
+  selectAdminLoading,
+  selectAdminProductsPage,
+} from 'core/store/admin-store';
+import { deleteProduct } from 'core/store/product-store';
+
+import './admin-page.styles.scss';
+
+const productTypes: ProductType[] = ['COURSE', 'DOWNLOAD', 'CONSULTATION'];
+const productStatuses: ProductStatus[] = ['DRAFT', 'PUBLISHED', 'HIDDEN'];
+
+const AdminProductsPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const productsPage = useSelector(selectAdminProductsPage);
+  const loading = useSelector(selectAdminLoading);
+  const error = useSelector(selectAdminError);
+  const [search, setSearch] = useState('');
+  const [ownerId, setOwnerId] = useState('');
+  const [type, setType] = useState<ProductType | ''>('');
+  const [status, setStatus] = useState<ProductStatus | ''>('');
+  const [page, setPage] = useState(0);
+  const [creators, setCreators] = useState<AdminUser[]>([]);
+  const [selectedCreatorId, setSelectedCreatorId] = useState('');
+
+  useEffect(() => {
+    dispatch(
+      fetchAdminProducts({ search, ownerId, type, status, page, size: 20 }),
+    );
+  }, [dispatch, search, ownerId, type, status, page]);
+
+  useEffect(() => {
+    getAdminUsersAPI({ role: UserRole.CREATOR, page: 0, size: 100 })
+      .then((response) => setCreators(response.content))
+      .catch(() => setCreators([]));
+  }, []);
+
+  const refreshCurrentPage = () => {
+    dispatch(
+      fetchAdminProducts({ search, ownerId, type, status, page, size: 20 }),
+    );
+  };
+
+  const handleDelete = (productId?: string) => {
+    if (!productId || !window.confirm('Delete this product?')) {
+      return;
+    }
+    dispatch(deleteProduct({ productId }))
+      .unwrap()
+      .then(refreshCurrentPage);
+  };
+
+  return (
+    <section className="admin-page">
+      <header className="admin-page__header">
+        <h1>Products</h1>
+        <p>Admins can manage every product and create products for creators.</p>
+      </header>
+
+      <div className="admin-toolbar">
+        <input
+          aria-label="Search products"
+          placeholder="Search products"
+          value={search}
+          onChange={(event) => {
+            setPage(0);
+            setSearch(event.target.value);
+          }}
+        />
+        <input
+          aria-label="Owner id"
+          placeholder="Owner id"
+          value={ownerId}
+          onChange={(event) => {
+            setPage(0);
+            setOwnerId(event.target.value);
+          }}
+        />
+        <select
+          aria-label="Filter by type"
+          value={type}
+          onChange={(event) => {
+            setPage(0);
+            setType(event.target.value as ProductType | '');
+          }}
+        >
+          <option value="">All types</option>
+          {productTypes.map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label="Filter by status"
+          value={status}
+          onChange={(event) => {
+            setPage(0);
+            setStatus(event.target.value as ProductStatus | '');
+          }}
+        >
+          <option value="">All statuses</option>
+          {productStatuses.map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="admin-create-row">
+        <select
+          aria-label="Creator owner"
+          value={selectedCreatorId}
+          onChange={(event) => setSelectedCreatorId(event.target.value)}
+        >
+          <option value="">Select creator owner</option>
+          {creators.map((creator) => (
+            <option key={creator.id} value={creator.id}>
+              {`${creator.firstName ?? ''} ${creator.lastName ?? ''}`.trim() ||
+                creator.email}
+            </option>
+          ))}
+        </select>
+        <button
+          disabled={!selectedCreatorId}
+          onClick={() =>
+            navigate(`/app/admin/products/create?ownerId=${selectedCreatorId}`)
+          }
+        >
+          Create product
+        </button>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+      {loading && <p>Loading...</p>}
+
+      <div className="admin-table-wrap">
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>Product</th>
+              <th>Owner</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Price</th>
+              <th>Updated</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {productsPage?.content.map((product) => (
+              <tr key={product.id}>
+                <td>{product.title}</td>
+                <td>
+                  <span>{product.createdByName ?? '-'}</span>
+                  <small>{product.createdById}</small>
+                </td>
+                <td>{product.type}</td>
+                <td>{product.status}</td>
+                <td>{product.price ?? 'free'}</td>
+                <td>
+                  {product.updatedAt
+                    ? new Date(product.updatedAt).toLocaleString()
+                    : '-'}
+                </td>
+                <td className="admin-table__actions">
+                  <button onClick={() => navigate(`/app/product/${product.id}`)}>
+                    View
+                  </button>
+                  <button onClick={() => navigate(`/app/products/edit/${product.id}`)}>
+                    Edit
+                  </button>
+                  <button onClick={() => handleDelete(product.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="admin-pagination">
+        <button disabled={page === 0} onClick={() => setPage((value) => value - 1)}>
+          Previous
+        </button>
+        <span>
+          Page {productsPage ? productsPage.number + 1 : page + 1} of{' '}
+          {productsPage?.totalPages || 1}
+        </span>
+        <button
+          disabled={Boolean(productsPage?.last)}
+          onClick={() => setPage((value) => value + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default AdminProductsPage;

--- a/src/domains/app/pages/admin-page/admin-users-page.component.tsx
+++ b/src/domains/app/pages/admin-page/admin-users-page.component.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { AppDispatch, UserRole } from 'core/api/models';
+import {
+  fetchAdminUsers,
+  selectAdminError,
+  selectAdminLoading,
+  selectAdminUsersPage,
+  selectRoleUpdatingUserId,
+  updateAdminUserRole,
+} from 'core/store/admin-store';
+
+import './admin-page.styles.scss';
+
+const roles = [UserRole.ADMIN, UserRole.CREATOR, UserRole.USER];
+
+const AdminUsersPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const usersPage = useSelector(selectAdminUsersPage);
+  const loading = useSelector(selectAdminLoading);
+  const error = useSelector(selectAdminError);
+  const roleUpdatingUserId = useSelector(selectRoleUpdatingUserId);
+  const [search, setSearch] = useState('');
+  const [role, setRole] = useState<UserRole | ''>('');
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    dispatch(fetchAdminUsers({ search, role, page, size: 20 }));
+  }, [dispatch, search, role, page]);
+
+  const handleRoleChange = (userId: string, nextRole: UserRole) => {
+    dispatch(updateAdminUserRole({ userId, role: nextRole }));
+  };
+
+  return (
+    <section className="admin-page">
+      <header className="admin-page__header">
+        <h1>Users</h1>
+        <p>Role changes replace the user role and force re-login.</p>
+      </header>
+
+      <div className="admin-toolbar">
+        <input
+          aria-label="Search users"
+          placeholder="Search name or email"
+          value={search}
+          onChange={(event) => {
+            setPage(0);
+            setSearch(event.target.value);
+          }}
+        />
+        <select
+          aria-label="Filter by role"
+          value={role}
+          onChange={(event) => {
+            setPage(0);
+            setRole(event.target.value as UserRole | '');
+          }}
+        >
+          <option value="">All roles</option>
+          {roles.map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+      {loading && <p>Loading...</p>}
+
+      <div className="admin-table-wrap">
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Provider</th>
+              <th>Status</th>
+              <th>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usersPage?.content.map((user) => {
+              const currentRole = user.roles[0] ?? UserRole.USER;
+              return (
+                <tr key={user.id}>
+                  <td>{`${user.firstName ?? ''} ${user.lastName ?? ''}`.trim()}</td>
+                  <td>{user.email}</td>
+                  <td>
+                    <select
+                      aria-label={`Role for ${user.email}`}
+                      value={currentRole}
+                      disabled={roleUpdatingUserId === user.id}
+                      onChange={(event) =>
+                        handleRoleChange(user.id, event.target.value as UserRole)
+                      }
+                    >
+                      {roles.map((item) => (
+                        <option key={item} value={item}>
+                          {item}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>{user.authProvider ?? 'manual'}</td>
+                  <td>{user.enabled === false ? 'Disabled' : 'Enabled'}</td>
+                  <td>{user.createdAt ? new Date(user.createdAt).toLocaleString() : '-'}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="admin-pagination">
+        <button disabled={page === 0} onClick={() => setPage((value) => value - 1)}>
+          Previous
+        </button>
+        <span>
+          Page {usersPage ? usersPage.number + 1 : page + 1} of{' '}
+          {usersPage?.totalPages || 1}
+        </span>
+        <button
+          disabled={Boolean(usersPage?.last)}
+          onClick={() => setPage((value) => value + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default AdminUsersPage;

--- a/src/domains/app/pages/admin-page/index.ts
+++ b/src/domains/app/pages/admin-page/index.ts
@@ -1,1 +1,4 @@
+export { default as AdminAuditPage } from './admin-audit-page.component';
 export { default as AdminPage } from './admin-page.component';
+export { default as AdminProductsPage } from './admin-products-page.component';
+export { default as AdminUsersPage } from './admin-users-page.component';

--- a/src/domains/app/pages/app-layout/app-layout.component.tsx
+++ b/src/domains/app/pages/app-layout/app-layout.component.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import clsx from 'clsx';
 
 import { selectAuthUser } from 'core/store/auth-store';
-import { hasRole, UserRole } from 'core/api/models';
+import { isCreatorOrAdmin } from 'core/api/models';
 import {
   SidebarLayoutProvider,
   SidebarNav,
@@ -17,6 +17,7 @@ import './app-layout.styles.scss';
 
 const CREATOR_ROUTES = [
   '/app',
+  '/app/admin/*',
   '/app/products/*',
   '/app/sales',
   '/app/marketing',
@@ -35,7 +36,8 @@ const Shell: React.FC = () => {
 
     if (
       matchedRoute?.collapseSidebarOnLoad === true ||
-      location.pathname.includes('create' || 'edit')
+      location.pathname.includes('create') ||
+      location.pathname.includes('edit')
     ) {
       setIsSidebarCollapsed(true);
     }
@@ -43,16 +45,17 @@ const Shell: React.FC = () => {
 
   const user = useSelector(selectAuthUser);
 
-  const isUserCreator = hasRole(user?.roles, UserRole.CREATOR);
+  const hasManagementRole = isCreatorOrAdmin(user?.roles);
 
   const inCreatorArea = CREATOR_ROUTES.some((pattern) =>
     Boolean(matchPath(pattern, location.pathname)),
   );
-  const showSidebar = inCreatorArea && isUserCreator;
+  const showSidebar = inCreatorArea && hasManagementRole;
 
   const isBuilderRoute =
     location.pathname.startsWith('/app/products/create') ||
-    location.pathname.startsWith('/app/products/edit');
+    location.pathname.startsWith('/app/products/edit') ||
+    location.pathname.startsWith('/app/admin/products/create');
 
   useEffect(() => {
     if (!isBuilderRoute) {

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
@@ -29,6 +29,7 @@ const ProductForm: React.FC = () => {
   const {
     user,
     isEditMode,
+    productOwnerId,
     formData,
     setFormData,
     setField,
@@ -117,6 +118,10 @@ const ProductForm: React.FC = () => {
     return <p>You must be logged in to create a product.</p>;
   }
 
+  if (!isEditMode && !productOwnerId) {
+    return <p>Select a creator owner before creating a product.</p>;
+  }
+
   return (
     <div ref={container}>
       <ProductHeader
@@ -142,7 +147,7 @@ const ProductForm: React.FC = () => {
               showRestOfForm={showRestOfForm}
               setShowRestOfForm={setShowRestOfForm}
               setShowLoadingRestOfForm={setShowLoadingRestOfForm}
-              userId={user?.id}
+              userId={productOwnerId ?? ''}
             />
           </div>
         )}

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
@@ -170,6 +170,7 @@ afterEach(() => {
 const makeFacadeState = (overrides: Partial<any> = {}) => ({
   user: { id: 'user-123' },
   isEditMode: false,
+  productOwnerId: 'user-123',
   formData: {
     id: 'prod-1',
     name: 'My Product',

--- a/src/domains/app/routes/app-router.test.tsx
+++ b/src/domains/app/routes/app-router.test.tsx
@@ -1,0 +1,98 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+import AppRouter from './app-router';
+import { UserRole } from '@core/api';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../pages', () => {
+  const React = require('react');
+  const { Outlet } = require('react-router-dom');
+  const makePage = (name: string) => () => <div>{name}</div>;
+
+  return {
+    AllProductsTab: makePage('All products'),
+    AdminAuditPage: makePage('Admin audit'),
+    AdminPage: makePage('Admin dashboard'),
+    AdminProductsPage: makePage('Admin products'),
+    AdminUsersPage: makePage('Admin users'),
+    AppLayout: () => <Outlet />,
+    Cart: makePage('Cart'),
+    ConsultationTab: makePage('Consultations'),
+    CoursesTab: makePage('Courses'),
+    CreatorDashboard: makePage('Creator dashboard'),
+    DownloadPackagesTab: makePage('Downloads'),
+    ExplorePage: makePage('Explore'),
+    GalacticaHome: makePage('User home'),
+    LibraryPage: () => <Outlet />,
+    MarketingPage: makePage('Marketing'),
+    Onboarding: makePage('Onboarding'),
+    ProductForm: makePage('Product form'),
+    ProductPage: makePage('Product page'),
+    ProductsList: makePage('Products list'),
+    SalesPage: makePage('Sales'),
+    SearchResultsPage: makePage('Search results'),
+    SettingsPage: makePage('Settings'),
+    StorefrontPage: makePage('Storefront'),
+    UserPagePreview: makePage('Preview'),
+    WishlistTab: makePage('Wishlist'),
+  };
+});
+
+const renderRouter = (roles: UserRole[], initialEntry = '/') => {
+  const state = {
+    auth: {
+      user: {
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.test',
+        roles,
+      },
+      loading: false,
+      error: null,
+      isUserLoggedIn: true,
+    },
+  };
+  (useSelector as unknown as jest.Mock).mockImplementation((selector) =>
+    selector(state),
+  );
+
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <AppRouter />
+    </MemoryRouter>,
+  );
+};
+
+describe('AppRouter role routing', () => {
+  it('resolves / to the admin dashboard for admins', () => {
+    renderRouter([UserRole.ADMIN]);
+
+    expect(screen.getByText('Admin dashboard')).toBeInTheDocument();
+  });
+
+  it('resolves / to the creator dashboard for creators', () => {
+    renderRouter([UserRole.CREATOR]);
+
+    expect(screen.getByText('Creator dashboard')).toBeInTheDocument();
+  });
+
+  it('resolves / to normal home for users', () => {
+    renderRouter([UserRole.USER]);
+
+    expect(screen.getByText('User home')).toBeInTheDocument();
+  });
+
+  it('renders admin user management for admins', () => {
+    renderRouter([UserRole.ADMIN], '/admin/users');
+
+    expect(screen.getByText('Admin users')).toBeInTheDocument();
+  });
+});

--- a/src/domains/app/routes/app-router.test.tsx
+++ b/src/domains/app/routes/app-router.test.tsx
@@ -13,9 +13,18 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('../pages', () => {
-  const React = require('react');
-  const { Outlet } = require('react-router-dom');
-  const makePage = (name: string) => () => <div>{name}</div>;
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { Outlet } =
+    jest.requireActual<typeof import('react-router-dom')>('react-router-dom');
+
+  const makePage = (name: string) => {
+    const MockPage = () => ReactActual.createElement('div', null, name);
+    MockPage.displayName = `Mock${name.replace(/\s+/g, '')}`;
+    return MockPage;
+  };
+
+  const MockOutletPage = () => ReactActual.createElement(Outlet);
+  MockOutletPage.displayName = 'MockOutletPage';
 
   return {
     AllProductsTab: makePage('All products'),
@@ -23,7 +32,7 @@ jest.mock('../pages', () => {
     AdminPage: makePage('Admin dashboard'),
     AdminProductsPage: makePage('Admin products'),
     AdminUsersPage: makePage('Admin users'),
-    AppLayout: () => <Outlet />,
+    AppLayout: MockOutletPage,
     Cart: makePage('Cart'),
     ConsultationTab: makePage('Consultations'),
     CoursesTab: makePage('Courses'),
@@ -31,7 +40,7 @@ jest.mock('../pages', () => {
     DownloadPackagesTab: makePage('Downloads'),
     ExplorePage: makePage('Explore'),
     GalacticaHome: makePage('User home'),
-    LibraryPage: () => <Outlet />,
+    LibraryPage: MockOutletPage,
     MarketingPage: makePage('Marketing'),
     Onboarding: makePage('Onboarding'),
     ProductForm: makePage('Product form'),

--- a/src/domains/app/routes/app-router.tsx
+++ b/src/domains/app/routes/app-router.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { Route, Routes, Navigate, Outlet } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 import {
   AllProductsTab,
+  AdminAuditPage,
+  AdminPage,
+  AdminProductsPage,
+  AdminUsersPage,
   AppLayout,
   Cart,
   ConsultationTab,
@@ -10,6 +15,7 @@ import {
   CreatorDashboard,
   DownloadPackagesTab,
   ExplorePage,
+  GalacticaHome,
   LibraryPage,
   MarketingPage,
   Onboarding,
@@ -24,7 +30,23 @@ import {
   WishlistTab,
 } from '../pages';
 import { ProtectedRoute } from '@core/providers';
-import { UserRole } from '@core/api';
+import { getPrimaryRole, UserRole } from '@core/api';
+import { selectAuthUser } from '@core/store/auth-store';
+
+const RoleHome: React.FC = () => {
+  const user = useSelector(selectAuthUser);
+  const primaryRole = getPrimaryRole(user?.roles);
+
+  if (primaryRole === UserRole.ADMIN) {
+    return <AdminPage />;
+  }
+
+  if (primaryRole === UserRole.CREATOR) {
+    return <CreatorDashboard />;
+  }
+
+  return <GalacticaHome />;
+};
 
 const AppRouter: React.FC = () => (
   <Routes>
@@ -60,7 +82,22 @@ const AppRouter: React.FC = () => (
         }
       >
         {/* Shared dashboard home */}
-        <Route index element={<CreatorDashboard />} />
+        <Route index element={<RoleHome />} />
+
+        <Route
+          path="admin"
+          element={
+            <ProtectedRoute allowedRoles={[UserRole.ADMIN]}>
+              <Outlet />
+            </ProtectedRoute>
+          }
+        >
+          <Route index element={<AdminPage />} />
+          <Route path="users" element={<AdminUsersPage />} />
+          <Route path="products" element={<AdminProductsPage />} />
+          <Route path="products/create" element={<ProductForm />} />
+          <Route path="audit" element={<AdminAuditPage />} />
+        </Route>
 
         {/* Creator/Admin: products */}
         <Route

--- a/src/domains/app/widgets/top-navbar/top-navbar.component.tsx
+++ b/src/domains/app/widgets/top-navbar/top-navbar.component.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { selectAuthUser } from 'core/store/auth-store';
-import { hasRole, UserRole } from 'core/api/models';
+import { isCreatorOrAdmin } from 'core/api/models';
 import { Button } from '@shared/ui';
 import { SmartSearch } from 'domains/app/features/smart-search';
 import {
@@ -19,8 +19,9 @@ const TopNavbar: React.FC = () => {
   const navigate = useNavigate();
   const user = useSelector(selectAuthUser);
   const location = useLocation();
-  const isUserCreator = hasRole(user?.roles, UserRole.CREATOR);
-  const isPathDashboard = location.pathname.startsWith('/app') && isUserCreator;
+  const hasManagementRole = isCreatorOrAdmin(user?.roles);
+  const isPathDashboard =
+    location.pathname.startsWith('/app') && hasManagementRole;
 
   return (
     <nav className="galactica-home-nav">
@@ -43,13 +44,13 @@ const TopNavbar: React.FC = () => {
           ) : (
             <Link to={'library/all-products'}>Library</Link>
           ))} */}
-        {user && !isUserCreator && (
+        {user && !hasManagementRole && (
           <Link to={'library/all-products'}>Library</Link>
         )}
       </div>
       {user && (
         <div className="nav-links">
-          {!isUserCreator && (
+          {!hasManagementRole && (
             <>
               <GalWishlistDropdown />
               <ShopCartDropdown />


### PR DESCRIPTION
- add admin API models, services, and Redux store
- add admin dashboard, users, products, and audit pages
- route /app by primary role for admin, creator, and user
- protect admin routes for ADMIN users only
- support admin product creation with selected creator owner
- preserve product owner during admin edits
- update management navigation role checks
- add admin API, store, router, and product form tests
- update Jest/Babel config for full test suite compatibility

### What changed

-

### Checklist

- [ ] Updated docs if behavior/routes changed
  - [ ] `docs/docs/routing-map.md`
  - [ ] Relevant guide/playbook page(s)
- [ ] Added/updated tests (unit/e2e) if applicable
- [ ] Screens checked for a11y basics (keyboard/focus)

### Screenshots / notes
