### PR TITLE
aleb/membership v1.1 -  add content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,6 @@ dist
 
 
 # mocks
-src/api/_mocks.ts
+src/core/api/_mocks.ts
 *storybook.log
 storybook-static

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -5,7 +5,7 @@ Generated from repository state:
 Branch: main
 Commit: b9f5510
 
-Last reviewed: 2026-08-07
+Last reviewed: 2026-08-08
 
 # How to use this document
 
@@ -34,7 +34,7 @@ Important product types:
 - `COURSE`: section-based product with lessons.
 - `DOWNLOAD`: section-based product with downloadable files.
 - `CONSULTATION`: appointment/session details instead of sections.
-- `MEMBERSHIP`: shared Product with a Membership-specific builder path; included products and recurring pricing are currently frontend-only.
+- `MEMBERSHIP`: shared Product with a Membership-specific builder path; included products, native content foundation, and recurring pricing are currently frontend-only.
 
 ## Architecture Summary
 
@@ -79,6 +79,21 @@ Intentional model decisions:
 - Product normalizers handle backend `details` payload shape for sections and consultation details; Membership responses currently remain shared Product data with no persisted Membership-specific details.
 - Product type metadata is centralized in `src/core/constants/products.ts` and drives create options, basic info options, filters, headers, and type metadata.
 
+Membership content architecture:
+
+- Native Membership content is modeled as frontend/domain state under `src/domains/app/features/product-form/membership-content/models`, not as Product API DTOs.
+- Native Membership content types are `POST`, `VIDEO`, and `RESOURCE`, with statuses `DRAFT`, `PUBLISHED`, and `HIDDEN`.
+- Native Membership content must not be added to `AbstractProduct`, Product autosave payloads, Product normalizers, or fake backend persistence.
+- Included standalone Products remain Products, currently represented by `ProductMinimised`; Course/Download products must not be converted into native Membership content entities.
+- `MembershipContentList` is the presentation shell that renders a unified Membership content hub from native content items plus included Products.
+- `MembershipContentSection` owns the inline `+ Add Content` chooser state and current native content creation mode. This state is local React state, not Redux.
+- `MembershipContentTypeChooser` is presentation/control-only. It offers `Video`, `Post`, `Resource`, and `Existing Product`, but does not fetch data or create content.
+- Selecting `Video`, `Post`, or `Resource` sets a local frontend-only `MembershipContentCreationMode` and shows a minimal placeholder; native editors are not implemented yet.
+- Selecting `Existing Product` closes the chooser and requests that `MembershipIncludedProducts` open its existing `ProductPicker`; no second ProductPicker or duplicated product loading logic should be introduced.
+- The current deterministic list order is native Membership content first, then included Products. There is no drag-and-drop, `position`, or persisted ordering contract yet.
+- `MembershipIncludedProducts` owns Product summary loading, picker state, included-product IDs, add/remove behavior, and duplicate prevention; it delegates list rendering to `MembershipContentList`.
+- The native content source boundary currently passes `nativeContentItems = []` from the Membership content section. Future native content state/API integration should connect there.
+
 ## Current Feature State
 
 Implemented / reasonably wired:
@@ -89,6 +104,7 @@ Implemented / reasonably wired:
 - Product create/edit builder for course/download/consultation/membership basics.
 - Membership builder integration with a Membership Content tab.
 - Generic reusable Product Picker used by Membership included-product selection.
+- Unified Membership content list foundation and inline `+ Add Content` chooser that can select native Membership content modes or open the existing ProductPicker.
 - Course/download section creation, autosave, deletion.
 - Course lesson creation, autosave, deletion for `VIDEO`, `ARTICLE`, `QUIZ`; assignment is placeholder.
 - Download section file upload via presigned URL + confirm upload.
@@ -105,6 +121,7 @@ Partially implemented / placeholder:
 - Creator dashboard has placeholder audience/sales sections and hardcoded “member since”.
 - Cart/wishlist exist mostly frontend-side/localStorage; persistence/checkout contract is not clearly backend-backed.
 - Membership included products are limited to existing Course/Download products and held in frontend state only.
+- Native Membership content has frontend-only model/list/chooser foundations and placeholder creation modes, but no create/edit/delete UI and no backend persistence.
 - Membership recurring pricing has a frontend-only `RecurringPricing` model and `RecurringPriceSelector`; no backend Product pricing contract exists for it yet.
 - Lesson content persistence for uploaded videos/rich text/quiz data may need backend contract verification.
 - Assignment lesson editor is a visible placeholder.
@@ -123,6 +140,7 @@ Confirmed:
 - `.github/workflows/docs.yml` expects a `docs/` directory, but no `docs/` directory exists in this checkout.
 - `src/core/store/shop-cart/shop-cart.slice.ts` removal has a likely index bug: index `0` is treated as false, so the first cart item may not remove.
 - Membership has no backend included-product relationship API yet.
+- Membership has no backend native content API yet.
 - Membership has no backend recurring pricing contract yet.
 - Membership has no subscription/entitlement/member-access model yet.
 
@@ -132,12 +150,13 @@ Deliberate temporary implementations:
 - Blank section/lesson drafts exist locally until enough data is present for backend creation.
 - Download upload deduping is local to the section editor instance.
 - Membership included-product selection is local frontend state until a relationship API exists.
+- Membership native content state is currently an empty frontend boundary with local placeholder creation modes until content creation/editing and persistence are defined.
 - Membership recurring pricing is local frontend state until a structured recurring pricing contract exists.
 
 Speculative / verify before changing:
 
 - Backend shape for lesson rich text, quiz payloads, video upload, checkout/cart, and storefront data.
-- Backend contracts for Membership included products, recurring pricing, subscriptions, entitlements, and member access.
+- Backend contracts for Membership native content, included products, recurring pricing, subscriptions, entitlements, and member access.
 - Whether product type changes after creation should remain disallowed in edit mode; current UI limits edit mode to current type in `BasicInfo`.
 
 ## Recent / Unfinished Work
@@ -148,7 +167,7 @@ Recent Git history includes admin role/product ownership work and Membership fro
 - Dev role switcher/backend role change support.
 - Admin product management and create-for-creator flow using `ownerId` query param.
 - Membership added as a first-class frontend Product type.
-- Membership uses the shared builder shell, its own Membership Content tab, frontend-only Course/Download included-product selection, and frontend-only recurring pricing controls.
+- Membership uses the shared builder shell, its own Membership Content tab, frontend-only Course/Download included-product selection, a frontend-only native content list/chooser foundation, and frontend-only recurring pricing controls.
 
 Likely next steps:
 
@@ -156,4 +175,4 @@ Likely next steps:
 - Complete product detail and storefront UI using real backend fields.
 - Fix known warnings and cart removal bug.
 - Verify product builder contracts for lesson content, quiz persistence, media upload, and consultation scheduling.
-- Define backend contracts for Membership included-product relationships, recurring pricing, subscription checkout, and entitlement/member access before persisting Membership-specific fields.
+- Define backend contracts for Membership native content, included-product relationships, recurring pricing, subscription checkout, and entitlement/member access before persisting Membership-specific fields.

--- a/src/core/api/_mocks.ts
+++ b/src/core/api/_mocks.ts
@@ -8,7 +8,7 @@ import { SearchResponse } from './services/products/products-api';
 import { SocialPlatforms } from './models/socials/social-media-link';
 import { ProductSectionUpdateRequest } from './models/product/section';
 import { ProductMinimised } from './models/product/product';
-import { AbstractProduct, ProductType } from './models';
+import { AbstractProduct } from './models';
 
 /**
  * Call this once (passing in your axios instance) to wire up all mock endpoints.
@@ -43,6 +43,445 @@ export function setupMocks(client: AxiosInstance) {
     ],
   };
 
+  const now = new Date();
+  const daysAgo = (days: number) =>
+    new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const mockProducts: AbstractProduct[] = [
+    {
+      type: 'COURSE',
+      id: 'course-video-sprint',
+      name: 'Video Sales Page Sprint',
+      description:
+        'A hands-on course for creators who want to script, shoot, edit, and publish a sales page video in one focused weekend.',
+      status: 'PUBLISHED',
+      price: 149,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(24),
+      updatedAt: daysAgo(2),
+      imageUrl:
+        'https://images.unsplash.com/photo-1492724441997-5dc865305da7?auto=format&fit=crop&w=1200&q=80',
+      sections: [
+        {
+          id: 'course-video-sprint-section-1',
+          productId: 'course-video-sprint',
+          title: 'Position the Offer',
+          description:
+            'Clarify the promise, audience, objections, and call to action before recording.',
+          position: 1,
+          lessons: [
+            {
+              id: 'course-video-sprint-lesson-1',
+              productId: 'course-video-sprint',
+              sectionId: 'course-video-sprint-section-1',
+              title: 'Map the viewer journey',
+              type: 'VIDEO',
+              description: 'Turn visitor intent into a persuasive video outline.',
+              content:
+                'Identify the before-state, desired outcome, objections, proof, and next action.',
+              videoUrl: 'https://cdn.example.com/video-sales-page/journey.mp4',
+              position: 1,
+            },
+            {
+              id: 'course-video-sprint-lesson-2',
+              productId: 'course-video-sprint',
+              sectionId: 'course-video-sprint-section-1',
+              title: 'Write a conversion script',
+              type: 'ARTICLE',
+              description: 'Use a tight script structure that still sounds natural.',
+              content:
+                'Hook, context, stakes, product promise, proof, objections, offer, and close.',
+              position: 2,
+            },
+          ],
+        },
+        {
+          id: 'course-video-sprint-section-2',
+          productId: 'course-video-sprint',
+          title: 'Produce and Publish',
+          description:
+            'Record with a practical setup and ship the final asset with confidence.',
+          position: 2,
+          lessons: [
+            {
+              id: 'course-video-sprint-lesson-3',
+              productId: 'course-video-sprint',
+              sectionId: 'course-video-sprint-section-2',
+              title: 'Lighting, sound, and framing',
+              type: 'VIDEO',
+              description: 'Set up a clean recording environment without a studio.',
+              videoUrl: 'https://cdn.example.com/video-sales-page/studio.mp4',
+              content: 'A simple desk setup can look premium with careful framing.',
+              position: 1,
+            },
+            {
+              id: 'course-video-sprint-lesson-4',
+              productId: 'course-video-sprint',
+              sectionId: 'course-video-sprint-section-2',
+              title: 'Final launch checklist',
+              type: 'ASSIGNMENT',
+              description: 'Export, upload, QA captions, and publish.',
+              content:
+                'Submit your published sales page URL and a short note on what changed.',
+              position: 2,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'COURSE',
+      id: 'course-analytics-lab-draft',
+      name: 'Creator Analytics Lab',
+      description:
+        'Draft curriculum for reading funnel, retention, and revenue signals without drowning in dashboards.',
+      status: 'DRAFT',
+      price: 79,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(6),
+      updatedAt: daysAgo(1),
+      imageUrl:
+        'https://images.unsplash.com/photo-1551288049-bebda4e38f71?auto=format&fit=crop&w=1200&q=80',
+      sections: [
+        {
+          id: 'course-analytics-lab-section-1',
+          productId: 'course-analytics-lab-draft',
+          title: 'Metrics That Matter',
+          description: 'Working outline for the first module.',
+          position: 1,
+          lessons: [
+            {
+              id: 'course-analytics-lab-lesson-1',
+              productId: 'course-analytics-lab-draft',
+              sectionId: 'course-analytics-lab-section-1',
+              title: 'North star metric',
+              type: 'ARTICLE',
+              description: 'Draft notes for choosing one primary product metric.',
+              content: 'TODO: add examples for course, download, and membership.',
+              position: 1,
+            },
+          ],
+        },
+        {
+          id: 'course-analytics-lab-section-2',
+          productId: 'course-analytics-lab-draft',
+          title: 'Retention Review',
+          description: '',
+          position: 2,
+          lessons: [],
+        },
+      ],
+    },
+    {
+      type: 'DOWNLOAD',
+      id: 'download-launch-asset-vault',
+      name: 'Launch Asset Vault',
+      description:
+        'A polished pack of sales page sections, email swipes, pricing calculators, and launch QA templates.',
+      status: 'PUBLISHED',
+      price: 49,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(42),
+      updatedAt: daysAgo(5),
+      imageUrl:
+        'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1200&q=80',
+      sections: [
+        {
+          id: 'download-launch-asset-vault-section-1',
+          productId: 'download-launch-asset-vault',
+          title: 'Templates',
+          description: 'Editable files for planning and publishing a launch.',
+          position: 1,
+          files: [
+            {
+              id: 'download-launch-asset-vault-file-1',
+              fileName: 'sales-page-wireframes.fig',
+              fileType: 'application/octet-stream',
+              size: 18400000,
+              url: 'https://cdn.example.com/launch-vault/sales-page-wireframes.fig',
+            },
+            {
+              id: 'download-launch-asset-vault-file-2',
+              fileName: 'launch-email-sequence.docx',
+              fileType:
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+              size: 920000,
+              url: 'https://cdn.example.com/launch-vault/email-sequence.docx',
+            },
+          ],
+        },
+        {
+          id: 'download-launch-asset-vault-section-2',
+          productId: 'download-launch-asset-vault',
+          title: 'Calculators',
+          description: 'Revenue, conversion, and cohort planning sheets.',
+          position: 2,
+          files: [
+            {
+              id: 'download-launch-asset-vault-file-3',
+              fileName: 'pricing-and-revenue-calculator.xlsx',
+              fileType:
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              size: 640000,
+              url: 'https://cdn.example.com/launch-vault/pricing-calculator.xlsx',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'DOWNLOAD',
+      id: 'download-caption-pack-draft',
+      name: 'Short-Form Caption Pack',
+      description:
+        'Draft pack of reusable hooks, captions, and description templates for short-form video.',
+      status: 'DRAFT',
+      price: 'free',
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(3),
+      updatedAt: daysAgo(1),
+      sections: [
+        {
+          id: 'download-caption-pack-section-1',
+          productId: 'download-caption-pack-draft',
+          title: 'Hook Bank',
+          description: '',
+          position: 1,
+          files: [
+            {
+              id: 'download-caption-pack-file-1',
+              fileName: 'hook-bank-draft.txt',
+              fileType: 'text/plain',
+              size: 18000,
+              url: 'https://cdn.example.com/caption-pack/hook-bank-draft.txt',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'CONSULTATION',
+      id: 'consultation-offer-audit',
+      name: '90-Minute Offer Audit',
+      description:
+        'A live strategy session reviewing your product positioning, sales page, pricing, and next launch moves.',
+      status: 'PUBLISHED',
+      price: 325,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(18),
+      updatedAt: daysAgo(4),
+      imageUrl:
+        'https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1200&q=80',
+      consultationDetails: {
+        durationMinutes: 90,
+        meetingMethod: 'ZOOM',
+        bufferBeforeMinutes: 15,
+        bufferAfterMinutes: 15,
+        maxSessionsPerDay: 3,
+        confirmationMessage:
+          'Bring your product link, current funnel numbers, and the decision you are trying to make.',
+        cancellationPolicy:
+          'Reschedule up to 24 hours before the session. No-shows are not refundable.',
+        connectedCalendars: [
+          {
+            id: 'calendar-google-primary',
+            provider: 'GOOGLE',
+            expiresAt: daysAgo(-30).toISOString(),
+          },
+        ],
+      },
+    },
+    {
+      type: 'CONSULTATION',
+      id: 'consultation-community-setup-draft',
+      name: 'Community Setup Jam',
+      description:
+        'Draft service for helping creators shape a membership onboarding and engagement rhythm.',
+      status: 'DRAFT',
+      price: 180,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(9),
+      updatedAt: daysAgo(9),
+      consultationDetails: {
+        durationMinutes: 60,
+        meetingMethod: 'GOOGLE_MEET',
+        bufferBeforeMinutes: 10,
+        bufferAfterMinutes: 10,
+        confirmationMessage: '',
+      },
+    },
+    {
+      type: 'MEMBERSHIP',
+      id: 'membership-studio-pass',
+      name: 'Creator Studio Pass',
+      description:
+        'Monthly access to workshops, private critiques, templates, and behind-the-scenes build notes.',
+      status: 'PUBLISHED',
+      price: 29,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(60),
+      updatedAt: daysAgo(3),
+      imageUrl:
+        'https://images.unsplash.com/photo-1517048676732-d65bc937f952?auto=format&fit=crop&w=1200&q=80',
+    },
+    {
+      type: 'MEMBERSHIP',
+      id: 'membership-founders-circle-draft',
+      name: 'Founders Circle',
+      description:
+        'Early draft for a higher-touch membership tier with small group sessions and launch reviews.',
+      status: 'DRAFT',
+      price: 99,
+      userId: 'mocked-user-id',
+      createdAt: daysAgo(2),
+      updatedAt: daysAgo(1),
+    },
+  ];
+
+  const creatorProfiles: Record<
+    string,
+    { createdByName: string; createdByTitle: string }
+  > = {
+    'mocked-user-id': {
+      createdByName: 'Aleb Mocked',
+      createdByTitle: 'Creator Product Strategist',
+    },
+    'mocked-user-id-2': {
+      createdByName: 'Tomi Varga',
+      createdByTitle: 'Launch Systems Coach',
+    },
+    'mocked-user-id-3': {
+      createdByName: 'Janos Mira',
+      createdByTitle: 'Community Builder',
+    },
+  };
+
+  const publicMockProducts: AbstractProduct[] = [
+    ...mockProducts,
+    {
+      type: 'COURSE',
+      id: 'course-cohort-facilitation',
+      name: 'Cohort Facilitation Playbook',
+      description:
+        'Design week-by-week live learning experiences with prompts, rituals, and feedback loops.',
+      status: 'PUBLISHED',
+      price: 199,
+      userId: 'mocked-user-id-2',
+      createdAt: daysAgo(31),
+      updatedAt: daysAgo(7),
+      imageUrl:
+        'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&q=80',
+      sections: [
+        {
+          id: 'course-cohort-facilitation-section-1',
+          productId: 'course-cohort-facilitation',
+          title: 'Plan the Cohort',
+          description: 'Set outcomes, milestones, and live session formats.',
+          position: 1,
+          lessons: [
+            {
+              id: 'course-cohort-facilitation-lesson-1',
+              productId: 'course-cohort-facilitation',
+              sectionId: 'course-cohort-facilitation-section-1',
+              title: 'Weekly arc design',
+              type: 'VIDEO',
+              description: 'Make each week feel purposeful and complete.',
+              content: 'Draft a week-by-week arc with one transformation per week.',
+              videoUrl: 'https://cdn.example.com/cohort-playbook/weekly-arc.mp4',
+              position: 1,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'DOWNLOAD',
+      id: 'download-community-prompts',
+      name: 'Community Prompt Library',
+      description:
+        'A searchable pack of onboarding, reflection, accountability, and reactivation prompts.',
+      status: 'PUBLISHED',
+      price: 24,
+      userId: 'mocked-user-id-3',
+      createdAt: daysAgo(14),
+      updatedAt: daysAgo(8),
+      imageUrl:
+        'https://images.unsplash.com/photo-1559136555-9303baea8ebd?auto=format&fit=crop&w=1200&q=80',
+      sections: [
+        {
+          id: 'download-community-prompts-section-1',
+          productId: 'download-community-prompts',
+          title: 'Prompt Files',
+          description: 'CSV and Notion-ready community prompts.',
+          position: 1,
+          files: [
+            {
+              id: 'download-community-prompts-file-1',
+              fileName: 'community-prompts.csv',
+              fileType: 'text/csv',
+              size: 125000,
+              url: 'https://cdn.example.com/community-prompts/prompts.csv',
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const toProductMinimised = (product: AbstractProduct): ProductMinimised => {
+    const creator = creatorProfiles[product.userId ?? 'mocked-user-id'];
+
+    return {
+      id: product.id,
+      title: product.name,
+      description: product.description,
+      type: product.type,
+      price: product.price,
+      status: product.status,
+      imageUrl: product.imageUrl,
+      createdById: product.userId,
+      createdByName: creator?.createdByName ?? 'Mock Creator',
+      createdByTitle: creator?.createdByTitle ?? 'Digital Product Creator',
+      createdAt: product.createdAt,
+      updatedAt: product.updatedAt,
+    };
+  };
+
+  const withApiDetails = (product: AbstractProduct) => ({
+    ...product,
+    title: product.name,
+    details:
+      product.type === 'COURSE' || product.type === 'DOWNLOAD'
+        ? { sections: product.sections ?? [] }
+        : product.type === 'CONSULTATION'
+          ? product.consultationDetails ?? null
+          : null,
+  });
+
+  const getProductById = (productId: string | null | undefined) =>
+    publicMockProducts.find((product) => product.id === productId);
+
+  const getProductsByUser = (userId: string | null) =>
+    mockProducts.filter((product) => !userId || product.userId === userId);
+
+  const toSimplePage = <T,>(content: T[], page: number, size: number) => {
+    const start = page * size;
+    const pageContent = content.slice(start, start + size);
+    const totalElements = content.length;
+    const totalPages = Math.ceil(totalElements / size);
+
+    return {
+      content: pageContent,
+      totalElements,
+      totalPages,
+      size,
+      number: page,
+      first: page === 0,
+      last: page + 1 >= totalPages,
+      empty: pageContent.length === 0,
+    };
+  };
+
   /* ------------------USER-----------------------------------*/
   mock.onGet('api/user/userInfo').reply(200, mockedUser);
 
@@ -65,6 +504,34 @@ export function setupMocks(client: AxiosInstance) {
     console.info('[MOCK] login attempt:', { email, password });
 
     return [200, 'SUCCESS'];
+  });
+
+  /* ------------------ADMIN PRODUCTS----------------------------*/
+  mock.onGet(new RegExp('^api/admin/products.*')).reply((config) => {
+    const url = new URL(config.url!, 'http://localhost');
+    const search = url.searchParams.get('search')?.trim().toLowerCase() ?? '';
+    const ownerId = url.searchParams.get('ownerId') ?? '';
+    const type = url.searchParams.get('type') ?? '';
+    const status = url.searchParams.get('status') ?? '';
+    const page = Number(url.searchParams.get('page') || '0');
+    const size = Number(url.searchParams.get('size') || '20');
+
+    const filtered = publicMockProducts
+      .map(toProductMinimised)
+      .filter((product) => {
+        const matchesSearch =
+          !search ||
+          [product.title, product.description, product.createdByName]
+            .filter(Boolean)
+            .some((value) => value!.toLowerCase().includes(search));
+        const matchesOwner = !ownerId || product.createdById === ownerId;
+        const matchesType = !type || product.type === type;
+        const matchesStatus = !status || product.status === status;
+
+        return matchesSearch && matchesOwner && matchesType && matchesStatus;
+      });
+
+    return [200, toSimplePage(filtered, page, size)];
   });
 
   /* ------------------PRODUCTS-----------------------------------*/
@@ -108,92 +575,19 @@ export function setupMocks(client: AxiosInstance) {
     return [200, productData];
   });
 
-  mock.onGet(new RegExp('^api/products\\?ownerId=.*')).reply(() => {
-    return [
-      200,
-      [
-        {
-          type: 'COURSE' as ProductType,
-          id: 'mocked-course-product-id-1',
-          title: 'Mocked Course Product 1',
-          description: 'This is a mocked course product description.',
-          status: 'DRAFT',
-          price: 'free',
-          createdById: 'mocked-user-id',
-          createdByName: 'Aleb Mocked',
-          createdByTitle: 'D to the E.V.I.L',
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-        {
-          type: 'DOWNLOAD' as ProductType,
-          id: 'mocked-download-product-id-1',
-          title: 'Mocked Download Product 1',
-          description: 'This is a mocked download product description.',
-          status: 'DRAFT',
-          price: 50,
-          createdById: 'mocked-user-id',
-          createdByName: 'Aleb Mocked',
-          createdByTitle: 'D to the E.V.I.L',
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      ],
-    ];
-  });
+  mock
+    .onGet(new RegExp('^api/products\\?ownerId=.*'))
+    .reply(() => [200, getProductsByUser('mocked-user-id').map(toProductMinimised)]);
 
   mock.onGet(new RegExp('^api/products/[^/]+$')).reply((config) => {
     const productId = config.url?.split('/').pop();
-    const isDownload = productId?.includes('download');
+    const product = getProductById(productId);
 
-    return [
-      200,
-      {
-        type: isDownload ? ('DOWNLOAD' as ProductType) : ('COURSE' as ProductType),
-        id: productId,
-        name: isDownload
-          ? 'Mocked Download Product 1'
-          : 'Mocked Course Product 1',
-        description: 'This is a mocked product description.',
-        status: 'DRAFT',
-        price: 'free',
-        userId: 'mocked-user-id',
-        details: {
-          sections: [
-            {
-              id: 'mocked-section-id-1',
-              title: 'Mocked Section 1',
-              description: 'This is a mocked section description.',
-              position: 1,
-              productId,
-              lessons: isDownload
-                ? []
-                : [
-                    {
-                      id: 'mocked-lesson-id-1',
-                      title: 'Mocked Lesson 1',
-                      description: 'This is a mocked lesson description.',
-                      position: 1,
-                      sectionId: 'mocked-section-id-1',
-                      content: 'This is some mocked content for lesson 1.',
-                    },
-                  ],
-              files: isDownload
-                ? [
-                    {
-                      id: 'mocked-file-id-1',
-                      fileName: 'starter-pack.zip',
-                      fileType: 'application/zip',
-                      size: 120,
-                      url: 'https://cdn.example.com/starter-pack.zip',
-                    },
-                  ]
-                : [],
-            },
-          ],
-        },
-      },
-    ];
+    if (!product) {
+      return [404, { message: 'Product not found' }];
+    }
+
+    return [200, withApiDetails(product)];
   });
 
   mock.onPost(new RegExp('^api/products/[^/]+/sections$')).reply((config) => {
@@ -352,53 +746,7 @@ export function setupMocks(client: AxiosInstance) {
   });
 
   mock.onGet('api/products?userId=mocked-user-id').reply(() => {
-    const resp = [
-      {
-        type: 'COURSE' as ProductType,
-        id: 'mocked-course-product-id-1',
-        name: 'Mocked Course Product 1',
-        description: 'This is a mocked course product description.',
-        status: 'draft',
-        price: 'free',
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'COURSE' as ProductType,
-        id: 'mocked-course-product-id-2',
-        name: 'Mocked Course Product 2',
-        description: 'This is another mocked course product description.',
-        status: 'published',
-        price: 100,
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'DOWNLOAD' as ProductType,
-        id: 'mocked-download-product-id-1',
-        name: 'Mocked Download Product 1',
-        description: 'This is a mocked download product description.',
-        status: 'draft',
-        price: 50,
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'DOWNLOAD' as ProductType,
-        id: 'mocked-download-product-id-2',
-        name: 'Mocked Download Product 2',
-        description: 'This is another mocked download product description.',
-        status: 'published',
-        price: 'free',
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'CONSULTATION' as ProductType,
-        id: 'mocked-consultation-product-id-1',
-        name: 'Mocked Consultation Product 1',
-        description: 'This is a mocked consultation product description.',
-        status: 'published',
-        price: 89,
-        userId: 'mocked-user-id',
-      },
-    ];
+    const resp = getProductsByUser('mocked-user-id').map(withApiDetails);
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve([200, resp]);
@@ -411,46 +759,7 @@ export function setupMocks(client: AxiosInstance) {
     const userId = url.searchParams.get('userId');
     console.info('[MOCK] get products by user id request:', userId);
 
-    const allProducts = [
-      {
-        type: 'COURSE' as ProductType,
-        id: 'mocked-course-product-id-1',
-        name: 'Mocked Course Product 1',
-        description: 'This is a mocked course product description.',
-        status: 'draft',
-        price: 'free',
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'COURSE' as ProductType,
-        id: 'mocked-course-product-id-2',
-        name: 'Mocked Course Product 2',
-        description: 'This is another mocked course product description.',
-        status: 'published',
-        price: 100,
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'DOWNLOAD' as ProductType,
-        id: 'mocked-download-product-id-1',
-        name: 'Mocked Download Product 1',
-        description: 'This is a mocked download product description.',
-        status: 'draft',
-        price: 50,
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'DOWNLOAD' as ProductType,
-        id: 'mocked-download-product-id-2',
-        name: 'Mocked Download Product 2',
-        description: 'This is another mocked download product description.',
-        status: 'published',
-        price: 'free',
-        userId: 'mocked-user-id',
-      },
-    ];
-
-    return [200, allProducts];
+    return [200, getProductsByUser(userId).map(withApiDetails)];
   });
 
   mock.onGet(new RegExp('api/products/getProduct.*')).reply((config) => {
@@ -460,77 +769,12 @@ export function setupMocks(client: AxiosInstance) {
 
     console.info('[MOCK] getProduct request:', { productId, type });
 
-    // Simulate looking up from a mock DB
-    const allProducts = [
-      {
-        type: type as ProductType,
-        id: productId,
-        name: 'Mocked Course Product 1',
-        description: 'This is a mocked course product description.',
-        status: 'draft',
-        price: 'free',
-        userId: 'mocked-user-id',
-        sections: [
-          {
-            id: 'mocked-section-id-1',
-            title: 'Mocked Section 1',
-            description: 'This is a mocked section description.',
-            position: 1,
-            productId: productId,
-            lessons: [
-              {
-                id: 'mocked-lesson-id-1',
-                title: 'Mocked Lesson 1',
-                description: 'This is a mocked lesson description.',
-                position: 1,
-                content: 'This is some mocked content for lesson 1.',
-              },
-              {
-                id: 'mocked-lesson-id-2',
-                title: 'Mocked Lesson 2',
-                description: 'This is another mocked lesson description.',
-                position: 2,
-                content: 'This is some mocked content for lesson 2.',
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: 'COURSE' as ProductType,
-        id: 'mocked-course-product-id-2',
-        name: 'Mocked Course Product 2',
-        description: 'This is another mocked course product description.',
-        status: 'published',
-        price: 100,
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'DOWNLOAD' as ProductType,
-        id: 'mocked-download-product-id-1',
-        name: 'Mocked Download Product 1',
-        description: 'This is a mocked download product description.',
-        status: 'draft',
-        price: 50,
-        userId: 'mocked-user-id',
-      },
-      {
-        type: 'DOWNLOAD' as ProductType,
-        id: 'mocked-download-product-id-2',
-        name: 'Mocked Download Product 2',
-        description: 'This is another mocked download product description.',
-        status: 'published',
-        price: 'free',
-        userId: 'mocked-user-id',
-      },
-    ];
-
-    const product = allProducts.find(
+    const product = publicMockProducts.find(
       (p) => p.id === productId && p.type === type,
     );
 
     if (product) {
-      return [200, product];
+      return [200, withApiDetails(product)];
     } else {
       return [404, { message: 'Product not found' }];
     }
@@ -547,20 +791,28 @@ export function setupMocks(client: AxiosInstance) {
 
     console.info('[MOCK] search for:', { term, page, size, sort });
 
-    // Generate some fake products matching the term
-    const all: ProductMinimised[] = Array.from({ length: size }, (_, i) => ({
-      id: `mock-${term}-${page * size + i}`,
-      title: `${term || 'Product'} ${page * size + i + 1}`,
-      type: 'COURSE',
-      price: i % 2 === 0 ? 'free' : 9.99,
-      createdById: 'mocked-user-id',
-      createdByName: 'Mock User',
-      createdByTitle: 'Mock Creator',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }));
+    const normalisedTerm = term.trim().toLowerCase();
+    const filtered = publicMockProducts
+      .map(toProductMinimised)
+      .filter((product) => {
+        if (!normalisedTerm) {
+          return product.status === 'PUBLISHED';
+        }
 
-    const totalElements = 100; // pretend there are 100 total
+        return [
+          product.title,
+          product.description,
+          product.type,
+          product.createdByName,
+          product.createdByTitle,
+        ]
+          .filter(Boolean)
+          .some((value) => value!.toLowerCase().includes(normalisedTerm));
+      });
+
+    const start = page * size;
+    const all = filtered.slice(start, start + size);
+    const totalElements = filtered.length;
     const totalPages = Math.ceil(totalElements / size);
 
     const response: SearchResponse<ProductMinimised> = {
@@ -588,52 +840,9 @@ export function setupMocks(client: AxiosInstance) {
   });
 
   // getAllProductsMinimalAPI
-  mock.onGet('api/products/get-all-products-min').reply(200, [
-    {
-      type: 'COURSE' as ProductType,
-      id: 'mocked-course-product-id-1',
-      title: 'Mocked Course Product 1',
-      price: 'free',
-      createdById: 'mocked-user-id',
-      createdByName: 'Aleb Mocked',
-      createdByTitle: 'D to the E.V.I.L',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    } as ProductMinimised,
-    {
-      type: 'DOWNLOAD' as ProductType,
-      id: 'mocked-course-product-id-2',
-      title: 'Mocked Download Product 1',
-      price: 120,
-      createdById: 'mocked-user-id',
-      createdByName: 'Aleb Mocked',
-      createdByTitle: 'D to the E.V.I.L',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      type: 'COURSE' as ProductType,
-      id: 'mocked-course-product-id-3',
-      title: 'Mocked Course Product 2',
-      price: 'free',
-      createdById: 'mocked-user-id-2',
-      createdByName: 'Tomi',
-      createdByTitle: 'The Savage',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      type: 'CONSULTATION' as ProductType,
-      id: 'mocked-course-product-id-4',
-      title: 'Mocked Consultation Product 1',
-      price: 780,
-      createdById: 'mocked-user-id-3',
-      createdByName: 'Janos',
-      createdByTitle: 'The Idjit',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-  ]);
+  mock
+    .onGet('api/products/get-all-products-min')
+    .reply(200, publicMockProducts.map(toProductMinimised));
 
   // --------------------- CALENDAR --------------------------
 
@@ -660,46 +869,13 @@ export function setupMocks(client: AxiosInstance) {
       size,
     });
 
-    // ---------- Products available in the mocks ----------
-    const PRODUCT_IDS = [
-      'mocked-course-product-id-1',
-      'mocked-course-product-id-2',
-      'mocked-download-product-id-1',
-      'mocked-download-product-id-2',
-    ];
-
-    const PRODUCTS = [
-      {
-        id: 'mocked-course-product-id-1',
-        name: 'Mocked Course Product 1',
-        type: 'COURSE',
-      },
-      {
-        id: 'mocked-course-product-id-2',
-        name: 'Mocked Course Product 2',
-        type: 'COURSE',
-      },
-      {
-        id: 'mocked-course-product-id-3',
-        name: 'Mocked Course Product: The Second Expansion - Part Two',
-        type: 'COURSE',
-      },
-      {
-        id: 'mocked-download-product-id-1',
-        name: 'Mocked Download Product 1',
-        type: 'DOWNLOAD',
-      },
-      {
-        id: 'mocked-download-product-id-2',
-        name: 'Mocked Download Product 2',
-        type: 'DOWNLOAD',
-      },
-      {
-        id: 'mocked-consultation-product-id-1',
-        name: 'Mocked Consultation Product 1',
-        type: 'CONSULTATION',
-      },
-    ];
+    const PRODUCTS = publicMockProducts
+      .filter((product) => product.status === 'PUBLISHED')
+      .map((product) => ({
+        id: product.id,
+        name: product.name,
+        type: product.type,
+      }));
 
     const USER_FIRSTNAMES = [
       'Michael',
@@ -762,8 +938,8 @@ export function setupMocks(client: AxiosInstance) {
       {
         id: 'r_manual_1',
         product: {
-          id: 'mocked-course-product-id-1',
-          name: 'Mocked Course Product 1',
+          id: 'course-video-sprint',
+          name: 'Video Sales Page Sprint',
           type: 'COURSE',
         },
         customer: {
@@ -786,8 +962,8 @@ export function setupMocks(client: AxiosInstance) {
       {
         id: 'r_manual_2',
         product: {
-          id: 'mocked-download-product-id-1',
-          name: 'Mocked Download Product 1',
+          id: 'download-launch-asset-vault',
+          name: 'Launch Asset Vault',
           type: 'DOWNLOAD',
         },
         customer: {

--- a/src/core/api/models/misc/routes.ts
+++ b/src/core/api/models/misc/routes.ts
@@ -1,10 +1,12 @@
 import { IconType } from 'react-icons';
+import { UserRole } from '../user/user';
 
 export interface Route {
   path: string;
   label: string;
   icon: IconType;
   end?: boolean;
+  allowedRoles?: UserRole[];
   hideFromSidebar?: boolean;
   collapseSidebarOnLoad?: boolean;
 }

--- a/src/core/constants/routes.ts
+++ b/src/core/constants/routes.ts
@@ -9,7 +9,8 @@ import { FaMoneyBillTrendUp } from 'react-icons/fa6';
 import { TiMessages } from 'react-icons/ti';
 import { MdAdminPanelSettings } from 'react-icons/md';
 
-import { Route } from '../api';
+import { Route } from '../api/models/misc';
+import { UserRole } from '../api/models/user';
 
 export const appRoutes: Route[] = [
   {
@@ -28,6 +29,7 @@ export const appRoutes: Route[] = [
     path: '/app/admin',
     label: 'Admin',
     icon: MdAdminPanelSettings,
+    allowedRoles: [UserRole.ADMIN],
   },
   {
     path: '/app/sales',

--- a/src/domains/app/features/product-form/membership-content/membership-content-list.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content-list.component.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ProductMinimised } from 'core/api/models';
+import MembershipContentList from './membership-content-list.component';
+import {
+  createMembershipContentListItems,
+  MembershipContentItemBase,
+} from './models';
+
+const nativePost: MembershipContentItemBase = {
+  id: 'post-1',
+  type: 'POST',
+  title: 'Member update',
+  description: 'A quick note for members',
+  status: 'DRAFT',
+  createdAt: '2026-08-08T10:00:00.000Z',
+  updatedAt: '2026-08-08T10:00:00.000Z',
+};
+
+const courseProduct: ProductMinimised = {
+  id: 'course-1',
+  title: 'Launch Course',
+  description: 'A full course',
+  type: 'COURSE',
+  status: 'PUBLISHED',
+};
+
+const downloadProduct: ProductMinimised = {
+  id: 'download-1',
+  title: 'Template Pack',
+  type: 'DOWNLOAD',
+  status: 'DRAFT',
+};
+
+describe('<MembershipContentList />', () => {
+  it('renders empty state when native content and included products are empty', () => {
+    render(
+      <MembershipContentList nativeContentItems={[]} includedProducts={[]} />,
+    );
+
+    expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
+  });
+
+  it('renders an included Course using registry-driven metadata', () => {
+    render(
+      <MembershipContentList
+        nativeContentItems={[]}
+        includedProducts={[courseProduct]}
+      />,
+    );
+
+    expect(screen.getByText('Launch Course')).toBeInTheDocument();
+    expect(screen.getByText('Course')).toBeInTheDocument();
+    expect(screen.getByText('🎓')).toBeInTheDocument();
+  });
+
+  it('renders an included Download using registry-driven metadata', () => {
+    render(
+      <MembershipContentList
+        nativeContentItems={[]}
+        includedProducts={[downloadProduct]}
+      />,
+    );
+
+    expect(screen.getByText('Template Pack')).toBeInTheDocument();
+    expect(screen.getByText('Download')).toBeInTheDocument();
+    expect(screen.getByText('⬇️')).toBeInTheDocument();
+  });
+
+  it('renders a native Membership content item using the frontend content model', () => {
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativePost]}
+        includedProducts={[]}
+      />,
+    );
+
+    expect(screen.getByText('Member update')).toBeInTheDocument();
+    expect(screen.getByText('Post')).toBeInTheDocument();
+    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+  });
+
+  it('renders native content before included Products when both are present', () => {
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativePost]}
+        includedProducts={[courseProduct]}
+      />,
+    );
+
+    const titles = screen
+      .getAllByRole('heading', { level: 4 })
+      .map((heading) => heading.textContent);
+
+    expect(titles).toEqual(['Member update', 'Launch Course']);
+  });
+
+  it('does not mutate input models while creating the unified list', () => {
+    const nativeContentItems = Object.freeze([Object.freeze(nativePost)]);
+    const includedProducts = Object.freeze([Object.freeze(courseProduct)]);
+
+    const listItems = createMembershipContentListItems(
+      nativeContentItems,
+      includedProducts,
+    );
+
+    expect(listItems).toEqual([
+      {
+        kind: 'CONTENT',
+        content: nativePost,
+      },
+      {
+        kind: 'PRODUCT',
+        product: courseProduct,
+      },
+    ]);
+    expect(nativeContentItems).toEqual([nativePost]);
+    expect(includedProducts).toEqual([courseProduct]);
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/membership-content-list.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content-list.component.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo } from 'react';
+
+import { Button, StatusChip } from '@shared/ui';
+import { ProductMinimised } from 'core/api/models';
+import { PRODUCT_TYPE_REGISTRY } from 'core/constants';
+import {
+  createMembershipContentListItems,
+  MEMBERSHIP_CONTENT_TYPE_ICONS,
+  MEMBERSHIP_CONTENT_TYPE_LABELS,
+  MembershipContentItemBase,
+} from './models';
+
+interface MembershipContentListProps {
+  nativeContentItems: readonly MembershipContentItemBase[];
+  includedProducts: readonly ProductMinimised[];
+  // eslint-disable-next-line no-unused-vars
+  onRemoveProduct?: (productId?: string) => void;
+}
+
+const getProductTitle = (product: ProductMinimised) =>
+  product.title ?? 'Untitled product';
+
+const MembershipContentList: React.FC<MembershipContentListProps> = ({
+  nativeContentItems,
+  includedProducts,
+  onRemoveProduct,
+}) => {
+  const listItems = useMemo(
+    () => createMembershipContentListItems(nativeContentItems, includedProducts),
+    [includedProducts, nativeContentItems],
+  );
+
+  if (listItems.length === 0) {
+    return (
+      <p className="membership-content-list__empty">
+        No membership content yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="membership-content-list">
+      {listItems.map((item) => {
+        if (item.kind === 'CONTENT') {
+          const { content } = item;
+
+          return (
+            <div
+              key={`content-${content.id}`}
+              className="membership-content-list-item"
+            >
+              <div className="membership-content-list-item__media">
+                <span>{MEMBERSHIP_CONTENT_TYPE_ICONS[content.type]}</span>
+              </div>
+              <div className="membership-content-list-item__content">
+                <h4>{content.title}</h4>
+                <div className="membership-content-list-item__meta">
+                  <span>{MEMBERSHIP_CONTENT_TYPE_LABELS[content.type]}</span>
+                  <span className="membership-content-list-item__status">
+                    {content.status}
+                  </span>
+                </div>
+                {content.description && <p>{content.description}</p>}
+              </div>
+            </div>
+          );
+        }
+
+        const { product } = item;
+        const typeConfig = product.type
+          ? PRODUCT_TYPE_REGISTRY[product.type]
+          : undefined;
+
+        return (
+          <div
+            key={`product-${product.id}`}
+            className="membership-content-list-item"
+          >
+            <div className="membership-content-list-item__media">
+              {product.imageUrl ? (
+                <img src={product.imageUrl} alt={getProductTitle(product)} />
+              ) : (
+                <span>{typeConfig?.displayIcon}</span>
+              )}
+            </div>
+            <div className="membership-content-list-item__content">
+              <h4>{getProductTitle(product)}</h4>
+              <div className="membership-content-list-item__meta">
+                <span>{typeConfig?.label ?? product.type}</span>
+                <StatusChip status={product.status ?? 'DRAFT'} />
+              </div>
+              {product.description && <p>{product.description}</p>}
+            </div>
+            {onRemoveProduct && (
+              <Button
+                type="button"
+                variant="remove"
+                onClick={() => onRemoveProduct(product.id)}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MembershipContentList;

--- a/src/domains/app/features/product-form/membership-content/membership-content-type-chooser.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content-type-chooser.component.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import MembershipContentTypeChooser from './membership-content-type-chooser.component';
+
+const renderChooser = () => {
+  const onSelect = jest.fn();
+  const onCancel = jest.fn();
+
+  render(
+    <MembershipContentTypeChooser
+      onSelect={onSelect}
+      onCancel={onCancel}
+    />,
+  );
+
+  return { onSelect, onCancel };
+};
+
+describe('<MembershipContentTypeChooser />', () => {
+  it('renders all four options', () => {
+    renderChooser();
+
+    expect(screen.getByRole('button', { name: /Video/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Post/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Resource/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Existing Product/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('selecting Video calls the callback with VIDEO', () => {
+    const { onSelect } = renderChooser();
+
+    fireEvent.click(screen.getByRole('button', { name: /Video/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('VIDEO');
+  });
+
+  it('selecting Post calls the callback with POST', () => {
+    const { onSelect } = renderChooser();
+
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('POST');
+  });
+
+  it('selecting Resource calls the callback with RESOURCE', () => {
+    const { onSelect } = renderChooser();
+
+    fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('RESOURCE');
+  });
+
+  it('selecting Existing Product calls the callback with EXISTING_PRODUCT', () => {
+    const { onSelect } = renderChooser();
+
+    fireEvent.click(screen.getByRole('button', { name: /Existing Product/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('EXISTING_PRODUCT');
+  });
+
+  it('Cancel closes without selection', () => {
+    const { onSelect, onCancel } = renderChooser();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/membership-content-type-chooser.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content-type-chooser.component.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { Button } from '@shared/ui';
+import { MembershipContentChooserSelection } from './models';
+
+interface MembershipContentTypeChooserProps {
+  // eslint-disable-next-line no-unused-vars
+  onSelect: (selection: MembershipContentChooserSelection) => void;
+  onCancel: () => void;
+}
+
+const CONTENT_OPTIONS: Array<{
+  selection: MembershipContentChooserSelection;
+  label: string;
+  description: string;
+}> = [
+  {
+    selection: 'VIDEO',
+    label: 'Video',
+    description: 'Upload a member-only video',
+  },
+  {
+    selection: 'POST',
+    label: 'Post',
+    description: 'Publish a text update',
+  },
+  {
+    selection: 'RESOURCE',
+    label: 'Resource',
+    description: 'Share a downloadable file',
+  },
+  {
+    selection: 'EXISTING_PRODUCT',
+    label: 'Existing Product',
+    description: 'Include an existing Course or Download',
+  },
+];
+
+const MembershipContentTypeChooser: React.FC<
+  MembershipContentTypeChooserProps
+> = ({ onSelect, onCancel }) => (
+  <div className="membership-content-type-chooser">
+    <div className="membership-content-type-chooser__options">
+      {CONTENT_OPTIONS.map((option) => (
+        <button
+          key={option.selection}
+          type="button"
+          className="membership-content-type-chooser__option"
+          onClick={() => onSelect(option.selection)}
+        >
+          <span>{option.label}</span>
+          <small>{option.description}</small>
+        </button>
+      ))}
+    </div>
+    <div className="membership-content-type-chooser__actions">
+      <Button type="button" variant="tertiary" onClick={onCancel}>
+        Cancel
+      </Button>
+    </div>
+  </div>
+);
+
+export default MembershipContentTypeChooser;

--- a/src/domains/app/features/product-form/membership-content/membership-content.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content.component.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('core/store/product-store', () => ({
+  __esModule: true,
+  getProductSummariesByOwner: jest.fn(),
+  selectProductSummaries: jest.fn((state) => state.products.productSummaries),
+  selectProductsLoading: jest.fn((state) => state.products.loading),
+  selectProductsError: jest.fn((state) => state.products.error),
+}));
+
+import { useDispatch, useSelector } from 'react-redux';
+import { ProductMinimised } from 'core/api/models';
+import MembershipContentSection from './membership-content.component';
+
+const productSummaries: ProductMinimised[] = [
+  {
+    id: 'course-1',
+    title: 'Course One',
+    description: 'A full course',
+    type: 'COURSE',
+    status: 'DRAFT',
+  },
+  {
+    id: 'download-1',
+    title: 'Download Kit',
+    type: 'DOWNLOAD',
+    status: 'PUBLISHED',
+  },
+  {
+    id: 'consultation-1',
+    title: 'Consulting Call',
+    type: 'CONSULTATION',
+    status: 'DRAFT',
+  },
+];
+
+const mockedUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+const mockedUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+const renderMembershipContent = () => {
+  mockedUseDispatch.mockReturnValue(jest.fn() as never);
+  mockedUseSelector.mockImplementation((selector) =>
+    selector({
+      products: {
+        productSummaries,
+        loading: false,
+        error: null,
+      },
+    } as never),
+  );
+
+  render(
+    <MembershipContentSection
+      ownerId="creator-1"
+      currentProductId="membership-1"
+    />,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+describe('<MembershipContentSection />', () => {
+  it('+ Add Content opens the chooser', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+
+    expect(screen.getByRole('button', { name: /Video/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Existing Product/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('selecting Post switches to POST creation mode', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+
+    expect(screen.getByText('Creating Post')).toBeInTheDocument();
+    expect(screen.getByText('Post editor coming next.')).toBeInTheDocument();
+  });
+
+  it('selecting Video switches to VIDEO creation mode', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Video/i }));
+
+    expect(screen.getByText('Creating Video')).toBeInTheDocument();
+    expect(screen.getByText('Video editor coming next.')).toBeInTheDocument();
+  });
+
+  it('selecting Resource switches to RESOURCE creation mode', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
+
+    expect(screen.getByText('Creating Resource')).toBeInTheDocument();
+    expect(screen.getByText('Resource editor coming next.')).toBeInTheDocument();
+  });
+
+  it('cancelling native creation returns to the content list', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByText('Creating Post')).not.toBeInTheDocument();
+    expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
+  });
+
+  it('selecting Existing Product opens the current ProductPicker flow', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Existing Product/i }));
+
+    expect(screen.getByPlaceholderText('Search products...')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select Course One')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select Download Kit')).toBeInTheDocument();
+    expect(screen.queryByText('Consulting Call')).not.toBeInTheDocument();
+  });
+
+  it('chooser does not alter existing included products', async () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Existing Product/i }));
+    fireEvent.click(screen.getByLabelText('Select Course One'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Course One')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('Course One')).toBeInTheDocument();
+  });
+
+  it('content list renders normally when no creation mode is active', () => {
+    renderMembershipContent();
+
+    expect(screen.getByText('Membership Content')).toBeInTheDocument();
+    expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
+    expect(screen.queryByText(/editor coming next/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/membership-content.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content.component.tsx
@@ -1,6 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 
+import { Button } from '@shared/ui';
 import MembershipIncludedProducts from './membership-included-products.component';
+import MembershipContentTypeChooser from './membership-content-type-chooser.component';
+import {
+  MEMBERSHIP_CONTENT_TYPE_LABELS,
+  MembershipContentChooserSelection,
+  MembershipContentCreationMode,
+  MembershipContentItemBase,
+} from './models';
 import './membership-content.styles.scss';
 
 interface MembershipContentSectionProps {
@@ -8,16 +16,83 @@ interface MembershipContentSectionProps {
   currentProductId?: string;
 }
 
+const nativeContentItems: MembershipContentItemBase[] = [];
+
 const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
   ownerId,
   currentProductId,
-}) => (
-  <div className="membership-content">
-    <MembershipIncludedProducts
-      ownerId={ownerId}
-      currentProductId={currentProductId}
-    />
-  </div>
-);
+}) => {
+  const [isChooserOpen, setIsChooserOpen] = useState(false);
+  const [creationMode, setCreationMode] =
+    useState<MembershipContentCreationMode>(null);
+  const [productPickerRequest, setProductPickerRequest] = useState(0);
+
+  const handleSelectContentType = (
+    selection: MembershipContentChooserSelection,
+  ) => {
+    setIsChooserOpen(false);
+
+    if (selection === 'EXISTING_PRODUCT') {
+      setCreationMode(null);
+      setProductPickerRequest((currentRequest) => currentRequest + 1);
+      return;
+    }
+
+    setCreationMode(selection);
+  };
+
+  return (
+    <div className="membership-content">
+      <div className="membership-content__header">
+        <div>
+          <h3>Membership Content</h3>
+          <p>Add member-only content or include existing products.</p>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => setIsChooserOpen(true)}
+        >
+          + Add Content
+        </Button>
+      </div>
+
+      {isChooserOpen && (
+        <MembershipContentTypeChooser
+          onSelect={handleSelectContentType}
+          onCancel={() => setIsChooserOpen(false)}
+        />
+      )}
+
+      {creationMode && (
+        <div className="membership-content-creation-placeholder">
+          <div>
+            <h4>
+              Creating {MEMBERSHIP_CONTENT_TYPE_LABELS[creationMode]}
+            </h4>
+            <p>
+              {MEMBERSHIP_CONTENT_TYPE_LABELS[creationMode]} editor coming next.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="tertiary"
+            onClick={() => setCreationMode(null)}
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
+
+      <MembershipIncludedProducts
+        ownerId={ownerId}
+        currentProductId={currentProductId}
+        nativeContentItems={nativeContentItems}
+        productPickerRequest={productPickerRequest}
+        isContentListHidden={Boolean(creationMode)}
+      />
+    </div>
+  );
+};
 
 export default MembershipContentSection;

--- a/src/domains/app/features/product-form/membership-content/membership-content.styles.scss
+++ b/src/domains/app/features/product-form/membership-content/membership-content.styles.scss
@@ -1,5 +1,89 @@
 .membership-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   width: 100%;
+}
+
+.membership-content__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h3,
+  p {
+    margin: 0;
+  }
+
+  p {
+    margin-top: 0.35rem;
+    color: var(--text-secondary);
+  }
+}
+
+.membership-content-type-chooser {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-0);
+}
+
+.membership-content-type-chooser__options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.75rem;
+}
+
+.membership-content-type-chooser__option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+  padding: 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-1);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+
+  span {
+    font-weight: 600;
+  }
+
+  small {
+    color: var(--text-secondary);
+  }
+}
+
+.membership-content-type-chooser__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.membership-content-creation-placeholder {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-0);
+
+  h4,
+  p {
+    margin: 0;
+  }
+
+  p {
+    margin-top: 0.35rem;
+    color: var(--text-secondary);
+  }
 }
 
 .membership-included-products {
@@ -31,13 +115,18 @@
   color: var(--text-secondary);
 }
 
-.membership-included-products__list {
+.membership-content-list {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-.membership-included-product {
+.membership-content-list__empty {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.membership-content-list-item {
   display: grid;
   grid-template-columns: 3.5rem minmax(0, 1fr) auto;
   gap: 0.75rem;
@@ -48,7 +137,7 @@
   background: var(--surface-0);
 }
 
-.membership-included-product__media {
+.membership-content-list-item__media {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,26 +149,40 @@
   font-size: 1.5rem;
 }
 
-.membership-included-product__media img {
+.membership-content-list-item__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.membership-included-product__content {
+.membership-content-list-item__content {
   min-width: 0;
 
   h4 {
     margin: 0;
     color: var(--text-primary);
   }
+
+  p {
+    margin: 0.35rem 0 0;
+    color: var(--text-secondary);
+  }
 }
 
-.membership-included-product__meta {
+.membership-content-list-item__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
   margin-top: 0.35rem;
   color: var(--text-secondary);
+}
+
+.membership-content-list-item__status {
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
 }

--- a/src/domains/app/features/product-form/membership-content/membership-included-products.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-included-products.component.test.tsx
@@ -56,12 +56,14 @@ const renderIncludedProducts = ({
   products = productSummaries,
   loading = false,
   error = null,
+  productPickerRequest = 0,
 }: {
   ownerId?: string;
   currentProductId?: string;
   products?: ProductMinimised[] | null;
   loading?: boolean;
   error?: string | null;
+  productPickerRequest?: number;
 } = {}) => {
   const dispatch = jest.fn();
 
@@ -83,14 +85,25 @@ const renderIncludedProducts = ({
       }) as any) as typeof getProductSummariesByOwner,
   );
 
-  render(
+  const view = render(
     <MembershipIncludedProducts
       ownerId={ownerId}
       currentProductId={currentProductId}
+      productPickerRequest={productPickerRequest}
     />,
   );
 
-  return { dispatch };
+  const rerenderIncludedProducts = (nextProductPickerRequest: number) => {
+    view.rerender(
+      <MembershipIncludedProducts
+        ownerId={ownerId}
+        currentProductId={currentProductId}
+        productPickerRequest={nextProductPickerRequest}
+      />,
+    );
+  };
+
+  return { dispatch, rerenderIncludedProducts };
 };
 
 afterEach(() => {
@@ -114,14 +127,12 @@ describe('<MembershipIncludedProducts />', () => {
   it('renders the local empty state before products are selected', () => {
     renderIncludedProducts();
 
-    expect(screen.getByText('Included Products')).toBeInTheDocument();
-    expect(screen.getByText('No products included yet.')).toBeInTheDocument();
+    expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
   });
 
   it('opens the inline picker and adds selected products locally', async () => {
-    renderIncludedProducts();
+    renderIncludedProducts({ productPickerRequest: 1 });
 
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Product' }));
     fireEvent.click(screen.getByLabelText('Select Course One'));
     fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
 
@@ -134,34 +145,34 @@ describe('<MembershipIncludedProducts />', () => {
   });
 
   it('prevents adding the same product twice', () => {
-    renderIncludedProducts();
+    const { rerenderIncludedProducts } = renderIncludedProducts({
+      productPickerRequest: 1,
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Product' }));
     fireEvent.click(screen.getByLabelText('Select Course One'));
     fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
 
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Product' }));
+    rerenderIncludedProducts(2);
 
     expect(screen.queryByLabelText('Select Course One')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Select Download Kit')).toBeInTheDocument();
   });
 
   it('allows an included product to be removed and selected again', () => {
-    renderIncludedProducts();
+    const { rerenderIncludedProducts } = renderIncludedProducts({
+      productPickerRequest: 1,
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Product' }));
     fireEvent.click(screen.getByLabelText('Select Course One'));
     fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Product' }));
+    rerenderIncludedProducts(2);
 
     expect(screen.getByLabelText('Select Course One')).toBeInTheDocument();
   });
 
   it('keeps memberships out of the picker candidates', () => {
-    renderIncludedProducts();
-
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Product' }));
+    renderIncludedProducts({ productPickerRequest: 1 });
 
     expect(screen.queryByText('Other Membership')).not.toBeInTheDocument();
   });

--- a/src/domains/app/features/product-form/membership-content/membership-included-products.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-included-products.component.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Button, StatusChip } from '@shared/ui';
 import { AppDispatch, ProductMinimised, ProductType } from 'core/api/models';
-import { PRODUCT_TYPE_REGISTRY } from 'core/constants';
 import {
   getProductSummariesByOwner,
   selectProductSummaries,
@@ -11,17 +9,25 @@ import {
   selectProductsLoading,
 } from 'core/store/product-store';
 import { ProductPicker } from '../product-picker';
+import MembershipContentList from './membership-content-list.component';
+import { MembershipContentItemBase } from './models';
 
 const ALLOWED_INCLUDED_PRODUCT_TYPES: ProductType[] = ['COURSE', 'DOWNLOAD'];
 
 interface MembershipIncludedProductsProps {
   ownerId?: string;
   currentProductId?: string;
+  nativeContentItems?: MembershipContentItemBase[];
+  productPickerRequest?: number;
+  isContentListHidden?: boolean;
 }
 
 const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   ownerId,
   currentProductId,
+  nativeContentItems = [],
+  productPickerRequest = 0,
+  isContentListHidden = false,
 }) => {
   const dispatch = useDispatch<AppDispatch>();
   const products = useSelector(selectProductSummaries);
@@ -29,6 +35,7 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   const error = useSelector(selectProductsError);
   const [includedProductIds, setIncludedProductIds] = useState<string[]>([]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const previousProductPickerRequest = useRef(0);
 
   useEffect(() => {
     if (!ownerId || products || loading) {
@@ -37,6 +44,18 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
 
     dispatch(getProductSummariesByOwner(ownerId));
   }, [dispatch, loading, ownerId, products]);
+
+  useEffect(() => {
+    if (productPickerRequest === previousProductPickerRequest.current) {
+      return;
+    }
+
+    previousProductPickerRequest.current = productPickerRequest;
+
+    if (productPickerRequest > 0) {
+      setIsPickerOpen(true);
+    }
+  }, [productPickerRequest]);
 
   const productById = useMemo(() => {
     const productMap = new Map<string, ProductMinimised>();
@@ -81,23 +100,6 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
 
   return (
     <section className="membership-included-products">
-      <div className="membership-included-products__header">
-        <div>
-          <h3>Included Products</h3>
-          <p>
-            Add existing standalone products that members should get access to.
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="secondary"
-          onClick={() => setIsPickerOpen(true)}
-          disabled={!ownerId || loading}
-        >
-          + Add Product
-        </Button>
-      </div>
-
       {!ownerId && (
         <p className="membership-included-products__empty">
           Save the membership before adding products.
@@ -107,46 +109,12 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
       {ownerId && loading && <p>Loading products...</p>}
       {ownerId && error && <p className="error-message">Error: {error}</p>}
 
-      {ownerId && !loading && !error && includedProducts.length === 0 && (
-        <p className="membership-included-products__empty">
-          No products included yet.
-        </p>
-      )}
-
-      {includedProducts.length > 0 && (
-        <div className="membership-included-products__list">
-          {includedProducts.map((product) => {
-            const typeConfig = product.type
-              ? PRODUCT_TYPE_REGISTRY[product.type]
-              : undefined;
-
-            return (
-              <div key={product.id} className="membership-included-product">
-                <div className="membership-included-product__media">
-                  {product.imageUrl ? (
-                    <img src={product.imageUrl} alt={product.title} />
-                  ) : (
-                    <span>{typeConfig?.displayIcon}</span>
-                  )}
-                </div>
-                <div className="membership-included-product__content">
-                  <h4>{product.title ?? 'Untitled product'}</h4>
-                  <div className="membership-included-product__meta">
-                    <span>{typeConfig?.label ?? product.type}</span>
-                    <StatusChip status={product.status ?? 'DRAFT'} />
-                  </div>
-                </div>
-                <Button
-                  type="button"
-                  variant="remove"
-                  onClick={() => handleRemoveProduct(product.id)}
-                >
-                  Remove
-                </Button>
-              </div>
-            );
-          })}
-        </div>
+      {ownerId && !loading && !error && !isContentListHidden && (
+        <MembershipContentList
+          nativeContentItems={nativeContentItems}
+          includedProducts={includedProducts}
+          onRemoveProduct={handleRemoveProduct}
+        />
       )}
 
       {ownerId && !loading && !error && eligibleProductCount === 0 && (

--- a/src/domains/app/features/product-form/membership-content/models/index.ts
+++ b/src/domains/app/features/product-form/membership-content/models/index.ts
@@ -1,0 +1,1 @@
+export * from './membership-content';

--- a/src/domains/app/features/product-form/membership-content/models/membership-content.ts
+++ b/src/domains/app/features/product-form/membership-content/models/membership-content.ts
@@ -1,0 +1,67 @@
+import { ProductMinimised } from 'core/api/models';
+
+export type MembershipContentType = 'POST' | 'VIDEO' | 'RESOURCE';
+
+export type MembershipContentStatus = 'DRAFT' | 'PUBLISHED' | 'HIDDEN';
+
+export type MembershipContentCreationMode =
+  | 'VIDEO'
+  | 'POST'
+  | 'RESOURCE'
+  | null;
+
+export type MembershipContentChooserSelection =
+  | Exclude<MembershipContentCreationMode, null>
+  | 'EXISTING_PRODUCT';
+
+export interface MembershipContentItemBase {
+  id: string;
+  type: MembershipContentType;
+  title: string;
+  description?: string;
+  status: MembershipContentStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MembershipContentListItem =
+  | {
+      kind: 'CONTENT';
+      content: MembershipContentItemBase;
+    }
+  | {
+      kind: 'PRODUCT';
+      product: ProductMinimised;
+    };
+
+export const MEMBERSHIP_CONTENT_TYPE_LABELS: Record<
+  MembershipContentType,
+  string
+> = {
+  POST: 'Post',
+  VIDEO: 'Video',
+  RESOURCE: 'Resource',
+};
+
+export const MEMBERSHIP_CONTENT_TYPE_ICONS: Record<
+  MembershipContentType,
+  string
+> = {
+  POST: 'P',
+  VIDEO: 'V',
+  RESOURCE: 'R',
+};
+
+export const createMembershipContentListItems = (
+  nativeContentItems: readonly MembershipContentItemBase[],
+  includedProducts: readonly ProductMinimised[],
+): MembershipContentListItem[] => [
+  ...nativeContentItems.map((content) => ({
+    kind: 'CONTENT' as const,
+    content,
+  })),
+  ...includedProducts.map((product) => ({
+    kind: 'PRODUCT' as const,
+    product,
+  })),
+];

--- a/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.test.tsx
+++ b/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.test.tsx
@@ -1,0 +1,57 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+import { UserRole } from 'core/api/models';
+import SidebarNav from './sidebar-nav.component';
+import { SidebarLayoutProvider } from './sidebar-layout.context';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const renderSidebar = (roles: UserRole[]) => {
+  const state = {
+    auth: {
+      user: {
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.test',
+        roles,
+      },
+    },
+  };
+
+  (useSelector as unknown as jest.Mock).mockImplementation((selector) =>
+    selector(state),
+  );
+
+  return render(
+    <MemoryRouter>
+      <SidebarLayoutProvider>
+        <SidebarNav />
+      </SidebarLayoutProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('SidebarNav', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the admin route for admins', () => {
+    renderSidebar([UserRole.ADMIN]);
+
+    expect(screen.getByRole('link', { name: /admin/i })).toBeInTheDocument();
+  });
+
+  it('hides the admin route for non-admin users', () => {
+    renderSidebar([UserRole.CREATOR]);
+
+    expect(screen.queryByRole('link', { name: /admin/i })).toBeNull();
+  });
+});

--- a/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.tsx
+++ b/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import clsx from 'clsx';
 import { HiChevronDoubleLeft, HiChevronDoubleRight } from 'react-icons/hi2';
 
 import { appRoutes } from 'core/constants';
+import { hasAnyRole } from 'core/api/models';
+import { selectAuthUser } from 'core/store/auth-store';
 import { GalIcon } from '@shared/ui';
 import { getCssVar } from '@shared/utils';
 import { useSidebarLayout } from './sidebar-layout.context';
@@ -12,6 +15,7 @@ import './sidebar-nav.styles.scss';
 
 const SidebarNav: React.FC = () => {
   const { isSidebarCollapsed, toggleSidebar } = useSidebarLayout();
+  const user = useSelector(selectAuthUser);
 
   const linkClass = (active: boolean) =>
     clsx('sidebar-link', { 'sidebar-link__active': active });
@@ -27,7 +31,11 @@ const SidebarNav: React.FC = () => {
       </div>
       <ul className="routes-list">
         {appRoutes
-          .filter((route) => !route.hideFromSidebar)
+          .filter(
+            (route) =>
+              !route.hideFromSidebar &&
+              (!route.allowedRoles || hasAnyRole(user?.roles, route.allowedRoles)),
+          )
           .map((route, index) => (
             <li key={index}>
               <NavLink


### PR DESCRIPTION
## Summary

Introduces the frontend foundation for Membership content and the initial `+ Add Content` flow.

Memberships now have a unified content area designed to support both native Membership content and existing standalone products without mixing their domain models.

### Membership content foundation

* Added frontend-only Membership content types for:

  * Post
  * Video
  * Resource
* Added a presentation model that can represent both native Membership content and included standalone Products.
* Added `MembershipContentList` as the unified Membership content hub.
* Included Courses and Downloads remain standalone Products and are represented through `ProductMinimised` rather than being converted into Membership content entities.
* Refactored included-product rendering to use the unified content list while preserving the existing ProductPicker behavior.
* Added an empty state for Memberships without content.

### Add Content flow

* Added an inline `+ Add Content` action to the Membership builder.
* Added `MembershipContentTypeChooser` with:

  * Video
  * Post
  * Resource
  * Existing Product
* Added frontend-only creation mode state owned by the Membership content section.
* Video, Post, and Resource currently transition to placeholder creation states in preparation for their editors.
* Existing Product reuses the existing ProductPicker and creator product-summary flow.
* Refactored the included-products component so the parent can request opening the picker without moving its loading, selection, duplicate-prevention, or removal responsibilities.

## Architecture

Native Membership content and standalone Products remain intentionally separate domain concepts:

* Native content: `POST`, `VIDEO`, `RESOURCE`
* Included Products: currently `COURSE` and `DOWNLOAD`

They are combined only at the presentation layer to create a single Membership content hub.

All new Membership content and creation-mode models are frontend-only. No backend DTOs, API contracts, persistence, or Product payloads were introduced.

## Out of Scope

This PR does not implement:

* Post, Video, or Resource editors
* native Membership content persistence
* media/file uploads
* backend Membership content APIs
* buyer-facing Membership content
* comments
* scheduling/drip
* drag-and-drop ordering

## Verification

* `npm run tsc` ✅
* `npm test -- --runInBand` ✅ — 225 tests passing
* `npm run lint` ✅ — existing repository warnings only

`PROJECT_CONTEXT.md` was updated to document the new Membership content architecture and state boundaries.
