### PR TITLE
Complete Membership content management and ordering

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -85,15 +85,21 @@ Membership content architecture:
 - Native Membership content types are `POST`, `VIDEO`, and `RESOURCE`, with statuses `DRAFT`, `PUBLISHED`, and `HIDDEN`.
 - Native Membership content must not be added to `AbstractProduct`, Product autosave payloads, Product normalizers, or fake backend persistence.
 - Included standalone Products remain Products, currently represented by `ProductMinimised`; Course/Download products must not be converted into native Membership content entities.
-- `MembershipContentList` is the presentation shell that renders a unified Membership content hub from native content items plus included Products.
-- `MembershipContentSection` owns the inline `+ Add Content` chooser state and current native content creation mode. This state is local React state, not Redux.
+- Membership builder content state is owned above the conditionally mounted Membership Content tab via `useMembershipBuilderState` in `ProductForm`, so saved native content, included Product relationships, and feed metadata survive tab switches. This state is local React state, not Redux or `ProductDraft`.
+- Membership feed entries are frontend-only metadata objects for native content and included Products. They carry deterministic identities (`content:{contentId}` / `product:{productId}`), Membership-specific `addedAt`, and optional future `position`; Product `createdAt` must not be used as Membership added time.
+- Membership content ordering is frontend-only and owned by the lifted builder state. `NEWEST_FIRST` is the default derived view sorted by feed-entry `addedAt`; `MANUAL` uses feed-entry array order as the source of truth.
+- Switching from `NEWEST_FIRST` to `MANUAL` initializes manual order from the currently visible newest-first sequence. Switching back to `NEWEST_FIRST` derives chronological display without destroying the stored manual sequence for the current builder session.
+- Manual ordering uses unified Move Up / Move Down controls for native content and included Products. Do not add ordering fields to Product, Post, Video, or Resource entities.
+- `MembershipContentList` is the presentation shell that renders a unified Membership content hub by resolving ordered feed entries against native content items and included Products.
+- `MembershipContentSection` owns only transient inline `+ Add Content` chooser, editor draft, and editing-mode state.
 - `MembershipContentTypeChooser` is presentation/control-only. It offers `Video`, `Post`, `Resource`, and `Existing Product`, but does not fetch data or create content.
-- Selecting `Post` opens `MembershipPostEditor`, a controlled frontend-only editor for title, body, and status. Selecting `Video` or `Resource` still shows only a minimal placeholder.
-- `MembershipContentSection` owns native Membership content items in local React state. Post create/edit/delete is frontend-only; it uses local counter IDs and ISO timestamps, and it must not write to Product autosave or API payloads.
+- Selecting `Post` opens `MembershipPostEditor`, a controlled frontend-only editor for title, body, and status.
+- Selecting `Video` opens `MembershipVideoEditor`, a controlled frontend-only editor for title, description, local video file metadata, and status. Video selection uses `GalUppyFileUploader` in selection-only mode and does not perform a Membership upload request.
+- Selecting `Resource` opens `MembershipResourceEditor`, a controlled frontend-only editor for title, description, local file metadata, and status. Resource selection uses `GalUppyFileUploader` in selection-only mode and does not perform a Membership upload request.
+- Post, Video, and Resource create/edit/delete are frontend-only; they use local counter IDs and ISO timestamps, and they must not write to Product autosave or API payloads.
 - Selecting `Existing Product` closes the chooser and requests that `MembershipIncludedProducts` open its existing `ProductPicker`; no second ProductPicker or duplicated product loading logic should be introduced.
-- The current deterministic list order is native Membership content first, then included Products. There is no drag-and-drop, `position`, or persisted ordering contract yet.
-- `MembershipIncludedProducts` owns Product summary loading, picker state, included-product IDs, add/remove behavior, and duplicate prevention; it delegates list rendering to `MembershipContentList`.
-- The native content source boundary currently passes `nativeContentItems = []` from the Membership content section. Future native content state/API integration should connect there.
+- The current deterministic manual list order is feed-entry array order. There is no drag-and-drop, populated `position`, or persisted ordering contract yet.
+- `MembershipIncludedProducts` owns Product summary loading and picker state. Included Product relationship state, add/remove behavior, and duplicate prevention are controlled by the lifted Membership builder state.
 
 ## Current Feature State
 
@@ -105,7 +111,7 @@ Implemented / reasonably wired:
 - Product create/edit builder for course/download/consultation/membership basics.
 - Membership builder integration with a Membership Content tab.
 - Generic reusable Product Picker used by Membership included-product selection.
-- Unified Membership content list foundation, inline `+ Add Content` chooser, and frontend-only Post create/edit/delete flow.
+- Unified Membership content list foundation, inline `+ Add Content` chooser, and frontend-only Post/Video/Resource create/edit/delete flows.
 - Course/download section creation, autosave, deletion.
 - Course lesson creation, autosave, deletion for `VIDEO`, `ARTICLE`, `QUIZ`; assignment is placeholder.
 - Download section file upload via presigned URL + confirm upload.
@@ -122,7 +128,7 @@ Partially implemented / placeholder:
 - Creator dashboard has placeholder audience/sales sections and hardcoded “member since”.
 - Cart/wishlist exist mostly frontend-side/localStorage; persistence/checkout contract is not clearly backend-backed.
 - Membership included products are limited to existing Course/Download products and held in frontend state only.
-- Native Membership Post content has frontend-only create/edit/delete support. Native Video and Resource remain placeholders. No native Membership content has backend persistence.
+- Native Membership Post, Video, and Resource content have frontend-only create/edit/delete support. Native Video/Resource store selected local file metadata only and have no upload/persistence contract. No native Membership content has backend persistence.
 - Membership recurring pricing has a frontend-only `RecurringPricing` model and `RecurringPriceSelector`; no backend Product pricing contract exists for it yet.
 - Lesson content persistence for uploaded videos/rich text/quiz data may need backend contract verification.
 - Assignment lesson editor is a visible placeholder.
@@ -150,8 +156,8 @@ Deliberate temporary implementations:
 - `REACT_APP_USE_MOCKS` can load ignored local `src/core/api/_mocks.ts`.
 - Blank section/lesson drafts exist locally until enough data is present for backend creation.
 - Download upload deduping is local to the section editor instance.
-- Membership included-product selection is local frontend state until a relationship API exists.
-- Membership native content state is local frontend state. Post can be created/edited/deleted locally; Video/Resource and backend persistence remain undefined.
+- Membership included-product selection, ordering mode, manual feed order, and feed metadata are local frontend state until a relationship/feed API exists.
+- Membership native content state is local frontend state lifted above the Membership Content tab. Post, Video, and Resource can be created/edited/deleted locally; Video/Resource use selection-only local file metadata. Backend persistence remains undefined.
 - Membership recurring pricing is local frontend state until a structured recurring pricing contract exists.
 
 Speculative / verify before changing:
@@ -168,7 +174,7 @@ Recent Git history includes admin role/product ownership work and Membership fro
 - Dev role switcher/backend role change support.
 - Admin product management and create-for-creator flow using `ownerId` query param.
 - Membership added as a first-class frontend Product type.
-- Membership uses the shared builder shell, its own Membership Content tab, frontend-only Course/Download included-product selection, frontend-only Post content creation/editing, native Video/Resource placeholders, and frontend-only recurring pricing controls.
+- Membership uses the shared builder shell, its own Membership Content tab, frontend-only Course/Download included-product selection, frontend-only Post/Video/Resource content creation/editing, and frontend-only recurring pricing controls.
 
 Likely next steps:
 

--- a/src/domains/app/features/product-form/membership-content/index.ts
+++ b/src/domains/app/features/product-form/membership-content/index.ts
@@ -1,1 +1,3 @@
 export { default as MembershipContentSection } from './membership-content.component';
+export * from './models';
+export * from './use-membership-builder-state.hook';

--- a/src/domains/app/features/product-form/membership-content/membership-content-list.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content-list.component.test.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ProductMinimised } from 'core/api/models';
 import MembershipContentList from './membership-content-list.component';
 import {
   createMembershipContentListItems,
+  createMembershipContentFeedEntry,
   createMembershipPostItem,
+  createMembershipProductFeedEntry,
+  createMembershipResourceItem,
+  createMembershipVideoItem,
   MembershipContentItem,
+  orderMembershipFeedEntries,
   updateMembershipPostItem,
+  updateMembershipResourceItem,
+  updateMembershipVideoItem,
 } from './models';
 
 const nativePost: MembershipContentItem = {
@@ -17,6 +24,36 @@ const nativePost: MembershipContentItem = {
   title: 'Member update',
   body: 'A quick note for members',
   status: 'DRAFT',
+  createdAt: '2026-08-08T10:00:00.000Z',
+  updatedAt: '2026-08-08T10:00:00.000Z',
+};
+
+const nativeVideo: MembershipContentItem = {
+  id: 'video-1',
+  type: 'VIDEO',
+  title: 'Member video',
+  description: 'Private video update',
+  status: 'PUBLISHED',
+  video: {
+    fileName: 'member-video.mp4',
+    fileType: 'video/mp4',
+    size: 4096,
+  },
+  createdAt: '2026-08-08T10:00:00.000Z',
+  updatedAt: '2026-08-08T10:00:00.000Z',
+};
+
+const nativeResource: MembershipContentItem = {
+  id: 'resource-1',
+  type: 'RESOURCE',
+  title: 'Member resource',
+  description: 'Private worksheet',
+  status: 'HIDDEN',
+  file: {
+    fileName: 'member-resource.pdf',
+    fileType: 'application/pdf',
+    size: 8192,
+  },
   createdAt: '2026-08-08T10:00:00.000Z',
   updatedAt: '2026-08-08T10:00:00.000Z',
 };
@@ -36,10 +73,35 @@ const downloadProduct: ProductMinimised = {
   status: 'DRAFT',
 };
 
+const nativePostEntry = createMembershipContentFeedEntry(
+  'post-1',
+  '2026-08-08T10:00:00.000Z',
+);
+const nativeVideoEntry = createMembershipContentFeedEntry(
+  'video-1',
+  '2026-08-08T10:00:00.000Z',
+);
+const nativeResourceEntry = createMembershipContentFeedEntry(
+  'resource-1',
+  '2026-08-08T10:00:00.000Z',
+);
+const courseProductEntry = createMembershipProductFeedEntry(
+  'course-1',
+  '2026-08-08T11:00:00.000Z',
+);
+const downloadProductEntry = createMembershipProductFeedEntry(
+  'download-1',
+  '2026-08-08T11:00:00.000Z',
+);
+
 describe('<MembershipContentList />', () => {
   it('renders empty state when native content and included products are empty', () => {
     render(
-      <MembershipContentList nativeContentItems={[]} includedProducts={[]} />,
+      <MembershipContentList
+        nativeContentItems={[]}
+        feedEntries={[]}
+        includedProducts={[]}
+      />,
     );
 
     expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
@@ -49,6 +111,7 @@ describe('<MembershipContentList />', () => {
     render(
       <MembershipContentList
         nativeContentItems={[]}
+        feedEntries={[courseProductEntry]}
         includedProducts={[courseProduct]}
       />,
     );
@@ -62,6 +125,7 @@ describe('<MembershipContentList />', () => {
     render(
       <MembershipContentList
         nativeContentItems={[]}
+        feedEntries={[downloadProductEntry]}
         includedProducts={[downloadProduct]}
       />,
     );
@@ -75,6 +139,7 @@ describe('<MembershipContentList />', () => {
     render(
       <MembershipContentList
         nativeContentItems={[nativePost]}
+        feedEntries={[nativePostEntry]}
         includedProducts={[]}
       />,
     );
@@ -84,10 +149,84 @@ describe('<MembershipContentList />', () => {
     expect(screen.getByText('DRAFT')).toBeInTheDocument();
   });
 
+  it('renders a native Video with filename metadata', () => {
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativeVideo]}
+        feedEntries={[nativeVideoEntry]}
+        includedProducts={[]}
+      />,
+    );
+
+    expect(screen.getByText('Member video')).toBeInTheDocument();
+    expect(screen.getByText('Video')).toBeInTheDocument();
+    expect(screen.getByText('PUBLISHED')).toBeInTheDocument();
+    expect(screen.getByText('member-video.mp4')).toBeInTheDocument();
+  });
+
+  it('exposes edit and delete actions for native Video items', () => {
+    const onEditContent = jest.fn();
+    const onDeleteContent = jest.fn();
+
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativeVideo]}
+        feedEntries={[nativeVideoEntry]}
+        includedProducts={[]}
+        onEditContent={onEditContent}
+        onDeleteContent={onDeleteContent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onEditContent).toHaveBeenCalledWith('video-1');
+    expect(onDeleteContent).toHaveBeenCalledWith('video-1');
+  });
+
+  it('renders a native Resource with filename metadata', () => {
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativeResource]}
+        feedEntries={[nativeResourceEntry]}
+        includedProducts={[]}
+      />,
+    );
+
+    expect(screen.getByText('Member resource')).toBeInTheDocument();
+    expect(screen.getByText('Resource')).toBeInTheDocument();
+    expect(screen.getByText('HIDDEN')).toBeInTheDocument();
+    expect(screen.getByText('member-resource.pdf')).toBeInTheDocument();
+  });
+
+  it('exposes edit and delete actions for native Resource items', () => {
+    const onEditContent = jest.fn();
+    const onDeleteContent = jest.fn();
+
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativeResource]}
+        feedEntries={[nativeResourceEntry]}
+        includedProducts={[]}
+        onEditContent={onEditContent}
+        onDeleteContent={onDeleteContent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onEditContent).toHaveBeenCalledWith('resource-1');
+    expect(onDeleteContent).toHaveBeenCalledWith('resource-1');
+  });
+
   it('renders native content before included Products when both are present', () => {
     render(
       <MembershipContentList
         nativeContentItems={[nativePost]}
+        feedEntries={[nativePostEntry, courseProductEntry]}
+        orderingMode="MANUAL"
         includedProducts={[courseProduct]}
       />,
     );
@@ -103,23 +242,170 @@ describe('<MembershipContentList />', () => {
     const nativeContentItems = Object.freeze([Object.freeze(nativePost)]);
     const includedProducts = Object.freeze([Object.freeze(courseProduct)]);
 
+    const feedEntries = Object.freeze([
+      Object.freeze(nativePostEntry),
+      Object.freeze(courseProductEntry),
+    ]);
     const listItems = createMembershipContentListItems(
+      feedEntries,
       nativeContentItems,
       includedProducts,
+      'MANUAL',
     );
 
     expect(listItems).toEqual([
       {
         kind: 'CONTENT',
+        entry: nativePostEntry,
         content: nativePost,
       },
       {
         kind: 'PRODUCT',
+        entry: courseProductEntry,
         product: courseProduct,
       },
     ]);
+    expect(feedEntries).toEqual([nativePostEntry, courseProductEntry]);
     expect(nativeContentItems).toEqual([nativePost]);
     expect(includedProducts).toEqual([courseProduct]);
+  });
+
+  it('uses feed entry order and skips unresolved entries', () => {
+    const listItems = createMembershipContentListItems(
+      [
+        courseProductEntry,
+        createMembershipContentFeedEntry('missing-content', '2026-08-08T12:00:00.000Z'),
+        nativePostEntry,
+      ],
+      [nativePost],
+      [courseProduct],
+      'MANUAL',
+    );
+
+    expect(listItems.map((item) => item.entry.entryId)).toEqual([
+      'product:course-1',
+      'content:post-1',
+    ]);
+  });
+
+  it('defaults unified list resolution to NEWEST_FIRST', () => {
+    const listItems = createMembershipContentListItems(
+      [nativePostEntry, courseProductEntry],
+      [nativePost],
+      [courseProduct],
+    );
+
+    expect(listItems.map((item) => item.entry.entryId)).toEqual([
+      'product:course-1',
+      'content:post-1',
+    ]);
+  });
+
+  it('sorts feed entries by Membership addedAt descending without mutating the source array', () => {
+    const feedEntries = Object.freeze([
+      Object.freeze(nativePostEntry),
+      Object.freeze(courseProductEntry),
+      Object.freeze(
+        createMembershipContentFeedEntry(
+          'video-1',
+          '2026-08-09T12:00:00.000Z',
+        ),
+      ),
+    ]);
+
+    const orderedEntries = orderMembershipFeedEntries(feedEntries);
+
+    expect(orderedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:video-1',
+      'product:course-1',
+      'content:post-1',
+    ]);
+    expect(feedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:post-1',
+      'product:course-1',
+      'content:video-1',
+    ]);
+  });
+
+  it('ignores Product createdAt when ordering included Products', () => {
+    const olderProductAddedToMembership = {
+      ...courseProduct,
+      createdAt: new Date('2026-08-10T16:00:00.000Z'),
+    } as ProductMinimised;
+    const newerProductAddedToMembership = {
+      ...downloadProduct,
+      createdAt: new Date('2026-08-01T09:00:00.000Z'),
+    } as ProductMinimised;
+
+    const listItems = createMembershipContentListItems(
+      [
+        createMembershipProductFeedEntry(
+          'course-1',
+          '2026-08-10T10:00:00.000Z',
+        ),
+        createMembershipProductFeedEntry(
+          'download-1',
+          '2026-08-10T12:00:00.000Z',
+        ),
+      ],
+      [],
+      [olderProductAddedToMembership, newerProductAddedToMembership],
+    );
+
+    expect(listItems.map((item) => item.entry.entryId)).toEqual([
+      'product:download-1',
+      'product:course-1',
+    ]);
+  });
+
+  it('keeps equal addedAt values deterministic by preserving feed entry order', () => {
+    const orderedEntries = orderMembershipFeedEntries([
+      nativePostEntry,
+      nativeVideoEntry,
+      nativeResourceEntry,
+    ]);
+
+    expect(orderedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:post-1',
+      'content:video-1',
+      'content:resource-1',
+    ]);
+  });
+
+  it('exposes manual Move Up and Move Down controls with boundary buttons disabled', () => {
+    const onMoveFeedEntry = jest.fn();
+
+    render(
+      <MembershipContentList
+        nativeContentItems={[nativePost]}
+        feedEntries={[nativePostEntry, courseProductEntry]}
+        orderingMode="MANUAL"
+        includedProducts={[courseProduct]}
+        onMoveFeedEntry={onMoveFeedEntry}
+      />,
+    );
+
+    const moveUpButtons = screen.getAllByRole('button', { name: 'Move Up' });
+    const moveDownButtons = screen.getAllByRole('button', {
+      name: 'Move Down',
+    });
+
+    expect(moveUpButtons[0]).toBeDisabled();
+    expect(moveDownButtons[1]).toBeDisabled();
+
+    fireEvent.click(moveDownButtons[0]);
+    fireEvent.click(moveUpButtons[1]);
+
+    expect(onMoveFeedEntry).toHaveBeenNthCalledWith(
+      1,
+      'content:post-1',
+      'DOWN',
+    );
+    expect(onMoveFeedEntry).toHaveBeenNthCalledWith(
+      2,
+      'product:course-1',
+      'UP',
+    );
   });
 
   it('updating a Post preserves id and createdAt', () => {
@@ -148,6 +434,100 @@ describe('<MembershipContentList />', () => {
       title: 'Updated title',
       body: 'Updated body',
       status: 'PUBLISHED',
+      updatedAt: '2026-08-08T11:00:00.000Z',
+    });
+    expect(updated.id).toBe(created.id);
+    expect(updated.createdAt).toBe(created.createdAt);
+  });
+
+  it('updating a Video preserves id and createdAt', () => {
+    const created = createMembershipVideoItem(
+      {
+        title: 'Original title',
+        description: 'Original description',
+        status: 'DRAFT',
+        video: {
+          fileName: 'original.mp4',
+          fileType: 'video/mp4',
+          size: 4096,
+        },
+      },
+      'video-1',
+      '2026-08-08T10:00:00.000Z',
+    );
+
+    const updated = updateMembershipVideoItem(
+      created,
+      {
+        title: 'Updated title',
+        description: 'Updated description',
+        status: 'PUBLISHED',
+        video: {
+          fileName: 'replacement.mp4',
+          fileType: 'video/mp4',
+          size: 8192,
+        },
+      },
+      '2026-08-08T11:00:00.000Z',
+    );
+
+    expect(updated).toEqual({
+      ...created,
+      title: 'Updated title',
+      description: 'Updated description',
+      status: 'PUBLISHED',
+      video: {
+        fileName: 'replacement.mp4',
+        fileType: 'video/mp4',
+        size: 8192,
+      },
+      updatedAt: '2026-08-08T11:00:00.000Z',
+    });
+    expect(updated.id).toBe(created.id);
+    expect(updated.createdAt).toBe(created.createdAt);
+  });
+
+  it('updating a Resource preserves id and createdAt', () => {
+    const created = createMembershipResourceItem(
+      {
+        title: 'Original title',
+        description: 'Original description',
+        status: 'DRAFT',
+        file: {
+          fileName: 'original.pdf',
+          fileType: 'application/pdf',
+          size: 4096,
+        },
+      },
+      'resource-1',
+      '2026-08-08T10:00:00.000Z',
+    );
+
+    const updated = updateMembershipResourceItem(
+      created,
+      {
+        title: 'Updated title',
+        description: 'Updated description',
+        status: 'PUBLISHED',
+        file: {
+          fileName: 'replacement.pdf',
+          fileType: 'application/pdf',
+          size: 8192,
+        },
+      },
+      '2026-08-08T11:00:00.000Z',
+    );
+
+    expect(updated).toEqual({
+      ...created,
+      title: 'Updated title',
+      description: 'Updated description',
+      status: 'PUBLISHED',
+      file: {
+        fileName: 'replacement.pdf',
+        fileType: 'application/pdf',
+        size: 8192,
+      },
       updatedAt: '2026-08-08T11:00:00.000Z',
     });
     expect(updated.id).toBe(created.id);

--- a/src/domains/app/features/product-form/membership-content/membership-content-list.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content-list.component.tsx
@@ -8,13 +8,20 @@ import {
   MEMBERSHIP_CONTENT_TYPE_ICONS,
   MEMBERSHIP_CONTENT_TYPE_LABELS,
   MembershipContentItem,
+  MembershipContentListItem,
+  MembershipFeedEntry,
+  MembershipOrderingMode,
 } from './models';
 
 interface MembershipContentListProps {
   nativeContentItems: readonly MembershipContentItem[];
+  feedEntries: readonly MembershipFeedEntry[];
+  orderingMode?: MembershipOrderingMode;
   includedProducts: readonly ProductMinimised[];
   // eslint-disable-next-line no-unused-vars
   onRemoveProduct?: (productId?: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onMoveFeedEntry?: (entryId: string, direction: 'UP' | 'DOWN') => void;
   // eslint-disable-next-line no-unused-vars
   onEditContent?: (contentId: string) => void;
   // eslint-disable-next-line no-unused-vars
@@ -24,16 +31,198 @@ interface MembershipContentListProps {
 const getProductTitle = (product: ProductMinimised) =>
   product.title ?? 'Untitled product';
 
+const canManageNativeContent = (content: MembershipContentItem) =>
+  content.type === 'POST' ||
+  content.type === 'VIDEO' ||
+  content.type === 'RESOURCE';
+
+interface MembershipNativeContentRowProps {
+  item: Extract<MembershipContentListItem, { kind: 'CONTENT' }>;
+  orderingControls?: React.ReactNode;
+  // eslint-disable-next-line no-unused-vars
+  onEditContent?: (contentId: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onDeleteContent?: (contentId: string) => void;
+}
+
+const MembershipNativeContentRow: React.FC<MembershipNativeContentRowProps> = ({
+  item,
+  orderingControls,
+  onEditContent,
+  onDeleteContent,
+}) => {
+  const { content } = item;
+
+  return (
+    <div
+      key={item.entry.entryId}
+      className="membership-content-list-item"
+    >
+      <div className="membership-content-list-item__media">
+        <span>{MEMBERSHIP_CONTENT_TYPE_ICONS[content.type]}</span>
+      </div>
+      <div className="membership-content-list-item__content">
+        <h4>{content.title}</h4>
+        <div className="membership-content-list-item__meta">
+          <span>{MEMBERSHIP_CONTENT_TYPE_LABELS[content.type]}</span>
+          <span className="membership-content-list-item__status">
+            {content.status}
+          </span>
+        </div>
+        {content.type === 'POST' && <p>{content.body}</p>}
+        {content.type !== 'POST' && content.description && (
+          <p>{content.description}</p>
+        )}
+        {content.type === 'VIDEO' && (
+          <p className="membership-content-list-item__file">
+            {content.video.fileName}
+          </p>
+        )}
+        {content.type === 'RESOURCE' && (
+          <p className="membership-content-list-item__file">
+            {content.file.fileName}
+          </p>
+        )}
+      </div>
+      <div className="membership-content-list-item__actions">
+        {orderingControls}
+        {canManageNativeContent(content) && (
+          <>
+            {onEditContent && (
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => onEditContent(content.id)}
+              >
+                Edit
+              </Button>
+            )}
+            {onDeleteContent && (
+              <Button
+                type="button"
+                variant="remove"
+                onClick={() => onDeleteContent(content.id)}
+              >
+                Delete
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface MembershipIncludedProductRowProps {
+  item: Extract<MembershipContentListItem, { kind: 'PRODUCT' }>;
+  orderingControls?: React.ReactNode;
+  // eslint-disable-next-line no-unused-vars
+  onRemoveProduct?: (productId?: string) => void;
+}
+
+const MembershipIncludedProductRow: React.FC<
+  MembershipIncludedProductRowProps
+> = ({ item, orderingControls, onRemoveProduct }) => {
+  const { product } = item;
+  const typeConfig = product.type
+    ? PRODUCT_TYPE_REGISTRY[product.type]
+    : undefined;
+
+  return (
+    <div
+      key={item.entry.entryId}
+      className="membership-content-list-item"
+    >
+      <div className="membership-content-list-item__media">
+        {product.imageUrl ? (
+          <img src={product.imageUrl} alt={getProductTitle(product)} />
+        ) : (
+          <span>{typeConfig?.displayIcon}</span>
+        )}
+      </div>
+      <div className="membership-content-list-item__content">
+        <h4>{getProductTitle(product)}</h4>
+        <div className="membership-content-list-item__meta">
+          <span>{typeConfig?.label ?? product.type}</span>
+          <StatusChip status={product.status ?? 'DRAFT'} />
+        </div>
+        {product.description && <p>{product.description}</p>}
+      </div>
+      <div className="membership-content-list-item__actions">
+        {orderingControls}
+        {onRemoveProduct && (
+          <Button
+            type="button"
+            variant="remove"
+            onClick={() => onRemoveProduct(product.id)}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface MembershipOrderingControlsProps {
+  entryId: string;
+  isFirst: boolean;
+  isLast: boolean;
+  // eslint-disable-next-line no-unused-vars
+  onMoveFeedEntry?: (entryId: string, direction: 'UP' | 'DOWN') => void;
+}
+
+const MembershipOrderingControls: React.FC<MembershipOrderingControlsProps> = ({
+  entryId,
+  isFirst,
+  isLast,
+  onMoveFeedEntry,
+}) => {
+  if (!onMoveFeedEntry) {
+    return null;
+  }
+
+  return (
+    <div className="membership-content-list-item__order-actions">
+      <Button
+        type="button"
+        variant="secondary"
+        disabled={isFirst}
+        onClick={() => onMoveFeedEntry(entryId, 'UP')}
+      >
+        Move Up
+      </Button>
+      <Button
+        type="button"
+        variant="secondary"
+        disabled={isLast}
+        onClick={() => onMoveFeedEntry(entryId, 'DOWN')}
+      >
+        Move Down
+      </Button>
+    </div>
+  );
+};
+
 const MembershipContentList: React.FC<MembershipContentListProps> = ({
   nativeContentItems,
+  feedEntries,
+  orderingMode = 'NEWEST_FIRST',
   includedProducts,
   onRemoveProduct,
+  onMoveFeedEntry,
   onEditContent,
   onDeleteContent,
 }) => {
   const listItems = useMemo(
-    () => createMembershipContentListItems(nativeContentItems, includedProducts),
-    [includedProducts, nativeContentItems],
+    () =>
+      createMembershipContentListItems(
+        feedEntries,
+        nativeContentItems,
+        includedProducts,
+        orderingMode,
+      ),
+    [feedEntries, includedProducts, nativeContentItems, orderingMode],
   );
 
   if (listItems.length === 0) {
@@ -46,92 +235,32 @@ const MembershipContentList: React.FC<MembershipContentListProps> = ({
 
   return (
     <div className="membership-content-list">
-      {listItems.map((item) => {
-        if (item.kind === 'CONTENT') {
-          const { content } = item;
+      {listItems.map((item, index) => {
+        const orderingControls =
+          orderingMode === 'MANUAL' ? (
+            <MembershipOrderingControls
+              entryId={item.entry.entryId}
+              isFirst={index === 0}
+              isLast={index === listItems.length - 1}
+              onMoveFeedEntry={onMoveFeedEntry}
+            />
+          ) : null;
 
-          return (
-            <div
-              key={`content-${content.id}`}
-              className="membership-content-list-item"
-            >
-              <div className="membership-content-list-item__media">
-                <span>{MEMBERSHIP_CONTENT_TYPE_ICONS[content.type]}</span>
-              </div>
-              <div className="membership-content-list-item__content">
-                <h4>{content.title}</h4>
-                <div className="membership-content-list-item__meta">
-                  <span>{MEMBERSHIP_CONTENT_TYPE_LABELS[content.type]}</span>
-                  <span className="membership-content-list-item__status">
-                    {content.status}
-                  </span>
-                </div>
-                {content.type === 'POST' && <p>{content.body}</p>}
-                {content.type !== 'POST' && content.description && (
-                  <p>{content.description}</p>
-                )}
-              </div>
-              {content.type === 'POST' && (
-                <div className="membership-content-list-item__actions">
-                  {onEditContent && (
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() => onEditContent(content.id)}
-                    >
-                      Edit
-                    </Button>
-                  )}
-                  {onDeleteContent && (
-                    <Button
-                      type="button"
-                      variant="remove"
-                      onClick={() => onDeleteContent(content.id)}
-                    >
-                      Delete
-                    </Button>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        }
-
-        const { product } = item;
-        const typeConfig = product.type
-          ? PRODUCT_TYPE_REGISTRY[product.type]
-          : undefined;
-
-        return (
-          <div
-            key={`product-${product.id}`}
-            className="membership-content-list-item"
-          >
-            <div className="membership-content-list-item__media">
-              {product.imageUrl ? (
-                <img src={product.imageUrl} alt={getProductTitle(product)} />
-              ) : (
-                <span>{typeConfig?.displayIcon}</span>
-              )}
-            </div>
-            <div className="membership-content-list-item__content">
-              <h4>{getProductTitle(product)}</h4>
-              <div className="membership-content-list-item__meta">
-                <span>{typeConfig?.label ?? product.type}</span>
-                <StatusChip status={product.status ?? 'DRAFT'} />
-              </div>
-              {product.description && <p>{product.description}</p>}
-            </div>
-            {onRemoveProduct && (
-              <Button
-                type="button"
-                variant="remove"
-                onClick={() => onRemoveProduct(product.id)}
-              >
-                Remove
-              </Button>
-            )}
-          </div>
+        return item.kind === 'CONTENT' ? (
+          <MembershipNativeContentRow
+            key={item.entry.entryId}
+            item={item}
+            orderingControls={orderingControls}
+            onEditContent={onEditContent}
+            onDeleteContent={onDeleteContent}
+          />
+        ) : (
+          <MembershipIncludedProductRow
+            key={item.entry.entryId}
+            item={item}
+            orderingControls={orderingControls}
+            onRemoveProduct={onRemoveProduct}
+          />
         );
       })}
     </div>

--- a/src/domains/app/features/product-form/membership-content/membership-content.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content.component.test.tsx
@@ -16,9 +16,44 @@ jest.mock('core/store/product-store', () => ({
   selectProductsError: jest.fn((state) => state.products.error),
 }));
 
+jest.mock('@shared/ui', () => {
+  const actual = jest.requireActual('@shared/ui');
+  type MockUploaderProps = {
+    allowedFileTypes?: string[];
+    // eslint-disable-next-line no-unused-vars
+    onFilesChange?: (files: File[]) => void;
+  };
+
+  return {
+    __esModule: true,
+    ...actual,
+    GalUppyFileUploader: ({
+      allowedFileTypes = [],
+      onFilesChange,
+    }: MockUploaderProps) => {
+      const isVideoUploader = allowedFileTypes.includes('video/*');
+      const selectedFile = isVideoUploader
+        ? new File(['video'], 'member-video.mp4', { type: 'video/mp4' })
+        : new File(['resource'], 'member-resource.pdf', {
+          type: 'application/pdf',
+        });
+
+      return (
+        <button
+          type="button"
+          onClick={() => onFilesChange?.([selectedFile])}
+        >
+          {isVideoUploader ? 'Select video file' : 'Select resource file'}
+        </button>
+      );
+    },
+  };
+});
+
 import { useDispatch, useSelector } from 'react-redux';
 import { ProductMinimised } from 'core/api/models';
 import MembershipContentSection from './membership-content.component';
+import { useMembershipBuilderState } from './use-membership-builder-state.hook';
 
 const productSummaries: ProductMinimised[] = [
   {
@@ -57,13 +92,105 @@ const renderMembershipContent = () => {
     } as never),
   );
 
-  render(
-    <MembershipContentSection
-      ownerId="creator-1"
-      currentProductId="membership-1"
-    />,
-  );
+  const TestMembershipContent = () => {
+    const membershipBuilderState = useMembershipBuilderState();
+
+    return (
+      <MembershipContentSection
+        ownerId="creator-1"
+        currentProductId="membership-1"
+        nativeContentItems={membershipBuilderState.nativeContentItems}
+        feedEntries={membershipBuilderState.feedEntries}
+        orderingMode={membershipBuilderState.orderingMode}
+        includedProductEntries={membershipBuilderState.includedProductEntries}
+        getNextNativeContentId={
+          membershipBuilderState.getNextNativeContentId
+        }
+        onAddNativeContentItem={
+          membershipBuilderState.addNativeContentItem
+        }
+        onUpdateNativeContentItem={
+          membershipBuilderState.updateNativeContentItem
+        }
+        onDeleteNativeContentItem={
+          membershipBuilderState.deleteNativeContentItem
+        }
+        onOrderingModeChange={membershipBuilderState.setOrderingMode}
+        onAddIncludedProducts={membershipBuilderState.addIncludedProducts}
+        onRemoveIncludedProduct={membershipBuilderState.removeIncludedProduct}
+        onMoveFeedEntry={membershipBuilderState.moveFeedEntry}
+      />
+    );
+  };
+
+  render(<TestMembershipContent />);
 };
+
+const renderSwitchableMembershipContent = () => {
+  mockedUseDispatch.mockReturnValue(jest.fn() as never);
+  mockedUseSelector.mockImplementation((selector) =>
+    selector({
+      products: {
+        productSummaries,
+        loading: false,
+        error: null,
+      },
+    } as never),
+  );
+
+  const TestSwitchableMembershipContent = () => {
+    const [isContentTabOpen, setIsContentTabOpen] = React.useState(true);
+    const membershipBuilderState = useMembershipBuilderState();
+
+    return (
+      <div>
+        <button type="button" onClick={() => setIsContentTabOpen(false)}>
+          Pricing
+        </button>
+        <button type="button" onClick={() => setIsContentTabOpen(true)}>
+          Membership Content
+        </button>
+        {isContentTabOpen && (
+          <MembershipContentSection
+            ownerId="creator-1"
+            currentProductId="membership-1"
+            nativeContentItems={membershipBuilderState.nativeContentItems}
+            feedEntries={membershipBuilderState.feedEntries}
+            orderingMode={membershipBuilderState.orderingMode}
+            includedProductEntries={
+              membershipBuilderState.includedProductEntries
+            }
+            getNextNativeContentId={
+              membershipBuilderState.getNextNativeContentId
+            }
+            onAddNativeContentItem={
+              membershipBuilderState.addNativeContentItem
+            }
+            onUpdateNativeContentItem={
+              membershipBuilderState.updateNativeContentItem
+            }
+            onDeleteNativeContentItem={
+              membershipBuilderState.deleteNativeContentItem
+            }
+            onOrderingModeChange={membershipBuilderState.setOrderingMode}
+            onAddIncludedProducts={membershipBuilderState.addIncludedProducts}
+            onRemoveIncludedProduct={
+              membershipBuilderState.removeIncludedProduct
+            }
+            onMoveFeedEntry={membershipBuilderState.moveFeedEntry}
+          />
+        )}
+      </div>
+    );
+  };
+
+  render(<TestSwitchableMembershipContent />);
+};
+
+const getRenderedContentTitles = () =>
+  screen
+    .getAllByRole('heading', { level: 4 })
+    .map((heading) => heading.textContent);
 
 afterEach(() => {
   cleanup();
@@ -100,8 +227,13 @@ describe('<MembershipContentSection />', () => {
     fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
     fireEvent.click(screen.getByRole('button', { name: /Video/i }));
 
-    expect(screen.getByText('Creating Video')).toBeInTheDocument();
-    expect(screen.getByText('Video editor coming next.')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Video title')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Describe this member-only video'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Select video file' }),
+    ).toBeInTheDocument();
   });
 
   it('selecting Resource switches to RESOURCE creation mode', () => {
@@ -110,8 +242,13 @@ describe('<MembershipContentSection />', () => {
     fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
     fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
 
-    expect(screen.getByText('Creating Resource')).toBeInTheDocument();
-    expect(screen.getByText('Resource editor coming next.')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Resource title')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Describe this member-only resource'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    ).toBeInTheDocument();
   });
 
   it('cancelling native creation returns to the content list', () => {
@@ -156,6 +293,120 @@ describe('<MembershipContentSection />', () => {
     expect(screen.getByText('Course One')).toBeInTheDocument();
   });
 
+  it('saved Post survives switching away from and back to Membership Content', () => {
+    renderSwitchableMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+    fireEvent.change(screen.getByPlaceholderText('Post title'), {
+      target: { value: 'Persistent post' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Write a member-only update'), {
+      target: { value: 'Still here after tab switch.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Pricing' }));
+
+    expect(screen.queryByText('Persistent post')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Membership Content' }),
+    );
+
+    expect(screen.getByText('Persistent post')).toBeInTheDocument();
+    expect(
+      screen.getByText('Still here after tab switch.'),
+    ).toBeInTheDocument();
+  });
+
+  it('included Product survives switching away from and back to Membership Content', async () => {
+    renderSwitchableMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Existing Product/i }));
+    fireEvent.click(screen.getByLabelText('Select Course One'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Course One')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pricing' }));
+    expect(screen.queryByText('Course One')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Membership Content' }),
+    );
+
+    expect(screen.getByText('Course One')).toBeInTheDocument();
+  });
+
+  it('manual ordering mode and sequence survive switching away from Membership Content', async () => {
+    renderSwitchableMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Existing Product/i }));
+    fireEvent.click(screen.getByLabelText('Select Course One'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Course One')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+    fireEvent.change(screen.getByPlaceholderText('Post title'), {
+      target: { value: 'Manual post' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Write a member-only update'), {
+      target: { value: 'Manual body' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(getRenderedContentTitles()).toEqual(['Manual post', 'Course One']);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Manual' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Move Down' })[0]);
+
+    expect(getRenderedContentTitles()).toEqual(['Course One', 'Manual post']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pricing' }));
+    expect(screen.queryByText('Course One')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Membership Content' }),
+    );
+
+    expect(screen.getByRole('radio', { name: 'Manual' })).toBeChecked();
+    expect(getRenderedContentTitles()).toEqual(['Course One', 'Manual post']);
+  });
+
+  it('newly added native content appears first in NEWEST_FIRST', async () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Existing Product/i }));
+    fireEvent.click(screen.getByLabelText('Select Course One'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add selected' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Course One')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Post/i }));
+    fireEvent.change(screen.getByPlaceholderText('Post title'), {
+      target: { value: 'Newest post' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Write a member-only update'), {
+      target: { value: 'Fresh body' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByRole('radio', { name: 'Newest first' })).toBeChecked();
+    expect(getRenderedContentTitles()).toEqual(['Newest post', 'Course One']);
+  });
+
   it('saving creates a local Post and renders it in the unified list', () => {
     renderMembershipContent();
 
@@ -171,6 +422,54 @@ describe('<MembershipContentSection />', () => {
 
     expect(screen.getByText('First member post')).toBeInTheDocument();
     expect(screen.getByText('Welcome to the membership.')).toBeInTheDocument();
+    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+  });
+
+  it('saving creates a local Video and renders it in the unified list', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Video/i }));
+    fireEvent.change(screen.getByPlaceholderText('Video title'), {
+      target: { value: 'First member video' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Describe this member-only video'),
+      {
+        target: { value: 'A private walkthrough.' },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Select video file' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('First member video')).toBeInTheDocument();
+    expect(screen.getByText('A private walkthrough.')).toBeInTheDocument();
+    expect(screen.getByText('member-video.mp4')).toBeInTheDocument();
+    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+  });
+
+  it('saving creates a local Resource and renders it in the unified list', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
+    fireEvent.change(screen.getByPlaceholderText('Resource title'), {
+      target: { value: 'First member resource' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Describe this member-only resource'),
+      {
+        target: { value: 'A private worksheet.' },
+      },
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('First member resource')).toBeInTheDocument();
+    expect(screen.getByText('A private worksheet.')).toBeInTheDocument();
+    expect(screen.getByText('member-resource.pdf')).toBeInTheDocument();
     expect(screen.getByText('DRAFT')).toBeInTheDocument();
   });
 
@@ -224,6 +523,90 @@ describe('<MembershipContentSection />', () => {
     expect(screen.queryByText('Original post')).not.toBeInTheDocument();
   });
 
+  it('Edit opens existing Video values and saving updates the Video', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Video/i }));
+    fireEvent.change(screen.getByPlaceholderText('Video title'), {
+      target: { value: 'Original video' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Describe this member-only video'),
+      {
+        target: { value: 'Original description' },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Select video file' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByDisplayValue('Original video')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('Original description'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Selected video: member-video\.mp4/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Video title'), {
+      target: { value: 'Updated video' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Describe this member-only video'),
+      {
+        target: { value: 'Updated description' },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Updated video')).toBeInTheDocument();
+    expect(screen.getByText('Updated description')).toBeInTheDocument();
+    expect(screen.queryByText('Original video')).not.toBeInTheDocument();
+  });
+
+  it('Edit opens existing Resource values and saving updates the Resource', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
+    fireEvent.change(screen.getByPlaceholderText('Resource title'), {
+      target: { value: 'Original resource' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Describe this member-only resource'),
+      {
+        target: { value: 'Original description' },
+      },
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByDisplayValue('Original resource')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('Original description'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Selected file: member-resource\.pdf/),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Resource title'), {
+      target: { value: 'Updated resource' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Describe this member-only resource'),
+      {
+        target: { value: 'Updated description' },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Updated resource')).toBeInTheDocument();
+    expect(screen.getByText('Updated description')).toBeInTheDocument();
+    expect(screen.queryByText('Original resource')).not.toBeInTheDocument();
+  });
+
   it('Cancel Edit leaves original Post unchanged', () => {
     renderMembershipContent();
 
@@ -246,6 +629,50 @@ describe('<MembershipContentSection />', () => {
     expect(screen.queryByText('Do not keep me')).not.toBeInTheDocument();
   });
 
+  it('Cancel Edit leaves original Video unchanged', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Video/i }));
+    fireEvent.change(screen.getByPlaceholderText('Video title'), {
+      target: { value: 'Keep this video' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Select video file' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByPlaceholderText('Video title'), {
+      target: { value: 'Do not keep this video' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('Keep this video')).toBeInTheDocument();
+    expect(screen.queryByText('Do not keep this video')).not.toBeInTheDocument();
+  });
+
+  it('Cancel Edit leaves original Resource unchanged', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
+    fireEvent.change(screen.getByPlaceholderText('Resource title'), {
+      target: { value: 'Keep this resource' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByPlaceholderText('Resource title'), {
+      target: { value: 'Do not keep this resource' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('Keep this resource')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Do not keep this resource'),
+    ).not.toBeInTheDocument();
+  });
+
   it('Delete removes Post', () => {
     renderMembershipContent();
 
@@ -261,6 +688,40 @@ describe('<MembershipContentSection />', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(screen.queryByText('Delete me')).not.toBeInTheDocument();
+    expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
+  });
+
+  it('Delete removes Video', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Video/i }));
+    fireEvent.change(screen.getByPlaceholderText('Video title'), {
+      target: { value: 'Delete video' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Select video file' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(screen.queryByText('Delete video')).not.toBeInTheDocument();
+    expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
+  });
+
+  it('Delete removes Resource', () => {
+    renderMembershipContent();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Content' }));
+    fireEvent.click(screen.getByRole('button', { name: /Resource/i }));
+    fireEvent.change(screen.getByPlaceholderText('Resource title'), {
+      target: { value: 'Delete resource' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(screen.queryByText('Delete resource')).not.toBeInTheDocument();
     expect(screen.getByText('No membership content yet.')).toBeInTheDocument();
   });
 

--- a/src/domains/app/features/product-form/membership-content/membership-content.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content.component.tsx
@@ -1,40 +1,97 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
-import { Button } from '@shared/ui';
+import { Button, Radio, RadioGroup } from '@shared/ui';
 import MembershipIncludedProducts from './membership-included-products.component';
 import MembershipContentTypeChooser from './membership-content-type-chooser.component';
 import MembershipPostEditor from './membership-post-editor.component';
+import MembershipResourceEditor from './membership-resource-editor.component';
+import MembershipVideoEditor from './membership-video-editor.component';
 import {
-  MEMBERSHIP_CONTENT_TYPE_LABELS,
   MembershipContentChooserSelection,
   MembershipContentCreationMode,
   MembershipContentItem,
+  MembershipFeedEntry,
+  MembershipOrderingMode,
   MembershipPostDraft,
+  MembershipProductFeedEntry,
+  MembershipResourceDraft,
+  MembershipVideoDraft,
+  MEMBERSHIP_ORDERING_MODE_OPTIONS,
+  createBlankMembershipResourceDraft,
   createBlankMembershipPostDraft,
+  createBlankMembershipVideoDraft,
+  createMembershipResourceItem,
   createMembershipPostItem,
+  createMembershipVideoItem,
+  updateMembershipResourceItem,
   updateMembershipPostItem,
+  updateMembershipVideoItem,
 } from './models';
 import './membership-content.styles.scss';
 
 interface MembershipContentSectionProps {
   ownerId?: string;
   currentProductId?: string;
+  nativeContentItems: MembershipContentItem[];
+  feedEntries: MembershipFeedEntry[];
+  orderingMode: MembershipOrderingMode;
+  includedProductEntries: MembershipProductFeedEntry[];
+  // eslint-disable-next-line no-unused-vars
+  getNextNativeContentId: (type: MembershipContentItem['type']) => string;
+  // eslint-disable-next-line no-unused-vars
+  onAddNativeContentItem: (
+    // eslint-disable-next-line no-unused-vars
+    item: MembershipContentItem,
+    // eslint-disable-next-line no-unused-vars
+    addedAt: string,
+  ) => void;
+  // eslint-disable-next-line no-unused-vars
+  onUpdateNativeContentItem: (
+    // eslint-disable-next-line no-unused-vars
+    contentId: string,
+    // eslint-disable-next-line no-unused-vars
+    updater: (item: MembershipContentItem) => MembershipContentItem,
+  ) => void;
+  // eslint-disable-next-line no-unused-vars
+  onDeleteNativeContentItem: (contentId: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onOrderingModeChange: (orderingMode: MembershipOrderingMode) => void;
+  // eslint-disable-next-line no-unused-vars
+  onAddIncludedProducts: (productIds: string[], addedAt: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onRemoveIncludedProduct: (productId?: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onMoveFeedEntry: (entryId: string, direction: 'UP' | 'DOWN') => void;
 }
 
 const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
   ownerId,
   currentProductId,
+  nativeContentItems,
+  feedEntries,
+  orderingMode,
+  includedProductEntries,
+  getNextNativeContentId,
+  onAddNativeContentItem,
+  onUpdateNativeContentItem,
+  onDeleteNativeContentItem,
+  onOrderingModeChange,
+  onAddIncludedProducts,
+  onRemoveIncludedProduct,
+  onMoveFeedEntry,
 }) => {
-  const nextLocalPostId = useRef(1);
-  const [nativeContentItems, setNativeContentItems] = useState<
-    MembershipContentItem[]
-  >([]);
   const [isChooserOpen, setIsChooserOpen] = useState(false);
   const [creationMode, setCreationMode] =
     useState<MembershipContentCreationMode>(null);
   const [editingContentId, setEditingContentId] = useState<string | null>(null);
   const [postDraft, setPostDraft] = useState<MembershipPostDraft>(
     createBlankMembershipPostDraft,
+  );
+  const [videoDraft, setVideoDraft] = useState<MembershipVideoDraft>(
+    createBlankMembershipVideoDraft,
+  );
+  const [resourceDraft, setResourceDraft] = useState<MembershipResourceDraft>(
+    createBlankMembershipResourceDraft,
   );
   const [productPickerRequest, setProductPickerRequest] = useState(0);
 
@@ -55,6 +112,16 @@ const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
       setEditingContentId(null);
       setPostDraft(createBlankMembershipPostDraft());
     }
+
+    if (selection === 'VIDEO') {
+      setEditingContentId(null);
+      setVideoDraft(createBlankMembershipVideoDraft());
+    }
+
+    if (selection === 'RESOURCE') {
+      setEditingContentId(null);
+      setResourceDraft(createBlankMembershipResourceDraft());
+    }
   };
 
   const handleSavePost = () => {
@@ -68,21 +135,16 @@ const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
     const now = new Date().toISOString();
 
     if (editingContentId) {
-      setNativeContentItems((currentItems) =>
-        currentItems.map((item) =>
-          item.id === editingContentId && item.type === 'POST'
-            ? updateMembershipPostItem(item, postDraft, now)
-            : item,
-        ),
+      onUpdateNativeContentItem(editingContentId, (item) =>
+        item.type === 'POST' ? updateMembershipPostItem(item, postDraft, now) : item,
       );
     } else {
-      const localPostId = `membership-post-${nextLocalPostId.current}`;
-      nextLocalPostId.current += 1;
+      const localPostId = getNextNativeContentId('POST');
 
-      setNativeContentItems((currentItems) => [
-        ...currentItems,
+      onAddNativeContentItem(
         createMembershipPostItem(postDraft, localPostId, now),
-      ]);
+        now,
+      );
     }
 
     setCreationMode(null);
@@ -96,30 +158,125 @@ const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
     setPostDraft(createBlankMembershipPostDraft());
   };
 
+  const handleSaveVideo = () => {
+    const title = videoDraft.title.trim();
+
+    if (!title || !videoDraft.video) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+
+    if (editingContentId) {
+      onUpdateNativeContentItem(editingContentId, (item) =>
+        item.type === 'VIDEO'
+          ? updateMembershipVideoItem(item, videoDraft, now)
+          : item,
+      );
+    } else {
+      const localVideoId = getNextNativeContentId('VIDEO');
+
+      onAddNativeContentItem(
+        createMembershipVideoItem(videoDraft, localVideoId, now),
+        now,
+      );
+    }
+
+    setCreationMode(null);
+    setEditingContentId(null);
+    setVideoDraft(createBlankMembershipVideoDraft());
+  };
+
+  const handleCancelVideoEditing = () => {
+    setCreationMode(null);
+    setEditingContentId(null);
+    setVideoDraft(createBlankMembershipVideoDraft());
+  };
+
+  const handleSaveResource = () => {
+    const title = resourceDraft.title.trim();
+
+    if (!title || !resourceDraft.file) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+
+    if (editingContentId) {
+      onUpdateNativeContentItem(editingContentId, (item) =>
+        item.type === 'RESOURCE'
+          ? updateMembershipResourceItem(item, resourceDraft, now)
+          : item,
+      );
+    } else {
+      const localResourceId = getNextNativeContentId('RESOURCE');
+
+      onAddNativeContentItem(
+        createMembershipResourceItem(resourceDraft, localResourceId, now),
+        now,
+      );
+    }
+
+    setCreationMode(null);
+    setEditingContentId(null);
+    setResourceDraft(createBlankMembershipResourceDraft());
+  };
+
+  const handleCancelResourceEditing = () => {
+    setCreationMode(null);
+    setEditingContentId(null);
+    setResourceDraft(createBlankMembershipResourceDraft());
+  };
+
   const handleEditContent = (contentId: string) => {
     const content = nativeContentItems.find((item) => item.id === contentId);
 
-    if (!content || content.type !== 'POST') {
+    if (!content) {
       return;
     }
 
     setIsChooserOpen(false);
-    setCreationMode('POST');
     setEditingContentId(content.id);
-    setPostDraft({
-      title: content.title,
-      body: content.body,
-      status: content.status,
-    });
+
+    if (content.type === 'POST') {
+      setCreationMode('POST');
+      setPostDraft({
+        title: content.title,
+        body: content.body,
+        status: content.status,
+      });
+      return;
+    }
+
+    if (content.type === 'VIDEO') {
+      setCreationMode('VIDEO');
+      setVideoDraft({
+        title: content.title,
+        description: content.description ?? '',
+        status: content.status,
+        video: content.video,
+      });
+      return;
+    }
+
+    if (content.type === 'RESOURCE') {
+      setCreationMode('RESOURCE');
+      setResourceDraft({
+        title: content.title,
+        description: content.description ?? '',
+        status: content.status,
+        file: content.file,
+      });
+    }
   };
 
   const handleDeleteContent = (contentId: string) => {
-    setNativeContentItems((currentItems) =>
-      currentItems.filter((item) => item.id !== contentId),
-    );
+    onDeleteNativeContentItem(contentId);
   };
 
   const isPostEditorOpen = creationMode === 'POST';
+  const isVideoEditorOpen = creationMode === 'VIDEO';
+  const isResourceEditorOpen = creationMode === 'RESOURCE';
 
   return (
     <div className="membership-content">
@@ -153,32 +310,56 @@ const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
         />
       )}
 
-      {creationMode && creationMode !== 'POST' && (
-        <div className="membership-content-creation-placeholder">
-          <div>
-            <h4>
-              Creating {MEMBERSHIP_CONTENT_TYPE_LABELS[creationMode]}
-            </h4>
-            <p>
-              {MEMBERSHIP_CONTENT_TYPE_LABELS[creationMode]} editor coming next.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="tertiary"
-            onClick={() => setCreationMode(null)}
-          >
-            Cancel
-          </Button>
-        </div>
+      {isVideoEditorOpen && (
+        <MembershipVideoEditor
+          value={videoDraft}
+          onChange={setVideoDraft}
+          onSave={handleSaveVideo}
+          onCancel={handleCancelVideoEditing}
+        />
       )}
+
+      {isResourceEditorOpen && (
+        <MembershipResourceEditor
+          value={resourceDraft}
+          onChange={setResourceDraft}
+          onSave={handleSaveResource}
+          onCancel={handleCancelResourceEditing}
+        />
+      )}
+
+      <div className="membership-content-ordering">
+        <RadioGroup
+          name="membership-content-ordering"
+          label="Content order"
+          value={orderingMode}
+          onChange={(value) =>
+            onOrderingModeChange(value as MembershipOrderingMode)
+          }
+          className="membership-content-ordering__options"
+        >
+          {MEMBERSHIP_ORDERING_MODE_OPTIONS.map((option) => (
+            <Radio
+              key={option.value}
+              label={option.label}
+              value={option.value}
+            />
+          ))}
+        </RadioGroup>
+      </div>
 
       <MembershipIncludedProducts
         ownerId={ownerId}
         currentProductId={currentProductId}
         nativeContentItems={nativeContentItems}
+        feedEntries={feedEntries}
+        orderingMode={orderingMode}
+        includedProductEntries={includedProductEntries}
         productPickerRequest={productPickerRequest}
         isContentListHidden={Boolean(creationMode)}
+        onAddProducts={onAddIncludedProducts}
+        onRemoveProduct={onRemoveIncludedProduct}
+        onMoveFeedEntry={onMoveFeedEntry}
         onEditContent={handleEditContent}
         onDeleteContent={handleDeleteContent}
       />

--- a/src/domains/app/features/product-form/membership-content/membership-content.styles.scss
+++ b/src/domains/app/features/product-form/membership-content/membership-content.styles.scss
@@ -86,7 +86,9 @@
   }
 }
 
-.membership-post-editor {
+.membership-post-editor,
+.membership-resource-editor,
+.membership-video-editor {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
@@ -96,7 +98,27 @@
   background: var(--surface-0);
 }
 
-.membership-post-editor__actions {
+.membership-resource-editor__file,
+.membership-video-editor__video {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  label {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+}
+
+.membership-resource-editor__selected,
+.membership-video-editor__selected {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.membership-post-editor__actions,
+.membership-resource-editor__actions,
+.membership-video-editor__actions {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
@@ -129,6 +151,19 @@
 .membership-included-products__empty {
   margin: 0;
   color: var(--text-secondary);
+}
+
+.membership-content-ordering {
+  padding: 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-0);
+}
+
+.membership-content-ordering__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .membership-content-list {
@@ -185,6 +220,11 @@
   }
 }
 
+.membership-content-list-item__file {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
 .membership-content-list-item__meta {
   display: flex;
   flex-wrap: wrap;
@@ -204,6 +244,13 @@
 }
 
 .membership-content-list-item__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.membership-content-list-item__order-actions {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;

--- a/src/domains/app/features/product-form/membership-content/membership-included-products.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-included-products.component.test.tsx
@@ -20,6 +20,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { ProductMinimised } from 'core/api/models';
 import { getProductSummariesByOwner } from 'core/store/product-store';
 import MembershipIncludedProducts from './membership-included-products.component';
+import { useMembershipBuilderState } from './use-membership-builder-state.hook';
 
 const productSummaries: ProductMinimised[] = [
   {
@@ -85,22 +86,33 @@ const renderIncludedProducts = ({
       }) as any) as typeof getProductSummariesByOwner,
   );
 
-  const view = render(
-    <MembershipIncludedProducts
-      ownerId={ownerId}
-      currentProductId={currentProductId}
-      productPickerRequest={productPickerRequest}
-    />,
-  );
+  const TestIncludedProducts = ({
+    request,
+  }: {
+    request: number;
+  }) => {
+    const membershipBuilderState = useMembershipBuilderState();
 
-  const rerenderIncludedProducts = (nextProductPickerRequest: number) => {
-    view.rerender(
+    return (
       <MembershipIncludedProducts
         ownerId={ownerId}
         currentProductId={currentProductId}
-        productPickerRequest={nextProductPickerRequest}
-      />,
+        nativeContentItems={membershipBuilderState.nativeContentItems}
+        feedEntries={membershipBuilderState.feedEntries}
+        orderingMode={membershipBuilderState.orderingMode}
+        includedProductEntries={membershipBuilderState.includedProductEntries}
+        productPickerRequest={request}
+        onAddProducts={membershipBuilderState.addIncludedProducts}
+        onRemoveProduct={membershipBuilderState.removeIncludedProduct}
+        onMoveFeedEntry={membershipBuilderState.moveFeedEntry}
+      />
     );
+  };
+
+  const view = render(<TestIncludedProducts request={productPickerRequest} />);
+
+  const rerenderIncludedProducts = (nextProductPickerRequest: number) => {
+    view.rerender(<TestIncludedProducts request={nextProductPickerRequest} />);
   };
 
   return { dispatch, rerenderIncludedProducts };

--- a/src/domains/app/features/product-form/membership-content/membership-included-products.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-included-products.component.tsx
@@ -10,7 +10,12 @@ import {
 } from 'core/store/product-store';
 import { ProductPicker } from '../product-picker';
 import MembershipContentList from './membership-content-list.component';
-import { MembershipContentItem } from './models';
+import {
+  MembershipContentItem,
+  MembershipFeedEntry,
+  MembershipOrderingMode,
+  MembershipProductFeedEntry,
+} from './models';
 
 const ALLOWED_INCLUDED_PRODUCT_TYPES: ProductType[] = ['COURSE', 'DOWNLOAD'];
 
@@ -18,8 +23,17 @@ interface MembershipIncludedProductsProps {
   ownerId?: string;
   currentProductId?: string;
   nativeContentItems?: MembershipContentItem[];
+  feedEntries: MembershipFeedEntry[];
+  orderingMode: MembershipOrderingMode;
+  includedProductEntries: MembershipProductFeedEntry[];
   productPickerRequest?: number;
   isContentListHidden?: boolean;
+  // eslint-disable-next-line no-unused-vars
+  onAddProducts: (productIds: string[], addedAt: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onRemoveProduct: (productId?: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onMoveFeedEntry: (entryId: string, direction: 'UP' | 'DOWN') => void;
   // eslint-disable-next-line no-unused-vars
   onEditContent?: (contentId: string) => void;
   // eslint-disable-next-line no-unused-vars
@@ -30,8 +44,14 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   ownerId,
   currentProductId,
   nativeContentItems = [],
+  feedEntries,
+  orderingMode,
+  includedProductEntries,
   productPickerRequest = 0,
   isContentListHidden = false,
+  onAddProducts,
+  onRemoveProduct,
+  onMoveFeedEntry,
   onEditContent,
   onDeleteContent,
 }) => {
@@ -39,9 +59,11 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   const products = useSelector(selectProductSummaries);
   const loading = useSelector(selectProductsLoading);
   const error = useSelector(selectProductsError);
-  const [includedProductIds, setIncludedProductIds] = useState<string[]>([]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const previousProductPickerRequest = useRef(0);
+  const includedProductIds = includedProductEntries.map(
+    (entry) => entry.productId,
+  );
 
   useEffect(() => {
     if (!ownerId || products || loading) {
@@ -88,20 +110,8 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   ).length;
 
   const handleConfirmProducts = (selectedIds: string[]) => {
-    setIncludedProductIds((currentIds) =>
-      Array.from(new Set([...currentIds, ...selectedIds])),
-    );
+    onAddProducts(selectedIds, new Date().toISOString());
     setIsPickerOpen(false);
-  };
-
-  const handleRemoveProduct = (productId?: string) => {
-    if (!productId) {
-      return;
-    }
-
-    setIncludedProductIds((currentIds) =>
-      currentIds.filter((id) => id !== productId),
-    );
   };
 
   return (
@@ -118,8 +128,11 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
       {ownerId && !loading && !error && !isContentListHidden && (
         <MembershipContentList
           nativeContentItems={nativeContentItems}
+          feedEntries={feedEntries}
+          orderingMode={orderingMode}
           includedProducts={includedProducts}
-          onRemoveProduct={handleRemoveProduct}
+          onRemoveProduct={onRemoveProduct}
+          onMoveFeedEntry={onMoveFeedEntry}
           onEditContent={onEditContent}
           onDeleteContent={onDeleteContent}
         />

--- a/src/domains/app/features/product-form/membership-content/membership-post-editor.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-post-editor.component.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Button, Input, Select, Textarea } from '@shared/ui';
 import {
   MembershipContentStatus,
+  MEMBERSHIP_CONTENT_STATUS_OPTIONS,
   MembershipPostDraft,
 } from './models';
 
@@ -13,13 +14,6 @@ interface MembershipPostEditorProps {
   onSave: () => void;
   onCancel: () => void;
 }
-
-const STATUS_OPTIONS: Array<{ value: MembershipContentStatus; label: string }> =
-  [
-    { value: 'DRAFT', label: 'Draft' },
-    { value: 'PUBLISHED', label: 'Published' },
-    { value: 'HIDDEN', label: 'Hidden' },
-  ];
 
 const isValidPostDraft = (value: MembershipPostDraft) =>
   value.title.trim().length > 0 && value.body.trim().length > 0;
@@ -59,7 +53,7 @@ const MembershipPostEditor: React.FC<MembershipPostEditorProps> = ({
         name="membership-post-status"
         label="Status"
         value={value.status}
-        options={STATUS_OPTIONS}
+        options={MEMBERSHIP_CONTENT_STATUS_OPTIONS}
         onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
           onChange({
             ...value,

--- a/src/domains/app/features/product-form/membership-content/membership-resource-editor.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-resource-editor.component.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@shared/ui', () => {
+  const actual = jest.requireActual('@shared/ui');
+  type MockUploaderProps = {
+    // eslint-disable-next-line no-unused-vars
+    onFilesChange?: (files: File[]) => void;
+  };
+
+  return {
+    __esModule: true,
+    ...actual,
+    GalUppyFileUploader: ({
+      onFilesChange,
+    }: MockUploaderProps) => (
+      <button
+        type="button"
+        onClick={() =>
+          onFilesChange?.([
+            new File(['resource'], 'member-resource.pdf', {
+              type: 'application/pdf',
+            }),
+          ])
+        }
+      >
+        Select resource file
+      </button>
+    ),
+  };
+});
+
+import MembershipResourceEditor from './membership-resource-editor.component';
+import { MembershipResourceDraft } from './models';
+
+const draft: MembershipResourceDraft = {
+  title: 'Weekly resource',
+  description: 'A private worksheet.',
+  status: 'DRAFT',
+  file: {
+    fileName: 'weekly-resource.pdf',
+    fileType: 'application/pdf',
+    size: 8192,
+  },
+};
+
+const renderEditor = (value: MembershipResourceDraft = draft) => {
+  const onChange = jest.fn();
+  const onSave = jest.fn();
+  const onCancel = jest.fn();
+
+  render(
+    <MembershipResourceEditor
+      value={value}
+      onChange={onChange}
+      onSave={onSave}
+      onCancel={onCancel}
+    />,
+  );
+
+  return { onChange, onSave, onCancel };
+};
+
+describe('<MembershipResourceEditor />', () => {
+  it('renders title', () => {
+    renderEditor();
+
+    expect(screen.getByDisplayValue('Weekly resource')).toBeInTheDocument();
+  });
+
+  it('renders description', () => {
+    renderEditor();
+
+    expect(screen.getByDisplayValue('A private worksheet.')).toBeInTheDocument();
+  });
+
+  it('renders file selector', () => {
+    renderEditor();
+
+    expect(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    ).toBeInTheDocument();
+  });
+
+  it('default status is DRAFT', () => {
+    renderEditor({
+      title: '',
+      description: '',
+      status: 'DRAFT',
+      file: null,
+    });
+
+    expect(screen.getByLabelText('Status')).toHaveValue('DRAFT');
+  });
+
+  it('requires title before saving', () => {
+    const { onSave } = renderEditor({
+      ...draft,
+      title: '  ',
+    });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('requires file before saving', () => {
+    const { onSave } = renderEditor({
+      ...draft,
+      file: null,
+    });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('selecting a file updates the controlled draft', () => {
+    const { onChange } = renderEditor({
+      title: 'Draft resource',
+      description: '',
+      status: 'DRAFT',
+      file: null,
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select resource file' }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith({
+      title: 'Draft resource',
+      description: '',
+      status: 'DRAFT',
+      file: {
+        fileName: 'member-resource.pdf',
+        fileType: 'application/pdf',
+        size: 8,
+      },
+    });
+  });
+
+  it('changing status preserves other values', () => {
+    const { onChange } = renderEditor();
+
+    fireEvent.change(screen.getByLabelText('Status'), {
+      target: { value: 'PUBLISHED' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...draft,
+      status: 'PUBLISHED',
+    });
+  });
+
+  it('valid Resource can be saved', () => {
+    const { onSave } = renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cancel works', () => {
+    const { onCancel } = renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/membership-resource-editor.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-resource-editor.component.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import { Button, GalUppyFileUploader, Input, Select, Textarea } from '@shared/ui';
+import {
+  MembershipContentStatus,
+  MEMBERSHIP_CONTENT_STATUS_OPTIONS,
+  MembershipResourceDraft,
+  createMembershipResourceFileRef,
+  formatMembershipFileSize,
+} from './models';
+
+interface MembershipResourceEditorProps {
+  value: MembershipResourceDraft;
+  // eslint-disable-next-line no-unused-vars
+  onChange: (value: MembershipResourceDraft) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+const RESOURCE_ALLOWED_FILE_TYPES = [
+  'application/pdf',
+  'application/zip',
+  'application/x-zip-compressed',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/*',
+  'image/*',
+  'audio/*',
+];
+const MAX_RESOURCE_FILE_SIZE = 500 * 1024 * 1024;
+
+const isValidResourceDraft = (value: MembershipResourceDraft) =>
+  value.title.trim().length > 0 && Boolean(value.file);
+
+const MembershipResourceEditor: React.FC<MembershipResourceEditorProps> = ({
+  value,
+  onChange,
+  onSave,
+  onCancel,
+}) => {
+  const canSave = isValidResourceDraft(value);
+
+  const handleFilesChange = (files: File[]) => {
+    const selectedFile = files[0];
+
+    onChange({
+      ...value,
+      file: selectedFile ? createMembershipResourceFileRef(selectedFile) : null,
+    });
+  };
+
+  return (
+    <div className="membership-resource-editor">
+      <Input
+        name="membership-resource-title"
+        label="Title"
+        value={value.title}
+        placeholder="Resource title"
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          onChange({ ...value, title: event.target.value })
+        }
+      />
+
+      <Textarea
+        name="membership-resource-description"
+        label="Description"
+        value={value.description}
+        placeholder="Describe this member-only resource"
+        block
+        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+          onChange({ ...value, description: event.target.value })
+        }
+      />
+
+      <div className="membership-resource-editor__file">
+        <label>File</label>
+        <GalUppyFileUploader
+          allowedFileTypes={RESOURCE_ALLOWED_FILE_TYPES}
+          maxNumberOfFiles={1}
+          maxFileSize={MAX_RESOURCE_FILE_SIZE}
+          disableImporters
+          uploadMode="SELECT_ONLY"
+          onFilesChange={handleFilesChange}
+        />
+        {value.file && (
+          <p className="membership-resource-editor__selected">
+            Selected file: {value.file.fileName} (
+            {formatMembershipFileSize(value.file.size)})
+          </p>
+        )}
+      </div>
+
+      <Select
+        name="membership-resource-status"
+        label="Status"
+        value={value.status}
+        options={MEMBERSHIP_CONTENT_STATUS_OPTIONS}
+        onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+          onChange({
+            ...value,
+            status: event.target.value as MembershipContentStatus,
+          })
+        }
+      />
+
+      <div className="membership-resource-editor__actions">
+        <Button type="button" variant="tertiary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          onClick={onSave}
+          disabled={!canSave}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default MembershipResourceEditor;

--- a/src/domains/app/features/product-form/membership-content/membership-video-editor.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-video-editor.component.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@shared/ui', () => {
+  const actual = jest.requireActual('@shared/ui');
+  type MockUploaderProps = {
+    // eslint-disable-next-line no-unused-vars
+    onFilesChange?: (files: File[]) => void;
+  };
+
+  return {
+    __esModule: true,
+    ...actual,
+    GalUppyFileUploader: ({
+      onFilesChange,
+    }: MockUploaderProps) => (
+      <button
+        type="button"
+        onClick={() =>
+          onFilesChange?.([
+            new File(['video'], 'member-video.mp4', { type: 'video/mp4' }),
+          ])
+        }
+      >
+        Select video file
+      </button>
+    ),
+  };
+});
+
+import MembershipVideoEditor from './membership-video-editor.component';
+import { MembershipVideoDraft } from './models';
+
+const draft: MembershipVideoDraft = {
+  title: 'Weekly video',
+  description: 'A private video update.',
+  status: 'DRAFT',
+  video: {
+    fileName: 'weekly-video.mp4',
+    fileType: 'video/mp4',
+    size: 4096,
+  },
+};
+
+const renderEditor = (value: MembershipVideoDraft = draft) => {
+  const onChange = jest.fn();
+  const onSave = jest.fn();
+  const onCancel = jest.fn();
+
+  render(
+    <MembershipVideoEditor
+      value={value}
+      onChange={onChange}
+      onSave={onSave}
+      onCancel={onCancel}
+    />,
+  );
+
+  return { onChange, onSave, onCancel };
+};
+
+describe('<MembershipVideoEditor />', () => {
+  it('renders title', () => {
+    renderEditor();
+
+    expect(screen.getByDisplayValue('Weekly video')).toBeInTheDocument();
+  });
+
+  it('renders description', () => {
+    renderEditor();
+
+    expect(screen.getByDisplayValue('A private video update.')).toBeInTheDocument();
+  });
+
+  it('renders video selector', () => {
+    renderEditor();
+
+    expect(
+      screen.getByRole('button', { name: 'Select video file' }),
+    ).toBeInTheDocument();
+  });
+
+  it('default status is DRAFT', () => {
+    renderEditor({
+      title: '',
+      description: '',
+      status: 'DRAFT',
+      video: null,
+    });
+
+    expect(screen.getByLabelText('Status')).toHaveValue('DRAFT');
+  });
+
+  it('requires title before saving', () => {
+    const { onSave } = renderEditor({
+      ...draft,
+      title: '  ',
+    });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('requires video before saving', () => {
+    const { onSave } = renderEditor({
+      ...draft,
+      video: null,
+    });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('selecting a video updates the controlled draft', () => {
+    const { onChange } = renderEditor({
+      title: 'Draft video',
+      description: '',
+      status: 'DRAFT',
+      video: null,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select video file' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      title: 'Draft video',
+      description: '',
+      status: 'DRAFT',
+      video: {
+        fileName: 'member-video.mp4',
+        fileType: 'video/mp4',
+        size: 5,
+      },
+    });
+  });
+
+  it('changing status preserves other values', () => {
+    const { onChange } = renderEditor();
+
+    fireEvent.change(screen.getByLabelText('Status'), {
+      target: { value: 'PUBLISHED' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...draft,
+      status: 'PUBLISHED',
+    });
+  });
+
+  it('valid Video can be saved', () => {
+    const { onSave } = renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cancel works', () => {
+    const { onCancel } = renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/membership-video-editor.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-video-editor.component.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import { Button, GalUppyFileUploader, Input, Select, Textarea } from '@shared/ui';
+import {
+  MembershipContentStatus,
+  MEMBERSHIP_CONTENT_STATUS_OPTIONS,
+  MembershipVideoDraft,
+  createMembershipVideoFileRef,
+  formatMembershipFileSize,
+} from './models';
+
+interface MembershipVideoEditorProps {
+  value: MembershipVideoDraft;
+  // eslint-disable-next-line no-unused-vars
+  onChange: (value: MembershipVideoDraft) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+const VIDEO_ALLOWED_FILE_TYPES = ['video/*'];
+const MAX_VIDEO_FILE_SIZE = 500 * 1024 * 1024;
+
+const isValidVideoDraft = (value: MembershipVideoDraft) =>
+  value.title.trim().length > 0 && Boolean(value.video);
+
+const MembershipVideoEditor: React.FC<MembershipVideoEditorProps> = ({
+  value,
+  onChange,
+  onSave,
+  onCancel,
+}) => {
+  const canSave = isValidVideoDraft(value);
+
+  const handleFilesChange = (files: File[]) => {
+    const selectedVideo = files[0];
+
+    onChange({
+      ...value,
+      video: selectedVideo ? createMembershipVideoFileRef(selectedVideo) : null,
+    });
+  };
+
+  return (
+    <div className="membership-video-editor">
+      <Input
+        name="membership-video-title"
+        label="Title"
+        value={value.title}
+        placeholder="Video title"
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          onChange({ ...value, title: event.target.value })
+        }
+      />
+
+      <Textarea
+        name="membership-video-description"
+        label="Description"
+        value={value.description}
+        placeholder="Describe this member-only video"
+        block
+        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+          onChange({ ...value, description: event.target.value })
+        }
+      />
+
+      <div className="membership-video-editor__video">
+        <label>Video</label>
+        <GalUppyFileUploader
+          allowedFileTypes={VIDEO_ALLOWED_FILE_TYPES}
+          maxNumberOfFiles={1}
+          maxFileSize={MAX_VIDEO_FILE_SIZE}
+          disableImporters
+          uploadMode="SELECT_ONLY"
+          onFilesChange={handleFilesChange}
+        />
+        {value.video && (
+          <p className="membership-video-editor__selected">
+            Selected video: {value.video.fileName} (
+            {formatMembershipFileSize(value.video.size)})
+          </p>
+        )}
+      </div>
+
+      <Select
+        name="membership-video-status"
+        label="Status"
+        value={value.status}
+        options={MEMBERSHIP_CONTENT_STATUS_OPTIONS}
+        onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+          onChange({
+            ...value,
+            status: event.target.value as MembershipContentStatus,
+          })
+        }
+      />
+
+      <div className="membership-video-editor__actions">
+        <Button type="button" variant="tertiary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          onClick={onSave}
+          disabled={!canSave}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default MembershipVideoEditor;

--- a/src/domains/app/features/product-form/membership-content/models/membership-content.ts
+++ b/src/domains/app/features/product-form/membership-content/models/membership-content.ts
@@ -4,6 +4,36 @@ export type MembershipContentType = 'POST' | 'VIDEO' | 'RESOURCE';
 
 export type MembershipContentStatus = 'DRAFT' | 'PUBLISHED' | 'HIDDEN';
 
+export type MembershipOrderingMode = 'NEWEST_FIRST' | 'MANUAL';
+
+export const MEMBERSHIP_DEFAULT_ORDERING_MODE: MembershipOrderingMode =
+  'NEWEST_FIRST';
+
+export const MEMBERSHIP_ORDERING_MODE_OPTIONS: Array<{
+  value: MembershipOrderingMode;
+  label: string;
+}> = [
+  { value: 'NEWEST_FIRST', label: 'Newest first' },
+  { value: 'MANUAL', label: 'Manual' },
+];
+
+export const MEMBERSHIP_CONTENT_STATUS_OPTIONS: Array<{
+  value: MembershipContentStatus;
+  label: string;
+}> = [
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'PUBLISHED', label: 'Published' },
+  { value: 'HIDDEN', label: 'Hidden' },
+];
+
+export const formatMembershipFileSize = (size: number) => {
+  if (size < 1024 * 1024) {
+    return `${Math.max(1, Math.round(size / 1024))} KB`;
+  }
+
+  return `${Math.round((size / (1024 * 1024)) * 10) / 10} MB`;
+};
+
 export type MembershipContentCreationMode =
   | 'VIDEO'
   | 'POST'
@@ -29,9 +59,54 @@ export interface MembershipPostItem extends MembershipContentItemBase {
   body: string;
 }
 
+export interface MembershipVideoFileRef {
+  fileName: string;
+  fileType: string;
+  size: number;
+  localPreviewUrl?: string;
+}
+
+export interface MembershipVideoItem extends MembershipContentItemBase {
+  type: 'VIDEO';
+  video: MembershipVideoFileRef;
+}
+
+export interface MembershipResourceFileRef {
+  fileName: string;
+  fileType: string;
+  size: number;
+}
+
+export interface MembershipResourceItem extends MembershipContentItemBase {
+  type: 'RESOURCE';
+  file: MembershipResourceFileRef;
+}
+
 export type MembershipContentItem =
   | MembershipPostItem
-  | (MembershipContentItemBase & { type: 'VIDEO' | 'RESOURCE' });
+  | MembershipVideoItem
+  | MembershipResourceItem;
+
+export type MembershipFeedEntry =
+  | {
+      entryId: string;
+      kind: 'CONTENT';
+      contentId: string;
+      addedAt: string;
+      position?: number;
+    }
+  | {
+      entryId: string;
+      kind: 'PRODUCT';
+      productId: string;
+      addedAt: string;
+      position?: number;
+    };
+
+export type MembershipProductFeedEntry = Extract<
+  MembershipFeedEntry,
+  { kind: 'PRODUCT' }
+>;
 
 export interface MembershipPostDraft {
   title: string;
@@ -39,10 +114,55 @@ export interface MembershipPostDraft {
   status: MembershipContentStatus;
 }
 
+export interface MembershipVideoDraft {
+  title: string;
+  description: string;
+  status: MembershipContentStatus;
+  video: MembershipVideoFileRef | null;
+}
+
+export interface MembershipResourceDraft {
+  title: string;
+  description: string;
+  status: MembershipContentStatus;
+  file: MembershipResourceFileRef | null;
+}
+
 export const createBlankMembershipPostDraft = (): MembershipPostDraft => ({
   title: '',
   body: '',
   status: 'DRAFT',
+});
+
+export const createBlankMembershipVideoDraft = (): MembershipVideoDraft => ({
+  title: '',
+  description: '',
+  status: 'DRAFT',
+  video: null,
+});
+
+export const createBlankMembershipResourceDraft =
+  (): MembershipResourceDraft => ({
+    title: '',
+    description: '',
+    status: 'DRAFT',
+    file: null,
+  });
+
+export const createMembershipVideoFileRef = (
+  file: File,
+): MembershipVideoFileRef => ({
+  fileName: file.name,
+  fileType: file.type,
+  size: file.size,
+});
+
+export const createMembershipResourceFileRef = (
+  file: File,
+): MembershipResourceFileRef => ({
+  fileName: file.name,
+  fileType: file.type,
+  size: file.size,
 });
 
 export const createMembershipPostItem = (
@@ -71,15 +191,141 @@ export const updateMembershipPostItem = (
   updatedAt: now,
 });
 
+export const createMembershipVideoItem = (
+  draft: MembershipVideoDraft,
+  id: string,
+  now: string,
+): MembershipVideoItem => {
+  if (!draft.video) {
+    throw new Error('Cannot create Membership Video without a selected video.');
+  }
+
+  return {
+    id,
+    type: 'VIDEO',
+    title: draft.title.trim(),
+    description: draft.description.trim() || undefined,
+    status: draft.status,
+    video: draft.video,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+export const updateMembershipVideoItem = (
+  item: MembershipVideoItem,
+  draft: MembershipVideoDraft,
+  now: string,
+): MembershipVideoItem => {
+  if (!draft.video) {
+    throw new Error('Cannot update Membership Video without a selected video.');
+  }
+
+  return {
+    ...item,
+    title: draft.title.trim(),
+    description: draft.description.trim() || undefined,
+    status: draft.status,
+    video: draft.video,
+    updatedAt: now,
+  };
+};
+
+export const createMembershipResourceItem = (
+  draft: MembershipResourceDraft,
+  id: string,
+  now: string,
+): MembershipResourceItem => {
+  if (!draft.file) {
+    throw new Error('Cannot create Membership Resource without a selected file.');
+  }
+
+  return {
+    id,
+    type: 'RESOURCE',
+    title: draft.title.trim(),
+    description: draft.description.trim() || undefined,
+    status: draft.status,
+    file: draft.file,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+export const updateMembershipResourceItem = (
+  item: MembershipResourceItem,
+  draft: MembershipResourceDraft,
+  now: string,
+): MembershipResourceItem => {
+  if (!draft.file) {
+    throw new Error('Cannot update Membership Resource without a selected file.');
+  }
+
+  return {
+    ...item,
+    title: draft.title.trim(),
+    description: draft.description.trim() || undefined,
+    status: draft.status,
+    file: draft.file,
+    updatedAt: now,
+  };
+};
+
 export type MembershipContentListItem =
   | {
       kind: 'CONTENT';
+      entry: Extract<MembershipFeedEntry, { kind: 'CONTENT' }>;
       content: MembershipContentItem;
     }
   | {
       kind: 'PRODUCT';
+      entry: MembershipProductFeedEntry;
       product: ProductMinimised;
     };
+
+export const createMembershipContentFeedEntry = (
+  contentId: string,
+  addedAt: string,
+): Extract<MembershipFeedEntry, { kind: 'CONTENT' }> => ({
+  entryId: `content:${contentId}`,
+  kind: 'CONTENT',
+  contentId,
+  addedAt,
+});
+
+export const createMembershipProductFeedEntry = (
+  productId: string,
+  addedAt: string,
+): MembershipProductFeedEntry => ({
+  entryId: `product:${productId}`,
+  kind: 'PRODUCT',
+  productId,
+  addedAt,
+});
+
+export const orderMembershipFeedEntries = (
+  feedEntries: readonly MembershipFeedEntry[],
+  orderingMode: MembershipOrderingMode = MEMBERSHIP_DEFAULT_ORDERING_MODE,
+): MembershipFeedEntry[] => {
+  if (orderingMode === 'MANUAL') {
+    return [...feedEntries];
+  }
+
+  return feedEntries
+    .map((entry, index) => ({ entry, index }))
+    .sort((first, second) => {
+      const addedAtDifference =
+        new Date(second.entry.addedAt).getTime() -
+        new Date(first.entry.addedAt).getTime();
+
+      if (addedAtDifference !== 0) {
+        return addedAtDifference;
+      }
+
+      return first.index - second.index;
+    })
+    .map(({ entry }) => entry);
+};
 
 export const MEMBERSHIP_CONTENT_TYPE_LABELS: Record<
   MembershipContentType,
@@ -100,15 +346,41 @@ export const MEMBERSHIP_CONTENT_TYPE_ICONS: Record<
 };
 
 export const createMembershipContentListItems = (
+  feedEntries: readonly MembershipFeedEntry[],
   nativeContentItems: readonly MembershipContentItem[],
   includedProducts: readonly ProductMinimised[],
-): MembershipContentListItem[] => [
-  ...nativeContentItems.map((content) => ({
-    kind: 'CONTENT' as const,
-    content,
-  })),
-  ...includedProducts.map((product) => ({
-    kind: 'PRODUCT' as const,
-    product,
-  })),
-];
+  orderingMode: MembershipOrderingMode = MEMBERSHIP_DEFAULT_ORDERING_MODE,
+): MembershipContentListItem[] => {
+  const nativeContentById = new Map(
+    nativeContentItems.map((content) => [content.id, content]),
+  );
+  const includedProductById = new Map(
+    includedProducts
+      .filter((product): product is ProductMinimised & { id: string } =>
+        Boolean(product.id),
+      )
+      .map((product) => [product.id, product]),
+  );
+
+  return orderMembershipFeedEntries(feedEntries, orderingMode).reduce<
+    MembershipContentListItem[]
+  >((items, entry) => {
+    if (entry.kind === 'CONTENT') {
+      const content = nativeContentById.get(entry.contentId);
+
+      if (content) {
+        items.push({ kind: 'CONTENT', entry, content });
+      }
+
+      return items;
+    }
+
+    const product = includedProductById.get(entry.productId);
+
+    if (product) {
+      items.push({ kind: 'PRODUCT', entry, product });
+    }
+
+    return items;
+  }, []);
+};

--- a/src/domains/app/features/product-form/membership-content/use-membership-builder-state.hook.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/use-membership-builder-state.hook.test.tsx
@@ -1,0 +1,458 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  createMembershipPostItem,
+  createMembershipResourceItem,
+  createMembershipVideoItem,
+  orderMembershipFeedEntries,
+  updateMembershipPostItem,
+} from './models';
+import { useMembershipBuilderState } from './use-membership-builder-state.hook';
+
+describe('useMembershipBuilderState', () => {
+  it('defaults to NEWEST_FIRST ordering', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    expect(result.current.orderingMode).toBe('NEWEST_FIRST');
+  });
+
+  it('creates native content feed entries with stable identity and addedAt', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+    const now = '2026-08-10T10:00:00.000Z';
+
+    act(() => {
+      const postId = result.current.getNextNativeContentId('POST');
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Member post',
+            body: 'Saved content',
+            status: 'DRAFT',
+          },
+          postId,
+          now,
+        ),
+        now,
+      );
+    });
+
+    expect(result.current.feedEntries).toEqual([
+      {
+        entryId: 'content:membership-post-1',
+        kind: 'CONTENT',
+        contentId: 'membership-post-1',
+        addedAt: now,
+      },
+    ]);
+  });
+
+  it('editing native content preserves its feed entry identity', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+    const createdAt = '2026-08-10T10:00:00.000Z';
+    const updatedAt = '2026-08-10T11:00:00.000Z';
+
+    act(() => {
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Original post',
+            body: 'Original body',
+            status: 'DRAFT',
+          },
+          'membership-post-1',
+          createdAt,
+        ),
+        createdAt,
+      );
+    });
+
+    const originalFeedEntry = result.current.feedEntries[0];
+
+    act(() => {
+      result.current.updateNativeContentItem('membership-post-1', (item) => {
+        if (item.type !== 'POST') {
+          return item;
+        }
+
+        return updateMembershipPostItem(
+          item,
+          {
+            title: 'Updated post',
+            body: 'Updated body',
+            status: 'PUBLISHED',
+          },
+          updatedAt,
+        );
+      });
+    });
+
+    expect(result.current.feedEntries[0]).toEqual(originalFeedEntry);
+    expect(result.current.nativeContentItems[0]).toEqual(
+      expect.objectContaining({
+        title: 'Updated post',
+        updatedAt,
+      }),
+    );
+  });
+
+  it('deleting native content removes its corresponding feed entry', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+    const now = '2026-08-10T10:00:00.000Z';
+
+    act(() => {
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Member post',
+            body: 'Saved content',
+            status: 'DRAFT',
+          },
+          'membership-post-1',
+          now,
+        ),
+        now,
+      );
+      result.current.deleteNativeContentItem('membership-post-1');
+    });
+
+    expect(result.current.nativeContentItems).toEqual([]);
+    expect(result.current.feedEntries).toEqual([]);
+  });
+
+  it('creates included Product feed entries with membership-specific addedAt', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+    const addedAt = '2026-08-10T10:00:00.000Z';
+
+    act(() => {
+      result.current.addIncludedProducts(['course-1'], addedAt);
+    });
+
+    expect(result.current.includedProductEntries).toEqual([
+      {
+        entryId: 'product:course-1',
+        kind: 'PRODUCT',
+        productId: 'course-1',
+        addedAt,
+      },
+    ]);
+  });
+
+  it('removing and re-adding a Product creates the deterministic feed identity with new addedAt', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.removeIncludedProduct('course-1');
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T11:00:00.000Z',
+      );
+    });
+
+    expect(result.current.includedProductEntries).toEqual([
+      {
+        entryId: 'product:course-1',
+        kind: 'PRODUCT',
+        productId: 'course-1',
+        addedAt: '2026-08-10T11:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('does not duplicate included Product feed entries', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T11:00:00.000Z',
+      );
+    });
+
+    expect(result.current.includedProductEntries).toHaveLength(1);
+    expect(result.current.includedProductEntries[0].addedAt).toBe(
+      '2026-08-10T10:00:00.000Z',
+    );
+  });
+
+  it('switching from NEWEST_FIRST to MANUAL preserves the current visible order', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Older post',
+            body: 'Older body',
+            status: 'DRAFT',
+          },
+          'membership-post-1',
+          '2026-08-10T10:00:00.000Z',
+        ),
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T12:00:00.000Z',
+      );
+    });
+
+    act(() => {
+      result.current.setOrderingMode('MANUAL');
+    });
+
+    expect(result.current.orderingMode).toBe('MANUAL');
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'product:course-1',
+      'content:membership-post-1',
+    ]);
+  });
+
+  it('moves native content and Products within one manual sequence', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Post',
+            body: 'Body',
+            status: 'DRAFT',
+          },
+          'membership-post-1',
+          '2026-08-10T10:00:00.000Z',
+        ),
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T11:00:00.000Z',
+      );
+      result.current.addNativeContentItem(
+        createMembershipVideoItem(
+          {
+            title: 'Video',
+            description: '',
+            status: 'DRAFT',
+            video: {
+              fileName: 'video.mp4',
+              fileType: 'video/mp4',
+              size: 4096,
+            },
+          },
+          'membership-video-1',
+          '2026-08-10T12:00:00.000Z',
+        ),
+        '2026-08-10T12:00:00.000Z',
+      );
+      result.current.setOrderingMode('MANUAL');
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:membership-video-1',
+      'product:course-1',
+      'content:membership-post-1',
+    ]);
+
+    act(() => {
+      result.current.moveFeedEntry('product:course-1', 'UP');
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'product:course-1',
+      'content:membership-video-1',
+      'content:membership-post-1',
+    ]);
+
+    act(() => {
+      result.current.moveFeedEntry('product:course-1', 'DOWN');
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:membership-video-1',
+      'product:course-1',
+      'content:membership-post-1',
+    ]);
+  });
+
+  it('does not move beyond manual sequence boundaries', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.addIncludedProducts(
+        ['download-1'],
+        '2026-08-10T11:00:00.000Z',
+      );
+      result.current.setOrderingMode('MANUAL');
+    });
+
+    const initialOrder = result.current.feedEntries.map(
+      (entry) => entry.entryId,
+    );
+
+    act(() => {
+      result.current.moveFeedEntry(initialOrder[0], 'UP');
+      result.current.moveFeedEntry(initialOrder[1], 'DOWN');
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual(
+      initialOrder,
+    );
+  });
+
+  it('switching to NEWEST_FIRST restores chronological display while preserving manual order', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Post',
+            body: 'Body',
+            status: 'DRAFT',
+          },
+          'membership-post-1',
+          '2026-08-10T10:00:00.000Z',
+        ),
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T12:00:00.000Z',
+      );
+    });
+
+    act(() => {
+      result.current.setOrderingMode('MANUAL');
+    });
+
+    act(() => {
+      result.current.moveFeedEntry('content:membership-post-1', 'UP');
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:membership-post-1',
+      'product:course-1',
+    ]);
+
+    act(() => {
+      result.current.setOrderingMode('NEWEST_FIRST');
+    });
+
+    expect(
+      orderMembershipFeedEntries(
+        result.current.feedEntries,
+        result.current.orderingMode,
+      ).map((entry) => entry.entryId),
+    ).toEqual(['product:course-1', 'content:membership-post-1']);
+
+    act(() => {
+      result.current.setOrderingMode('MANUAL');
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:membership-post-1',
+      'product:course-1',
+    ]);
+  });
+
+  it('adds new native content and included Products at the top in MANUAL', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T10:00:00.000Z',
+      );
+    });
+
+    act(() => {
+      result.current.setOrderingMode('MANUAL');
+    });
+
+    act(() => {
+      result.current.addNativeContentItem(
+        createMembershipResourceItem(
+          {
+            title: 'Resource',
+            description: '',
+            status: 'DRAFT',
+            file: {
+              fileName: 'resource.pdf',
+              fileType: 'application/pdf',
+              size: 4096,
+            },
+          },
+          'membership-resource-1',
+          '2026-08-10T11:00:00.000Z',
+        ),
+        '2026-08-10T11:00:00.000Z',
+      );
+      result.current.addIncludedProducts(
+        ['download-1'],
+        '2026-08-10T12:00:00.000Z',
+      );
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'product:download-1',
+      'content:membership-resource-1',
+      'product:course-1',
+    ]);
+  });
+
+  it('editing native content preserves manual position', () => {
+    const { result } = renderHook(() => useMembershipBuilderState());
+
+    act(() => {
+      result.current.addIncludedProducts(
+        ['course-1'],
+        '2026-08-10T10:00:00.000Z',
+      );
+      result.current.addNativeContentItem(
+        createMembershipPostItem(
+          {
+            title: 'Post',
+            body: 'Body',
+            status: 'DRAFT',
+          },
+          'membership-post-1',
+          '2026-08-10T11:00:00.000Z',
+        ),
+        '2026-08-10T11:00:00.000Z',
+      );
+      result.current.setOrderingMode('MANUAL');
+      result.current.updateNativeContentItem('membership-post-1', (item) => {
+        if (item.type !== 'POST') {
+          return item;
+        }
+
+        return updateMembershipPostItem(
+          item,
+          {
+            title: 'Updated post',
+            body: 'Updated body',
+            status: 'PUBLISHED',
+          },
+          '2026-08-10T12:00:00.000Z',
+        );
+      });
+    });
+
+    expect(result.current.feedEntries.map((entry) => entry.entryId)).toEqual([
+      'content:membership-post-1',
+      'product:course-1',
+    ]);
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/use-membership-builder-state.hook.ts
+++ b/src/domains/app/features/product-form/membership-content/use-membership-builder-state.hook.ts
@@ -1,0 +1,207 @@
+import { useRef, useState } from 'react';
+
+import {
+  MembershipContentItem,
+  MembershipContentType,
+  MembershipFeedEntry,
+  MembershipOrderingMode,
+  MembershipProductFeedEntry,
+  MEMBERSHIP_DEFAULT_ORDERING_MODE,
+  createMembershipContentFeedEntry,
+  createMembershipProductFeedEntry,
+  orderMembershipFeedEntries,
+} from './models';
+
+const getContentIdPrefix = (type: MembershipContentType) =>
+  `membership-${type.toLowerCase()}`;
+
+export interface MembershipBuilderState {
+  nativeContentItems: MembershipContentItem[];
+  feedEntries: MembershipFeedEntry[];
+  orderingMode: MembershipOrderingMode;
+  includedProductEntries: MembershipProductFeedEntry[];
+  // eslint-disable-next-line no-unused-vars
+  getNextNativeContentId: (type: MembershipContentType) => string;
+  // eslint-disable-next-line no-unused-vars
+  setOrderingMode: (orderingMode: MembershipOrderingMode) => void;
+  addNativeContentItem: (
+    // eslint-disable-next-line no-unused-vars
+    item: MembershipContentItem,
+    // eslint-disable-next-line no-unused-vars
+    addedAt: string,
+  ) => void;
+  updateNativeContentItem: (
+    // eslint-disable-next-line no-unused-vars
+    contentId: string,
+    // eslint-disable-next-line no-unused-vars
+    updater: (item: MembershipContentItem) => MembershipContentItem,
+  ) => void;
+  // eslint-disable-next-line no-unused-vars
+  deleteNativeContentItem: (contentId: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  addIncludedProducts: (productIds: string[], addedAt: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  removeIncludedProduct: (productId?: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  moveFeedEntry: (entryId: string, direction: 'UP' | 'DOWN') => void;
+}
+
+export const useMembershipBuilderState = (): MembershipBuilderState => {
+  const nextLocalContentIds = useRef<Record<MembershipContentType, number>>({
+    POST: 1,
+    VIDEO: 1,
+    RESOURCE: 1,
+  });
+  const hasInitializedManualOrder = useRef(false);
+  const [nativeContentItems, setNativeContentItems] = useState<
+    MembershipContentItem[]
+  >([]);
+  const [feedEntries, setFeedEntries] = useState<MembershipFeedEntry[]>([]);
+  const [orderingMode, setOrderingModeState] = useState<MembershipOrderingMode>(
+    MEMBERSHIP_DEFAULT_ORDERING_MODE,
+  );
+
+  const getNextNativeContentId = (type: MembershipContentType) => {
+    const nextId = `${getContentIdPrefix(type)}-${nextLocalContentIds.current[type]}`;
+
+    nextLocalContentIds.current[type] += 1;
+
+    return nextId;
+  };
+
+  const setOrderingMode = (nextOrderingMode: MembershipOrderingMode) => {
+    if (nextOrderingMode === orderingMode) {
+      return;
+    }
+
+    if (
+      nextOrderingMode === 'MANUAL' &&
+      orderingMode === 'NEWEST_FIRST' &&
+      !hasInitializedManualOrder.current
+    ) {
+      setFeedEntries((currentEntries) =>
+        orderMembershipFeedEntries(currentEntries, 'NEWEST_FIRST'),
+      );
+      hasInitializedManualOrder.current = true;
+    }
+
+    setOrderingModeState(nextOrderingMode);
+  };
+
+  const addNativeContentItem = (
+    item: MembershipContentItem,
+    addedAt: string,
+  ) => {
+    const newEntry = createMembershipContentFeedEntry(item.id, addedAt);
+
+    setNativeContentItems((currentItems) => [...currentItems, item]);
+    setFeedEntries((currentEntries) =>
+      orderingMode === 'MANUAL'
+        ? [newEntry, ...currentEntries]
+        : [...currentEntries, newEntry],
+    );
+  };
+
+  const updateNativeContentItem = (
+    contentId: string,
+    // eslint-disable-next-line no-unused-vars
+    updater: (item: MembershipContentItem) => MembershipContentItem,
+  ) => {
+    setNativeContentItems((currentItems) =>
+      currentItems.map((item) =>
+        item.id === contentId ? updater(item) : item,
+      ),
+    );
+  };
+
+  const deleteNativeContentItem = (contentId: string) => {
+    setNativeContentItems((currentItems) =>
+      currentItems.filter((item) => item.id !== contentId),
+    );
+    setFeedEntries((currentEntries) =>
+      currentEntries.filter(
+        (entry) => entry.kind !== 'CONTENT' || entry.contentId !== contentId,
+      ),
+    );
+  };
+
+  const addIncludedProducts = (productIds: string[], addedAt: string) => {
+    setFeedEntries((currentEntries) => {
+      const includedProductIds = new Set(
+        currentEntries
+          .filter((entry): entry is MembershipProductFeedEntry =>
+            entry.kind === 'PRODUCT',
+          )
+          .map((entry) => entry.productId),
+      );
+      const nextEntries = productIds
+        .filter((productId) => !includedProductIds.has(productId))
+        .map((productId) => createMembershipProductFeedEntry(productId, addedAt));
+
+      return orderingMode === 'MANUAL'
+        ? [...nextEntries, ...currentEntries]
+        : [...currentEntries, ...nextEntries];
+    });
+  };
+
+  const removeIncludedProduct = (productId?: string) => {
+    if (!productId) {
+      return;
+    }
+
+    setFeedEntries((currentEntries) =>
+      currentEntries.filter(
+        (entry) => entry.kind !== 'PRODUCT' || entry.productId !== productId,
+      ),
+    );
+  };
+
+  const moveFeedEntry = (entryId: string, direction: 'UP' | 'DOWN') => {
+    if (orderingMode !== 'MANUAL') {
+      return;
+    }
+
+    setFeedEntries((currentEntries) => {
+      const currentIndex = currentEntries.findIndex(
+        (entry) => entry.entryId === entryId,
+      );
+
+      if (currentIndex === -1) {
+        return currentEntries;
+      }
+
+      const nextIndex = direction === 'UP' ? currentIndex - 1 : currentIndex + 1;
+
+      if (nextIndex < 0 || nextIndex >= currentEntries.length) {
+        return currentEntries;
+      }
+
+      const nextEntries = [...currentEntries];
+      const currentEntry = nextEntries[currentIndex];
+
+      nextEntries[currentIndex] = nextEntries[nextIndex];
+      nextEntries[nextIndex] = currentEntry;
+
+      return nextEntries;
+    });
+  };
+
+  const includedProductEntries = feedEntries.filter(
+    (entry): entry is MembershipProductFeedEntry => entry.kind === 'PRODUCT',
+  );
+
+  return {
+    nativeContentItems,
+    feedEntries,
+    orderingMode,
+    includedProductEntries,
+    getNextNativeContentId,
+    setOrderingMode,
+    addNativeContentItem,
+    updateNativeContentItem,
+    deleteNativeContentItem,
+    addIncludedProducts,
+    removeIncludedProduct,
+    moveFeedEntry,
+  };
+};

--- a/src/domains/app/features/product-form/utils/form-data-mapper.utils.test.ts
+++ b/src/domains/app/features/product-form/utils/form-data-mapper.utils.test.ts
@@ -17,6 +17,7 @@ describe('mapFormDataToProductPayload', () => {
         currency: 'EUR',
         interval: 'MONTH',
       },
+      orderingMode: 'MANUAL',
       nativeContentItems: [
         {
           id: 'post-1',
@@ -24,6 +25,46 @@ describe('mapFormDataToProductPayload', () => {
           title: 'Should not be sent',
           body: 'Post body',
           status: 'DRAFT',
+        },
+        {
+          id: 'video-1',
+          type: 'VIDEO',
+          title: 'Video should not be sent',
+          description: 'Video description',
+          status: 'PUBLISHED',
+          video: {
+            fileName: 'member-video.mp4',
+            fileType: 'video/mp4',
+            size: 4096,
+          },
+        },
+        {
+          id: 'resource-1',
+          type: 'RESOURCE',
+          title: 'Resource should not be sent',
+          description: 'Resource description',
+          status: 'HIDDEN',
+          file: {
+            fileName: 'member-resource.pdf',
+            fileType: 'application/pdf',
+            size: 8192,
+          },
+        },
+      ],
+      feedEntries: [
+        {
+          entryId: 'content:post-1',
+          kind: 'CONTENT',
+          contentId: 'post-1',
+          addedAt: '2026-08-10T10:00:00.000Z',
+          position: 0,
+        },
+        {
+          entryId: 'product:course-1',
+          kind: 'PRODUCT',
+          productId: 'course-1',
+          addedAt: '2026-08-10T11:00:00.000Z',
+          position: 1,
         },
       ],
       userId: 'creator-1',
@@ -39,6 +80,8 @@ describe('mapFormDataToProductPayload', () => {
       },
     } as ProductDraft & {
       nativeContentItems: unknown;
+      feedEntries: unknown;
+      orderingMode: unknown;
       recurringPricing: unknown;
     };
 
@@ -57,9 +100,17 @@ describe('mapFormDataToProductPayload', () => {
     expect(mapFormDataToProductPayload(formData, null)).not.toHaveProperty(
       'nativeContentItems',
     );
+    expect(mapFormDataToProductPayload(formData, null)).not.toHaveProperty(
+      'feedEntries',
+    );
+    expect(mapFormDataToProductPayload(formData, null)).not.toHaveProperty(
+      'orderingMode',
+    );
     expect(getAutosaveSnapshot(formData)).not.toHaveProperty('recurringPricing');
     expect(getAutosaveSnapshot(formData)).not.toHaveProperty(
       'nativeContentItems',
     );
+    expect(getAutosaveSnapshot(formData)).not.toHaveProperty('feedEntries');
+    expect(getAutosaveSnapshot(formData)).not.toHaveProperty('orderingMode');
   });
 });

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
@@ -19,6 +19,7 @@ import {
   MembershipContentSection,
   RecurringPriceSelector,
   RecurringPricing,
+  useMembershipBuilderState,
 } from 'domains/app/features/product-form';
 import { ProductType, ProductWithSections } from 'core/api/models';
 
@@ -68,6 +69,7 @@ const ProductForm: React.FC = () => {
   const [activeTab, setActiveTab] = useState<BuilderTab | null>(null);
   const [membershipRecurringPricing, setMembershipRecurringPricing] =
     useState<RecurringPricing>(DEFAULT_RECURRING_PRICING);
+  const membershipBuilderState = useMembershipBuilderState();
   const [hasHeroCollapsed, setHasHeroCollapsed] = useState(false);
   const [pendingSidebarScrollTarget, setPendingSidebarScrollTarget] = useState<{
     id: string;
@@ -244,6 +246,32 @@ const ProductForm: React.FC = () => {
                 <MembershipContentSection
                   ownerId={productOwnerId}
                   currentProductId={formData.id}
+                  nativeContentItems={membershipBuilderState.nativeContentItems}
+                  feedEntries={membershipBuilderState.feedEntries}
+                  orderingMode={membershipBuilderState.orderingMode}
+                  includedProductEntries={
+                    membershipBuilderState.includedProductEntries
+                  }
+                  getNextNativeContentId={
+                    membershipBuilderState.getNextNativeContentId
+                  }
+                  onAddNativeContentItem={
+                    membershipBuilderState.addNativeContentItem
+                  }
+                  onUpdateNativeContentItem={
+                    membershipBuilderState.updateNativeContentItem
+                  }
+                  onDeleteNativeContentItem={
+                    membershipBuilderState.deleteNativeContentItem
+                  }
+                  onOrderingModeChange={membershipBuilderState.setOrderingMode}
+                  onAddIncludedProducts={
+                    membershipBuilderState.addIncludedProducts
+                  }
+                  onRemoveIncludedProduct={
+                    membershipBuilderState.removeIncludedProduct
+                  }
+                  onMoveFeedEntry={membershipBuilderState.moveFeedEntry}
                 />
               )}
 

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@shared/ui', () => ({
 const mockUseProductFormFacade = jest.fn();
 const mockUseProductFormAnimation = jest.fn();
 const mockProductHeader = jest.fn();
+const mockUseMembershipBuilderState = jest.fn();
 
 jest.mock('domains/app/features/product-form', () => ({
   __esModule: true,
@@ -51,6 +52,8 @@ jest.mock('domains/app/features/product-form', () => ({
   useProductFormFacade: (...args: any[]) => mockUseProductFormFacade(...args),
   useProductFormAnimation: (...args: any[]) =>
     mockUseProductFormAnimation(...args),
+  useMembershipBuilderState: (...args: any[]) =>
+    mockUseMembershipBuilderState(...args),
 
   // step one: just a button that can toggle showRestOfForm
   CreateProductStepOne: ({
@@ -189,6 +192,23 @@ import ProductForm from './product-form.component';
 afterEach(() => {
   cleanup();
   jest.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseMembershipBuilderState.mockReturnValue({
+    nativeContentItems: [],
+    feedEntries: [],
+    orderingMode: 'NEWEST_FIRST',
+    includedProductEntries: [],
+    getNextNativeContentId: jest.fn(),
+    setOrderingMode: jest.fn(),
+    addNativeContentItem: jest.fn(),
+    updateNativeContentItem: jest.fn(),
+    deleteNativeContentItem: jest.fn(),
+    addIncludedProducts: jest.fn(),
+    removeIncludedProduct: jest.fn(),
+    moveFeedEntry: jest.fn(),
+  });
 });
 
 const makeFacadeState = (overrides: Partial<any> = {}) => ({

--- a/src/shared/ui/gal-uppy-file-uploader/gal-uppy-file-uploader.component.tsx
+++ b/src/shared/ui/gal-uppy-file-uploader/gal-uppy-file-uploader.component.tsx
@@ -30,6 +30,7 @@ interface GalUppyFileUploaderProps {
    * If true, do not load any “import/Companion” plugins (GoogleDrive, Dropbox, etc.)
    */
   disableImporters?: boolean;
+  uploadMode?: 'UPLOAD' | 'SELECT_ONLY';
 }
 
 const GalUppyFileUploader: React.FC<GalUppyFileUploaderProps> = ({
@@ -39,6 +40,7 @@ const GalUppyFileUploader: React.FC<GalUppyFileUploaderProps> = ({
   maxNumberOfFiles,
   maxFileSize = 5 * 1024 * 1024, // default to 5 MB
   disableImporters = false,
+  uploadMode = 'UPLOAD',
 }) => {
   // Use state to hold the Uppy instance so that re-render occurs when it’s created
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,12 +59,14 @@ const GalUppyFileUploader: React.FC<GalUppyFileUploaderProps> = ({
       locale: en_US,
     });
 
-    // Configure the upload endpoint (adjust '/upload' as needed)
-    uppyInstance.use(XHRUpload, {
-      endpoint: '/upload',
-      fieldName: 'file',
-      formData: true,
-    });
+    if (uploadMode === 'UPLOAD') {
+      // Configure the upload endpoint (adjust '/upload' as needed)
+      uppyInstance.use(XHRUpload, {
+        endpoint: '/upload',
+        fieldName: 'file',
+        formData: true,
+      });
+    }
 
     // Add additional plugins with the default Companion service
 
@@ -121,6 +125,7 @@ const GalUppyFileUploader: React.FC<GalUppyFileUploaderProps> = ({
     maxNumberOfFiles,
     memoizedOnFilesChange,
     disableImporters,
+    uploadMode,
   ]);
 
   // const mergedLocale: Locale<number> | undefined = customDropText ? {...en_US, strings: {

--- a/src/shared/ui/gal-uppy-file-uploader/gal-uppy-file-uploader.test.tsx
+++ b/src/shared/ui/gal-uppy-file-uploader/gal-uppy-file-uploader.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import GalUppyFileUploader from './gal-uppy-file-uploader.component';
 import Uppy from '@uppy/core';
+import XHRUpload from '@uppy/xhr-upload';
 import '@testing-library/jest-dom';
 
 jest.mock('@uppy/thumbnail-generator', () => jest.fn());
@@ -71,6 +72,30 @@ describe('GalUppyFileUploader component', () => {
     expect(dashboardProps.proudlyDisplayPoweredByUppy).toBe(true);
   });
 
+  it('uses XHR upload by default', () => {
+    render(<GalUppyFileUploader onFilesChange={mockOnFilesChange} />);
+
+    expect(mockUppyInstance.use).toHaveBeenCalledWith(XHRUpload, {
+      endpoint: '/upload',
+      fieldName: 'file',
+      formData: true,
+    });
+  });
+
+  it('does not use XHR upload in selection-only mode', () => {
+    render(
+      <GalUppyFileUploader
+        uploadMode="SELECT_ONLY"
+        onFilesChange={mockOnFilesChange}
+      />,
+    );
+
+    expect(mockUppyInstance.use).not.toHaveBeenCalledWith(
+      XHRUpload,
+      expect.anything(),
+    );
+  });
+
   it('registers event listeners for file-added and file-removed', () => {
     render(<GalUppyFileUploader onFilesChange={mockOnFilesChange} />);
     // Verify that our uppy instance registered "file-added" and "file-removed" event listeners.
@@ -85,7 +110,12 @@ describe('GalUppyFileUploader component', () => {
   });
 
   it('calls onFilesChange when a file is added', () => {
-    render(<GalUppyFileUploader onFilesChange={mockOnFilesChange} />);
+    render(
+      <GalUppyFileUploader
+        uploadMode="SELECT_ONLY"
+        onFilesChange={mockOnFilesChange}
+      />,
+    );
     // Retrieve the callback that was registered for "file-added"
     const fileAddedCallback = mockUppyInstance.on.mock.calls.find(
       (call: any) => call[0] === 'file-added',


### PR DESCRIPTION
## Summary

Completes the frontend foundation for managing Membership content by adding native Resources, stabilizing Membership builder state, and introducing unified content ordering.

Membership content can now contain native Posts, Videos, and Resources alongside included Courses and Downloads, with all entries participating in the same feed and ordering model.

### Resource content

* Added frontend-only Resource domain and draft models.
* Added `MembershipResourceEditor`.
* Added Resource create, edit, cancel, and delete flows.
* Reused `GalUppyFileUploader` in `SELECT_ONLY` mode for local file selection.
* Resources store local file metadata only; no upload or backend persistence is performed.
* Resource entries render alongside other Membership content in the unified list.

### Membership state and feed architecture

* Lifted saved Membership state into `ProductForm` through `useMembershipBuilderState`.
* Saved native content, included Products, and feed metadata now survive builder tab switches.
* Added `MembershipFeedEntry` as the Membership relationship/presentation layer.
* Added stable feed identities using `content:{id}` and `product:{id}`.
* Added Membership-specific `addedAt` metadata, including for standalone Products added to a Membership.
* Included Product relationships are now controlled by the lifted Membership state while ProductPicker loading/open state remains local.
* Lightly decomposed unified list row rendering for native content and included Products.
* Shared common Membership status options and file-size formatting.

### Content ordering

Added two Membership ordering modes:

* `NEWEST_FIRST` — default
* `MANUAL`

`NEWEST_FIRST` orders the unified feed by Membership-specific `addedAt`, so standalone Product creation/update dates do not affect their position in the Membership.

`MANUAL` allows Creators to curate one unified sequence containing:

* Posts
* Videos
* Resources
* Courses
* Downloads

Manual ordering currently uses Move Up / Move Down controls rather than drag-and-drop.

Switching from newest-first to manual preserves the currently visible order. Switching back to newest-first restores chronological display without discarding the Creator's manual sequence for the current builder session.

New content appears first in both modes, while editing existing content preserves its feed identity, original `addedAt`, and manual position.

## Architecture

Membership feed metadata remains separate from the underlying entities.

Native content and standalone Products are referenced through `MembershipFeedEntry`, keeping Membership-specific concerns such as:

* relationship identity
* date added to Membership
* manual ordering

out of Product and native-content entities.

Membership-specific state remains frontend-only and is not added to:

* Product DTOs
* `ProductDraft`
* Redux Product state
* Product update payloads
* autosave payloads

No backend Membership persistence is introduced in this PR.

## Out of Scope

This PR does not implement:

* backend Membership content persistence
* real Resource file uploads
* drag-and-drop ordering
* persistence across page refresh
* Membership APIs
* Product DTO changes
* buyer-facing Membership content
* comments
* scheduling/drip
* publish/readiness rules

## Verification

* `npm run tsc` ✅
* `npm test -- --runInBand` ✅ — 53 suites, 300 tests
* `npm run lint` ✅ — 0 errors; existing repository warnings remain

`PROJECT_CONTEXT.md` was updated to reflect the current Membership content architecture and ordering behavior.
