### PR TITLE
Add Membership readiness and publish guidance

### DIFF
--- a/src/domains/app/features/product-form/membership-content/index.ts
+++ b/src/domains/app/features/product-form/membership-content/index.ts
@@ -1,3 +1,4 @@
 export { default as MembershipContentSection } from './membership-content.component';
 export * from './models';
 export * from './use-membership-builder-state.hook';
+export * from './utils/membership-readiness.utils';

--- a/src/domains/app/features/product-form/membership-content/membership-content.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content.component.test.tsx
@@ -54,6 +54,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { ProductMinimised } from 'core/api/models';
 import MembershipContentSection from './membership-content.component';
 import { useMembershipBuilderState } from './use-membership-builder-state.hook';
+import { resolveMembershipIncludedProducts } from './utils/membership-readiness.utils';
 
 const productSummaries: ProductMinimised[] = [
   {
@@ -103,6 +104,13 @@ const renderMembershipContent = () => {
         feedEntries={membershipBuilderState.feedEntries}
         orderingMode={membershipBuilderState.orderingMode}
         includedProductEntries={membershipBuilderState.includedProductEntries}
+        productSummaries={productSummaries}
+        includedProducts={resolveMembershipIncludedProducts(
+          membershipBuilderState.includedProductEntries,
+          productSummaries,
+        )}
+        isLoadingProducts={false}
+        productsError={null}
         getNextNativeContentId={
           membershipBuilderState.getNextNativeContentId
         }
@@ -160,6 +168,13 @@ const renderSwitchableMembershipContent = () => {
             includedProductEntries={
               membershipBuilderState.includedProductEntries
             }
+            productSummaries={productSummaries}
+            includedProducts={resolveMembershipIncludedProducts(
+              membershipBuilderState.includedProductEntries,
+              productSummaries,
+            )}
+            isLoadingProducts={false}
+            productsError={null}
             getNextNativeContentId={
               membershipBuilderState.getNextNativeContentId
             }

--- a/src/domains/app/features/product-form/membership-content/membership-content.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-content.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import { Button, Radio, RadioGroup } from '@shared/ui';
+import { ProductMinimised } from 'core/api/models';
 import MembershipIncludedProducts from './membership-included-products.component';
 import MembershipContentTypeChooser from './membership-content-type-chooser.component';
 import MembershipPostEditor from './membership-post-editor.component';
@@ -36,6 +37,10 @@ interface MembershipContentSectionProps {
   feedEntries: MembershipFeedEntry[];
   orderingMode: MembershipOrderingMode;
   includedProductEntries: MembershipProductFeedEntry[];
+  productSummaries: ProductMinimised[] | null;
+  includedProducts: ProductMinimised[];
+  isLoadingProducts: boolean;
+  productsError: string | null;
   // eslint-disable-next-line no-unused-vars
   getNextNativeContentId: (type: MembershipContentItem['type']) => string;
   // eslint-disable-next-line no-unused-vars
@@ -71,6 +76,10 @@ const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
   feedEntries,
   orderingMode,
   includedProductEntries,
+  productSummaries,
+  includedProducts,
+  isLoadingProducts,
+  productsError,
   getNextNativeContentId,
   onAddNativeContentItem,
   onUpdateNativeContentItem,
@@ -355,6 +364,10 @@ const MembershipContentSection: React.FC<MembershipContentSectionProps> = ({
         feedEntries={feedEntries}
         orderingMode={orderingMode}
         includedProductEntries={includedProductEntries}
+        productSummaries={productSummaries}
+        includedProducts={includedProducts}
+        isLoadingProducts={isLoadingProducts}
+        productsError={productsError}
         productPickerRequest={productPickerRequest}
         isContentListHidden={Boolean(creationMode)}
         onAddProducts={onAddIncludedProducts}

--- a/src/domains/app/features/product-form/membership-content/membership-included-products.component.test.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-included-products.component.test.tsx
@@ -21,6 +21,7 @@ import { ProductMinimised } from 'core/api/models';
 import { getProductSummariesByOwner } from 'core/store/product-store';
 import MembershipIncludedProducts from './membership-included-products.component';
 import { useMembershipBuilderState } from './use-membership-builder-state.hook';
+import { resolveMembershipIncludedProducts } from './utils/membership-readiness.utils';
 
 const productSummaries: ProductMinimised[] = [
   {
@@ -101,6 +102,13 @@ const renderIncludedProducts = ({
         feedEntries={membershipBuilderState.feedEntries}
         orderingMode={membershipBuilderState.orderingMode}
         includedProductEntries={membershipBuilderState.includedProductEntries}
+        productSummaries={products}
+        includedProducts={resolveMembershipIncludedProducts(
+          membershipBuilderState.includedProductEntries,
+          products,
+        )}
+        isLoadingProducts={loading}
+        productsError={error}
         productPickerRequest={request}
         onAddProducts={membershipBuilderState.addIncludedProducts}
         onRemoveProduct={membershipBuilderState.removeIncludedProduct}

--- a/src/domains/app/features/product-form/membership-content/membership-included-products.component.tsx
+++ b/src/domains/app/features/product-form/membership-content/membership-included-products.component.tsx
@@ -1,12 +1,9 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { AppDispatch, ProductMinimised, ProductType } from 'core/api/models';
 import {
   getProductSummariesByOwner,
-  selectProductSummaries,
-  selectProductsError,
-  selectProductsLoading,
 } from 'core/store/product-store';
 import { ProductPicker } from '../product-picker';
 import MembershipContentList from './membership-content-list.component';
@@ -26,6 +23,10 @@ interface MembershipIncludedProductsProps {
   feedEntries: MembershipFeedEntry[];
   orderingMode: MembershipOrderingMode;
   includedProductEntries: MembershipProductFeedEntry[];
+  productSummaries: ProductMinimised[] | null;
+  includedProducts: ProductMinimised[];
+  isLoadingProducts: boolean;
+  productsError: string | null;
   productPickerRequest?: number;
   isContentListHidden?: boolean;
   // eslint-disable-next-line no-unused-vars
@@ -47,6 +48,10 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   feedEntries,
   orderingMode,
   includedProductEntries,
+  productSummaries,
+  includedProducts,
+  isLoadingProducts,
+  productsError,
   productPickerRequest = 0,
   isContentListHidden = false,
   onAddProducts,
@@ -56,9 +61,6 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   onDeleteContent,
 }) => {
   const dispatch = useDispatch<AppDispatch>();
-  const products = useSelector(selectProductSummaries);
-  const loading = useSelector(selectProductsLoading);
-  const error = useSelector(selectProductsError);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const previousProductPickerRequest = useRef(0);
   const includedProductIds = includedProductEntries.map(
@@ -66,12 +68,12 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
   );
 
   useEffect(() => {
-    if (!ownerId || products || loading) {
+    if (!ownerId || productSummaries || isLoadingProducts) {
       return;
     }
 
     dispatch(getProductSummariesByOwner(ownerId));
-  }, [dispatch, loading, ownerId, products]);
+  }, [dispatch, isLoadingProducts, ownerId, productSummaries]);
 
   useEffect(() => {
     if (productPickerRequest === previousProductPickerRequest.current) {
@@ -85,23 +87,7 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
     }
   }, [productPickerRequest]);
 
-  const productById = useMemo(() => {
-    const productMap = new Map<string, ProductMinimised>();
-
-    (products ?? []).forEach((product) => {
-      if (product.id) {
-        productMap.set(product.id, product);
-      }
-    });
-
-    return productMap;
-  }, [products]);
-
-  const includedProducts = includedProductIds
-    .map((id) => productById.get(id))
-    .filter((product): product is ProductMinimised => Boolean(product));
-
-  const eligibleProductCount = (products ?? []).filter(
+  const eligibleProductCount = (productSummaries ?? []).filter(
     (product) =>
       product.id &&
       product.type &&
@@ -122,10 +108,12 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
         </p>
       )}
 
-      {ownerId && loading && <p>Loading products...</p>}
-      {ownerId && error && <p className="error-message">Error: {error}</p>}
+      {ownerId && isLoadingProducts && <p>Loading products...</p>}
+      {ownerId && productsError && (
+        <p className="error-message">Error: {productsError}</p>
+      )}
 
-      {ownerId && !loading && !error && !isContentListHidden && (
+      {ownerId && !isLoadingProducts && !productsError && !isContentListHidden && (
         <MembershipContentList
           nativeContentItems={nativeContentItems}
           feedEntries={feedEntries}
@@ -138,7 +126,7 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
         />
       )}
 
-      {ownerId && !loading && !error && eligibleProductCount === 0 && (
+      {ownerId && !isLoadingProducts && !productsError && eligibleProductCount === 0 && (
         <p className="membership-included-products__empty">
           You do not have any eligible products to include yet.
         </p>
@@ -146,7 +134,7 @@ const MembershipIncludedProducts: React.FC<MembershipIncludedProductsProps> = ({
 
       {isPickerOpen && (
         <ProductPicker
-          products={products ?? []}
+          products={productSummaries ?? []}
           selectedIds={[]}
           allowedTypes={ALLOWED_INCLUDED_PRODUCT_TYPES}
           excludedIds={[...includedProductIds, currentProductId].filter(

--- a/src/domains/app/features/product-form/membership-content/utils/membership-readiness.utils.test.ts
+++ b/src/domains/app/features/product-form/membership-content/utils/membership-readiness.utils.test.ts
@@ -1,0 +1,240 @@
+import { ProductMinimised } from 'core/api/models';
+import { RecurringPricing } from '../../models';
+import {
+  MembershipContentItem,
+  MembershipProductFeedEntry,
+} from '../models';
+import {
+  evaluateMembershipReadiness,
+  resolveMembershipIncludedProducts,
+} from './membership-readiness.utils';
+
+const validPricing: RecurringPricing = {
+  amount: 12,
+  currency: 'EUR',
+  interval: 'MONTH',
+};
+
+const makePost = (
+  status: MembershipContentItem['status'] = 'PUBLISHED',
+): MembershipContentItem => ({
+  id: `post-${status}`,
+  type: 'POST',
+  title: 'Member update',
+  body: 'Hello members',
+  status,
+  createdAt: '2026-08-10T10:00:00.000Z',
+  updatedAt: '2026-08-10T10:00:00.000Z',
+});
+
+const makeVideo = (
+  status: MembershipContentItem['status'] = 'PUBLISHED',
+): MembershipContentItem => ({
+  id: `video-${status}`,
+  type: 'VIDEO',
+  title: 'Member video',
+  status,
+  video: {
+    fileName: 'video.mp4',
+    fileType: 'video/mp4',
+    size: 1024,
+  },
+  createdAt: '2026-08-10T10:00:00.000Z',
+  updatedAt: '2026-08-10T10:00:00.000Z',
+});
+
+const makeResource = (
+  status: MembershipContentItem['status'] = 'PUBLISHED',
+): MembershipContentItem => ({
+  id: `resource-${status}`,
+  type: 'RESOURCE',
+  title: 'Member resource',
+  status,
+  file: {
+    fileName: 'guide.pdf',
+    fileType: 'application/pdf',
+    size: 1024,
+  },
+  createdAt: '2026-08-10T10:00:00.000Z',
+  updatedAt: '2026-08-10T10:00:00.000Z',
+});
+
+const makeIncludedProduct = (
+  type: ProductMinimised['type'],
+  status: ProductMinimised['status'] = 'PUBLISHED',
+): ProductMinimised => ({
+  id: `${type?.toLowerCase()}-${status}`,
+  title: `${type} product`,
+  type,
+  status,
+});
+
+const evaluate = (
+  overrides: Partial<Parameters<typeof evaluateMembershipReadiness>[0]> = {},
+) =>
+  evaluateMembershipReadiness({
+    formData: { name: 'Founders Club', imageUrl: 'https://example.com/image.jpg' },
+    recurringPricing: validPricing,
+    nativeContentItems: [makePost()],
+    includedProducts: [],
+    ...overrides,
+  });
+
+describe('evaluateMembershipReadiness', () => {
+  it('marks an empty Membership as not publishable', () => {
+    const result = evaluate({
+      formData: { name: '', imageUrl: undefined },
+      recurringPricing: { ...validPricing, amount: 0 },
+      nativeContentItems: [],
+      includedProducts: [],
+    });
+
+    expect(result.canPublish).toBe(false);
+    expect(result.errors.map((error) => error.code)).toEqual([
+      'MISSING_NAME',
+      'INVALID_RECURRING_PRICE',
+      'NO_PUBLISHED_ENTRY',
+    ]);
+  });
+
+  it('blocks when the Membership name is missing', () => {
+    const result = evaluate({ formData: { name: '   ', imageUrl: 'thumb.jpg' } });
+
+    expect(result.canPublish).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ message: 'Add a Membership name.' }),
+    );
+  });
+
+  it('blocks when recurring price is invalid', () => {
+    const result = evaluate({
+      recurringPricing: { amount: 0, currency: 'EUR', interval: 'MONTH' },
+    });
+
+    expect(result.canPublish).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ message: 'Set a valid recurring price.' }),
+    );
+  });
+
+  it('blocks when there is no published access-ready entry', () => {
+    const result = evaluate({
+      nativeContentItems: [makePost('DRAFT')],
+      includedProducts: [makeIncludedProduct('COURSE', 'HIDDEN')],
+    });
+
+    expect(result.canPublish).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        message: 'Add at least one published content item or included Product.',
+      }),
+    );
+  });
+
+  it.each([
+    ['published Post', makePost()],
+    ['published Video', makeVideo()],
+    ['published Resource', makeResource()],
+  ])('%s satisfies the content requirement', (_label, item) => {
+    const result = evaluate({
+      nativeContentItems: [item],
+      includedProducts: [],
+    });
+
+    expect(result.canPublish).toBe(true);
+  });
+
+  it.each([
+    ['published included Course', makeIncludedProduct('COURSE')],
+    ['published included Download', makeIncludedProduct('DOWNLOAD')],
+  ])('%s satisfies the content requirement', (_label, product) => {
+    const result = evaluate({
+      nativeContentItems: [],
+      includedProducts: [product],
+    });
+
+    expect(result.canPublish).toBe(true);
+  });
+
+  it('does not count Draft or Hidden content toward the content requirement', () => {
+    const result = evaluate({
+      nativeContentItems: [makePost('DRAFT'), makeVideo('HIDDEN')],
+      includedProducts: [
+        makeIncludedProduct('COURSE', 'DRAFT'),
+        makeIncludedProduct('DOWNLOAD', 'HIDDEN'),
+      ],
+    });
+
+    expect(result.canPublish).toBe(false);
+    expect(result.errors.map((error) => error.code)).toContain(
+      'NO_PUBLISHED_ENTRY',
+    );
+  });
+
+  it('keeps warnings non-blocking', () => {
+    const result = evaluate({
+      formData: { name: 'Founders Club', imageUrl: undefined },
+      hasThumbnail: false,
+      nativeContentItems: [makePost()],
+      includedProducts: [],
+    });
+
+    expect(result.canPublish).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['NO_THUMBNAIL', { formData: { name: 'Founders Club', imageUrl: undefined } }],
+    ['HAS_DRAFT_CONTENT', { nativeContentItems: [makePost(), makeVideo('DRAFT')] }],
+    ['HAS_HIDDEN_CONTENT', { nativeContentItems: [makePost(), makeResource('HIDDEN')] }],
+    ['NO_NATIVE_CONTENT', { nativeContentItems: [], includedProducts: [makeIncludedProduct('COURSE')] }],
+    ['NO_INCLUDED_PRODUCTS', { includedProducts: [] }],
+  ])('adds the %s warning', (code, overrides) => {
+    const result = evaluate(overrides);
+
+    expect(result.warnings.map((warning) => warning.code)).toContain(code);
+  });
+
+  it('does not mutate inputs', () => {
+    const nativeContentItems = [makePost('DRAFT')];
+    const includedProducts = [makeIncludedProduct('COURSE', 'PUBLISHED')];
+    const input = {
+      formData: { name: 'Founders Club', imageUrl: undefined },
+      recurringPricing: validPricing,
+      nativeContentItems,
+      includedProducts,
+    };
+    const before = JSON.stringify(input);
+
+    evaluateMembershipReadiness(input);
+
+    expect(JSON.stringify(input)).toBe(before);
+  });
+});
+
+describe('resolveMembershipIncludedProducts', () => {
+  it('returns summaries in Membership entry order', () => {
+    const entries: MembershipProductFeedEntry[] = [
+      {
+        entryId: 'product:download-1',
+        kind: 'PRODUCT',
+        productId: 'download-1',
+        addedAt: '2026-08-10T10:00:00.000Z',
+      },
+      {
+        entryId: 'product:course-1',
+        kind: 'PRODUCT',
+        productId: 'course-1',
+        addedAt: '2026-08-10T10:01:00.000Z',
+      },
+    ];
+
+    expect(
+      resolveMembershipIncludedProducts(entries, [
+        { id: 'course-1', title: 'Course One' },
+        { id: 'download-1', title: 'Download One' },
+      ]).map((product) => product.id),
+    ).toEqual(['download-1', 'course-1']);
+  });
+});

--- a/src/domains/app/features/product-form/membership-content/utils/membership-readiness.utils.ts
+++ b/src/domains/app/features/product-form/membership-content/utils/membership-readiness.utils.ts
@@ -1,0 +1,157 @@
+import { ProductMinimised } from 'core/api/models';
+import { ProductDraft, RecurringPricing } from '../../models';
+import {
+  MembershipContentItem,
+  MembershipProductFeedEntry,
+} from '../models';
+
+export type MembershipReadinessSeverity = 'ERROR' | 'WARNING';
+
+export interface MembershipReadinessIssue {
+  code: string;
+  severity: MembershipReadinessSeverity;
+  message: string;
+}
+
+export interface MembershipReadinessResult {
+  canPublish: boolean;
+  errors: MembershipReadinessIssue[];
+  warnings: MembershipReadinessIssue[];
+}
+
+export interface MembershipReadinessInput {
+  formData: Pick<ProductDraft, 'name' | 'imageUrl'>;
+  recurringPricing: RecurringPricing;
+  nativeContentItems: readonly MembershipContentItem[];
+  includedProducts: readonly ProductMinimised[];
+  hasThumbnail?: boolean;
+}
+
+const VALID_BILLING_INTERVALS: RecurringPricing['interval'][] = [
+  'MONTH',
+  'YEAR',
+];
+
+const createIssue = (
+  code: string,
+  severity: MembershipReadinessSeverity,
+  message: string,
+): MembershipReadinessIssue => ({
+  code,
+  severity,
+  message,
+});
+
+export const resolveMembershipIncludedProducts = (
+  includedProductEntries: readonly MembershipProductFeedEntry[],
+  productSummaries: readonly ProductMinimised[] | null | undefined,
+): ProductMinimised[] => {
+  const productById = new Map<string, ProductMinimised>();
+
+  (productSummaries ?? []).forEach((product) => {
+    if (product.id) {
+      productById.set(product.id, product);
+    }
+  });
+
+  return includedProductEntries
+    .map((entry) => productById.get(entry.productId))
+    .filter((product): product is ProductMinimised => Boolean(product));
+};
+
+export const evaluateMembershipReadiness = ({
+  formData,
+  recurringPricing,
+  nativeContentItems,
+  includedProducts,
+  hasThumbnail,
+}: MembershipReadinessInput): MembershipReadinessResult => {
+  const errors: MembershipReadinessIssue[] = [];
+  const warnings: MembershipReadinessIssue[] = [];
+  const hasPublishedNativeContent = nativeContentItems.some(
+    (item) => item.status === 'PUBLISHED',
+  );
+  const hasPublishedIncludedProduct = includedProducts.some(
+    (product) => product.status === 'PUBLISHED',
+  );
+  const hasValidBillingInterval = VALID_BILLING_INTERVALS.includes(
+    recurringPricing.interval,
+  );
+  const hasResolvedThumbnail = hasThumbnail ?? Boolean(formData.imageUrl);
+
+  if (!formData.name?.trim()) {
+    errors.push(createIssue('MISSING_NAME', 'ERROR', 'Add a Membership name.'));
+  }
+
+  if (recurringPricing.amount <= 0 || !hasValidBillingInterval) {
+    errors.push(
+      createIssue('INVALID_RECURRING_PRICE', 'ERROR', 'Set a valid recurring price.'),
+    );
+  }
+
+  if (!hasPublishedNativeContent && !hasPublishedIncludedProduct) {
+    errors.push(
+      createIssue(
+        'NO_PUBLISHED_ENTRY',
+        'ERROR',
+        'Add at least one published content item or included Product.',
+      ),
+    );
+  }
+
+  if (!hasResolvedThumbnail) {
+    warnings.push(
+      createIssue(
+        'NO_THUMBNAIL',
+        'WARNING',
+        'Add a thumbnail to make the Membership easier to identify.',
+      ),
+    );
+  }
+
+  if (nativeContentItems.some((item) => item.status === 'DRAFT')) {
+    warnings.push(
+      createIssue(
+        'HAS_DRAFT_CONTENT',
+        'WARNING',
+        'Some Membership content is still in Draft.',
+      ),
+    );
+  }
+
+  if (nativeContentItems.some((item) => item.status === 'HIDDEN')) {
+    warnings.push(
+      createIssue(
+        'HAS_HIDDEN_CONTENT',
+        'WARNING',
+        'Some Membership content is Hidden.',
+      ),
+    );
+  }
+
+  if (nativeContentItems.length === 0) {
+    warnings.push(
+      createIssue(
+        'NO_NATIVE_CONTENT',
+        'WARNING',
+        'This Membership has no native content yet.',
+      ),
+    );
+  }
+
+  if (includedProducts.length === 0) {
+    warnings.push(
+      createIssue(
+        'NO_INCLUDED_PRODUCTS',
+        'WARNING',
+        'This Membership has no included Products.',
+      ),
+    );
+  }
+
+  return {
+    canPublish: errors.length === 0,
+    errors,
+    warnings,
+  };
+};

--- a/src/domains/app/features/product-form/product-header/product-header.component.test.tsx
+++ b/src/domains/app/features/product-form/product-header/product-header.component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useSelector } from 'react-redux';
 
@@ -52,5 +52,90 @@ describe('<ProductHeader />', () => {
     expect(
       screen.getByRole('heading', { name: 'EDIT PRODUCT' }),
     ).toBeInTheDocument();
+  });
+
+  it('disables Membership Publish and shows blockers when readiness fails', () => {
+    render(
+      <ProductHeader
+        formData={{ type: 'MEMBERSHIP', name: 'Founders Club' } as any}
+        isEditMode={true}
+        showRestOfForm={true}
+        hasHeroCollapsed={true}
+        headerRef={undefined}
+        membershipReadiness={{
+          canPublish: false,
+          errors: [
+            {
+              code: 'INVALID_RECURRING_PRICE',
+              severity: 'ERROR',
+              message: 'Set a valid recurring price.',
+            },
+            {
+              code: 'NO_PUBLISHED_ENTRY',
+              severity: 'ERROR',
+              message:
+                'Add at least one published content item or included Product.',
+            },
+          ],
+          warnings: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Not ready to publish')).toBeInTheDocument();
+    expect(screen.getByText('Set a valid recurring price.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Publish' }),
+    ).toBeDisabled();
+  });
+
+  it('keeps ready Membership Publish non-persistent and informational', () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation();
+
+    render(
+      <ProductHeader
+        formData={{ type: 'MEMBERSHIP', name: 'Founders Club' } as any}
+        isEditMode={true}
+        showRestOfForm={true}
+        hasHeroCollapsed={true}
+        headerRef={undefined}
+        membershipReadiness={{
+          canPublish: true,
+          errors: [],
+          warnings: [
+            {
+              code: 'NO_INCLUDED_PRODUCTS',
+              severity: 'WARNING',
+              message: 'This Membership has no included Products.',
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Membership publishing will be enabled once Membership persistence is available.',
+    );
+
+    alertSpy.mockRestore();
+  });
+
+  it('leaves non-Membership Publish rendering on the existing path', () => {
+    render(
+      <ProductHeader
+        formData={{ type: 'COURSE', name: 'Course' } as any}
+        isEditMode={true}
+        showRestOfForm={true}
+        hasHeroCollapsed={true}
+        headerRef={undefined}
+      />,
+    );
+
+    expect(screen.queryByText('Ready to publish')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Publish' }),
+    ).not.toBeDisabled();
   });
 });

--- a/src/domains/app/features/product-form/product-header/product-header.component.tsx
+++ b/src/domains/app/features/product-form/product-header/product-header.component.tsx
@@ -10,8 +10,9 @@ import {
   selectProductsLoading,
 } from 'core/store/product-store';
 import { PRODUCT_TYPE_REGISTRY } from 'core/constants';
-import { Button } from '@shared/ui';
+import { Button, InfoPopover } from '@shared/ui';
 import { SavingIndicator } from 'domains/app/components';
+import { MembershipReadinessResult } from '../membership-content';
 
 import './product-header.styles.scss';
 
@@ -21,6 +22,7 @@ interface ProductHeaderProps extends React.BaseHTMLAttributes<HTMLDivElement> {
   showRestOfForm: boolean;
   hasHeroCollapsed: boolean;
   headerRef: React.Ref<HTMLDivElement> | undefined;
+  membershipReadiness?: MembershipReadinessResult;
 }
 
 const ProductHeader: React.FC<ProductHeaderProps> = ({
@@ -29,6 +31,7 @@ const ProductHeader: React.FC<ProductHeaderProps> = ({
   showRestOfForm,
   hasHeroCollapsed,
   headerRef,
+  membershipReadiness,
 }) => {
   const loading = useSelector(selectProductsLoading);
   const error = useSelector(selectProductsError);
@@ -63,6 +66,80 @@ const ProductHeader: React.FC<ProductHeaderProps> = ({
     minSavingMs: 200,
     savedVisibleMs: 2000,
   });
+  const isMembership = formData.type === 'MEMBERSHIP';
+  const membershipPublishMessage =
+    'Membership publishing will be enabled once Membership persistence is available.';
+  const handleMembershipPublishClick = () => {
+    window.alert(membershipPublishMessage);
+  };
+
+  const renderMembershipReadiness = () => {
+    if (!membershipReadiness) {
+      return null;
+    }
+
+    const requirementText = membershipReadiness.canPublish
+      ? 'Ready to publish'
+      : 'Not ready to publish';
+    const blockingIssues = membershipReadiness.errors.slice(0, 2);
+    const remainingBlockers =
+      membershipReadiness.errors.length - blockingIssues.length;
+
+    return (
+      <div
+        className={clsx('membership-readiness-summary', {
+          'membership-readiness-summary__ready': membershipReadiness.canPublish,
+        })}
+      >
+        <div>
+          <span className="membership-readiness-summary__status">
+            {requirementText}
+          </span>
+          <span className="membership-readiness-summary__meta">
+            {membershipReadiness.canPublish
+              ? `${membershipReadiness.warnings.length} warnings`
+              : `${membershipReadiness.errors.length} blockers`}
+          </span>
+        </div>
+        {!membershipReadiness.canPublish && (
+          <ul className="membership-readiness-summary__inline-list">
+            {blockingIssues.map((issue) => (
+              <li key={issue.code}>{issue.message}</li>
+            ))}
+            {remainingBlockers > 0 && <li>{remainingBlockers} more blockers</li>}
+          </ul>
+        )}
+        <InfoPopover className="membership-readiness-summary__popover">
+          <div className="membership-readiness-summary__popover-content">
+            {membershipReadiness.errors.length > 0 && (
+              <>
+                <strong>Blockers</strong>
+                <ul>
+                  {membershipReadiness.errors.map((issue) => (
+                    <li key={issue.code}>{issue.message}</li>
+                  ))}
+                </ul>
+              </>
+            )}
+            {membershipReadiness.warnings.length > 0 && (
+              <>
+                <strong>Warnings</strong>
+                <ul>
+                  {membershipReadiness.warnings.map((issue) => (
+                    <li key={issue.code}>{issue.message}</li>
+                  ))}
+                </ul>
+              </>
+            )}
+            {membershipReadiness.canPublish && (
+              <p>{membershipPublishMessage}</p>
+            )}
+          </div>
+        </InfoPopover>
+      </div>
+    );
+  };
+
   return (
     <div className="product-header" ref={headerRef}>
       <h1>{isEditMode ? 'EDIT PRODUCT' : 'CREATE NEW PRODUCT'}</h1>
@@ -85,8 +162,20 @@ const ProductHeader: React.FC<ProductHeaderProps> = ({
 
           <div className="product-main-actions">
             <SavingIndicator status={saveStatus} size="sm" />
+            {isMembership && renderMembershipReadiness()}
             <Button variant="secondary">Save</Button>
-            <Button variant="primary">Publish</Button>
+            {isMembership ? (
+              <Button
+                type="button"
+                variant="primary"
+                disabled={!membershipReadiness?.canPublish}
+                onClick={handleMembershipPublishClick}
+              >
+                Publish
+              </Button>
+            ) : (
+              <Button variant="primary">Publish</Button>
+            )}
           </div>
         </>
       )}

--- a/src/domains/app/features/product-form/product-header/product-header.styles.scss
+++ b/src/domains/app/features/product-form/product-header/product-header.styles.scss
@@ -38,6 +38,7 @@
   .product-main-actions {
     margin-left: auto;
     display: flex;
+    align-items: center;
     gap: $spacing-4;
 
     .saving-spinner {
@@ -47,6 +48,50 @@
       width: 30px;
       height: 30px;
       animation: spin 0.5s linear infinite;
+    }
+  }
+
+  .membership-readiness-summary {
+    display: flex;
+    align-items: center;
+    gap: $spacing-2;
+    max-width: 360px;
+    padding: $spacing-2 $spacing-3;
+    border: 1px solid var(--border-color);
+    border-radius: $radius-sm;
+    background: var(--surface-1);
+    font-size: 12px;
+
+    &__ready {
+      border-color: var(--success);
+    }
+
+    &__status {
+      display: block;
+      font-weight: 700;
+    }
+
+    &__meta {
+      color: var(--text-secondary);
+    }
+
+    &__inline-list,
+    &__popover-content ul {
+      margin: $spacing-1 0 0;
+      padding-left: $spacing-4;
+    }
+
+    &__inline-list {
+      max-width: 210px;
+    }
+
+    &__popover-content {
+      display: grid;
+      gap: $spacing-2;
+    }
+
+    &__popover-content p {
+      margin: 0;
     }
   }
 }

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.component.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable indent */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import clsx from 'clsx';
 
 import { GalPriceSelector } from 'domains/app/components';
@@ -20,8 +21,16 @@ import {
   RecurringPriceSelector,
   RecurringPricing,
   useMembershipBuilderState,
+  evaluateMembershipReadiness,
+  resolveMembershipIncludedProducts,
 } from 'domains/app/features/product-form';
-import { ProductType, ProductWithSections } from 'core/api/models';
+import { AppDispatch, ProductType, ProductWithSections } from 'core/api/models';
+import {
+  getProductSummariesByOwner,
+  selectProductSummaries,
+  selectProductsError,
+  selectProductsLoading,
+} from 'core/store/product-store';
 
 import './product-form.styles.scss';
 
@@ -46,6 +55,10 @@ const getInitialBuilderTab = (productType: ProductType): BuilderTab => {
 };
 
 const ProductForm: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const productSummaries = useSelector(selectProductSummaries);
+  const productsLoading = useSelector(selectProductsLoading);
+  const productsError = useSelector(selectProductsError);
   const {
     user,
     isEditMode,
@@ -53,6 +66,7 @@ const ProductForm: React.FC = () => {
     formData,
     setFormData,
     setField,
+    productImage,
     handleSetPrice,
     handleImageChange,
     showRestOfForm,
@@ -70,6 +84,33 @@ const ProductForm: React.FC = () => {
   const [membershipRecurringPricing, setMembershipRecurringPricing] =
     useState<RecurringPricing>(DEFAULT_RECURRING_PRICING);
   const membershipBuilderState = useMembershipBuilderState();
+  const includedProducts = useMemo(
+    () =>
+      resolveMembershipIncludedProducts(
+        membershipBuilderState.includedProductEntries,
+        productSummaries,
+      ),
+    [membershipBuilderState.includedProductEntries, productSummaries],
+  );
+  const membershipReadiness = useMemo(() => {
+    if (formData.type !== 'MEMBERSHIP') {
+      return undefined;
+    }
+
+    return evaluateMembershipReadiness({
+      formData,
+      recurringPricing: membershipRecurringPricing,
+      nativeContentItems: membershipBuilderState.nativeContentItems,
+      includedProducts,
+      hasThumbnail: Boolean(formData.imageUrl || productImage),
+    });
+  }, [
+    formData,
+    includedProducts,
+    membershipBuilderState.nativeContentItems,
+    membershipRecurringPricing,
+    productImage,
+  ]);
   const [hasHeroCollapsed, setHasHeroCollapsed] = useState(false);
   const [pendingSidebarScrollTarget, setPendingSidebarScrollTarget] = useState<{
     id: string;
@@ -87,6 +128,27 @@ const ProductForm: React.FC = () => {
       setActiveTab(getInitialBuilderTab(formData.type));
     }
   }, [formData.type, showRestOfForm]);
+
+  useEffect(() => {
+    if (
+      formData.type !== 'MEMBERSHIP' ||
+      !showRestOfForm ||
+      !productOwnerId ||
+      productSummaries ||
+      productsLoading
+    ) {
+      return;
+    }
+
+    dispatch(getProductSummariesByOwner(productOwnerId));
+  }, [
+    dispatch,
+    formData.type,
+    productOwnerId,
+    productSummaries,
+    productsLoading,
+    showRestOfForm,
+  ]);
 
   useEffect(() => {
     if (activeTab !== 'sections' || !pendingSidebarScrollTarget) {
@@ -151,6 +213,7 @@ const ProductForm: React.FC = () => {
         hasHeroCollapsed={hasHeroCollapsed}
         showRestOfForm={showRestOfForm}
         headerRef={undefined}
+        membershipReadiness={membershipReadiness}
       />
 
       <form onSubmit={handleSubmit}>
@@ -252,6 +315,10 @@ const ProductForm: React.FC = () => {
                   includedProductEntries={
                     membershipBuilderState.includedProductEntries
                   }
+                  productSummaries={productSummaries}
+                  includedProducts={includedProducts}
+                  isLoadingProducts={productsLoading}
+                  productsError={productsError}
                   getNextNativeContentId={
                     membershipBuilderState.getNextNativeContentId
                   }

--- a/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-form/product-form.test.tsx
@@ -13,6 +13,14 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+const mockProductStoreState = {
+  products: {
+    productSummaries: null as any[] | null,
+    loading: false,
+    error: null as string | null,
+  },
+};
+
 // ── 1) Mock @shared/ui (UppyFileUploader) ────────────────────────────
 jest.mock('@shared/ui', () => ({
   __esModule: true,
@@ -40,11 +48,52 @@ jest.mock('@shared/ui', () => ({
   ),
 }));
 
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  useDispatch: jest.fn(() => jest.fn()),
+  useSelector: jest.fn((selector) => selector(mockProductStoreState)),
+}));
+
 // ── 2) Mock app features barrel used by ProductForm ──────────────────────
 const mockUseProductFormFacade = jest.fn();
 const mockUseProductFormAnimation = jest.fn();
 const mockProductHeader = jest.fn();
 const mockUseMembershipBuilderState = jest.fn();
+const mockEvaluateMembershipReadiness = jest.fn(
+  ({
+    formData,
+    recurringPricing,
+    nativeContentItems,
+    includedProducts,
+  }: any) => ({
+    canPublish:
+      Boolean(formData.name?.trim()) &&
+      recurringPricing.amount > 0 &&
+      (nativeContentItems.some((item: any) => item.status === 'PUBLISHED') ||
+        includedProducts.some((product: any) => product.status === 'PUBLISHED')),
+    errors:
+      recurringPricing.amount > 0
+        ? []
+        : [
+          {
+            code: 'INVALID_RECURRING_PRICE',
+            severity: 'ERROR',
+            message: 'Set a valid recurring price.',
+          },
+        ],
+    warnings: [],
+  }),
+);
+const mockResolveMembershipIncludedProducts = jest.fn(
+  (includedProductEntries: any[], productSummaries: any[] | null) =>
+    includedProductEntries
+      .map((entry) =>
+        (productSummaries ?? []).find(
+          (product) => product.id === entry.productId,
+        ),
+      )
+      .filter(Boolean),
+);
 
 jest.mock('domains/app/features/product-form', () => ({
   __esModule: true,
@@ -54,6 +103,16 @@ jest.mock('domains/app/features/product-form', () => ({
     mockUseProductFormAnimation(...args),
   useMembershipBuilderState: (...args: any[]) =>
     mockUseMembershipBuilderState(...args),
+  evaluateMembershipReadiness: (input: any) =>
+    mockEvaluateMembershipReadiness(input),
+  resolveMembershipIncludedProducts: (
+    includedProductEntries: any[],
+    productSummaries: any[] | null,
+  ) =>
+    mockResolveMembershipIncludedProducts(
+      includedProductEntries,
+      productSummaries,
+    ),
 
   // step one: just a button that can toggle showRestOfForm
   CreateProductStepOne: ({
@@ -161,12 +220,22 @@ jest.mock('domains/app/features/product-form', () => ({
   },
   RecurringPriceSelector: ({
     value,
+    onChange,
   }: {
     value: { amount: number; currency: string; interval: string };
+    onChange: (value: { amount: number; currency: string; interval: string }) => void;
   }) => (
-    <div data-testid="recurring-price-selector">
-      RecurringPriceSelector ({value.amount} {value.currency} {value.interval})
-    </div>
+    <>
+      <div data-testid="recurring-price-selector">
+        RecurringPriceSelector ({value.amount} {value.currency} {value.interval})
+      </div>
+      <button
+        data-testid="set-valid-membership-price"
+        onClick={() => onChange({ amount: 25, currency: 'EUR', interval: 'MONTH' })}
+      >
+        Set valid price
+      </button>
+    </>
   ),
   PriceSelector: ({ price }: { price: number }) => (
     <div data-testid="price-selector">
@@ -195,6 +264,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  mockProductStoreState.products.productSummaries = null;
+  mockProductStoreState.products.loading = false;
+  mockProductStoreState.products.error = null;
   mockUseMembershipBuilderState.mockReturnValue({
     nativeContentItems: [],
     feedEntries: [],
@@ -226,6 +298,7 @@ const makeFacadeState = (overrides: Partial<any> = {}) => ({
   setFormData: jest.fn(),
   setField: jest.fn(),
   handleSetPrice: jest.fn(),
+  productImage: null,
   handleImageChange: jest.fn(),
   showRestOfForm: true,
   setShowRestOfForm: jest.fn(),
@@ -407,6 +480,254 @@ describe('<ProductForm />', () => {
       '0 EUR MONTH',
     );
     expect(screen.queryByTestId('price-selector')).not.toBeInTheDocument();
+  });
+
+  it('passes derived Membership readiness to ProductHeader', async () => {
+    mockUseMembershipBuilderState.mockReturnValue({
+      nativeContentItems: [
+        {
+          id: 'post-1',
+          type: 'POST',
+          title: 'Published update',
+          body: 'Hello',
+          status: 'PUBLISHED',
+          createdAt: '2026-08-10T10:00:00.000Z',
+          updatedAt: '2026-08-10T10:00:00.000Z',
+        },
+      ],
+      feedEntries: [],
+      orderingMode: 'NEWEST_FIRST',
+      includedProductEntries: [],
+      getNextNativeContentId: jest.fn(),
+      setOrderingMode: jest.fn(),
+      addNativeContentItem: jest.fn(),
+      updateNativeContentItem: jest.fn(),
+      deleteNativeContentItem: jest.fn(),
+      addIncludedProducts: jest.fn(),
+      removeIncludedProduct: jest.fn(),
+      moveFeedEntry: jest.fn(),
+    });
+    const state = makeFacadeState({
+      formData: {
+        id: 'membership-1',
+        name: 'Founders Club',
+        description: '',
+        type: 'MEMBERSHIP',
+        price: 25,
+      },
+    });
+
+    mockUseProductFormFacade.mockReturnValue(state);
+
+    render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(mockEvaluateMembershipReadiness).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formData: state.formData,
+          nativeContentItems: expect.arrayContaining([
+            expect.objectContaining({ status: 'PUBLISHED' }),
+          ]),
+        }),
+      );
+    });
+
+    expect(mockProductHeader).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        membershipReadiness: expect.objectContaining({
+          canPublish: false,
+        }),
+      }),
+    );
+  });
+
+  it('updates Membership readiness when recurring pricing becomes valid', async () => {
+    const state = makeFacadeState({
+      formData: {
+        id: 'membership-1',
+        name: 'Founders Club',
+        description: '',
+        type: 'MEMBERSHIP',
+        price: 25,
+      },
+    });
+
+    mockUseProductFormFacade.mockReturnValue(state);
+
+    render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('builder-sidebar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('tab-pricing'));
+    fireEvent.click(screen.getByTestId('set-valid-membership-price'));
+
+    await waitFor(() => {
+      expect(mockEvaluateMembershipReadiness).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          recurringPricing: expect.objectContaining({ amount: 25 }),
+        }),
+      );
+    });
+  });
+
+  it('updates Membership readiness when published native content is added', async () => {
+    const emptyBuilderState = {
+      nativeContentItems: [],
+      feedEntries: [],
+      orderingMode: 'NEWEST_FIRST',
+      includedProductEntries: [],
+      getNextNativeContentId: jest.fn(),
+      setOrderingMode: jest.fn(),
+      addNativeContentItem: jest.fn(),
+      updateNativeContentItem: jest.fn(),
+      deleteNativeContentItem: jest.fn(),
+      addIncludedProducts: jest.fn(),
+      removeIncludedProduct: jest.fn(),
+      moveFeedEntry: jest.fn(),
+    };
+    const publishedBuilderState = {
+      ...emptyBuilderState,
+      nativeContentItems: [
+        {
+          id: 'post-1',
+          type: 'POST',
+          title: 'Published update',
+          body: 'Hello',
+          status: 'PUBLISHED',
+          createdAt: '2026-08-10T10:00:00.000Z',
+          updatedAt: '2026-08-10T10:00:00.000Z',
+        },
+      ],
+    };
+    const state = makeFacadeState({
+      formData: {
+        id: 'membership-1',
+        name: 'Founders Club',
+        description: '',
+        type: 'MEMBERSHIP',
+        price: 25,
+      },
+    });
+
+    mockUseProductFormFacade.mockReturnValue(state);
+    mockUseMembershipBuilderState.mockReturnValue(emptyBuilderState);
+
+    const view = render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(mockEvaluateMembershipReadiness).toHaveBeenCalledWith(
+        expect.objectContaining({ nativeContentItems: [] }),
+      );
+    });
+
+    mockUseMembershipBuilderState.mockReturnValue(publishedBuilderState);
+    view.rerender(<ProductForm />);
+
+    await waitFor(() => {
+      expect(mockEvaluateMembershipReadiness).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          nativeContentItems: expect.arrayContaining([
+            expect.objectContaining({ status: 'PUBLISHED' }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  it('updates Membership readiness when a published included Product is added', async () => {
+    mockProductStoreState.products.productSummaries = [
+      {
+        id: 'download-1',
+        title: 'Download Kit',
+        type: 'DOWNLOAD',
+        status: 'PUBLISHED',
+      },
+    ];
+    mockUseMembershipBuilderState.mockReturnValue({
+      nativeContentItems: [],
+      feedEntries: [
+        {
+          entryId: 'product:download-1',
+          kind: 'PRODUCT',
+          productId: 'download-1',
+          addedAt: '2026-08-10T10:00:00.000Z',
+        },
+      ],
+      orderingMode: 'NEWEST_FIRST',
+      includedProductEntries: [
+        {
+          entryId: 'product:download-1',
+          kind: 'PRODUCT',
+          productId: 'download-1',
+          addedAt: '2026-08-10T10:00:00.000Z',
+        },
+      ],
+      getNextNativeContentId: jest.fn(),
+      setOrderingMode: jest.fn(),
+      addNativeContentItem: jest.fn(),
+      updateNativeContentItem: jest.fn(),
+      deleteNativeContentItem: jest.fn(),
+      addIncludedProducts: jest.fn(),
+      removeIncludedProduct: jest.fn(),
+      moveFeedEntry: jest.fn(),
+    });
+    const state = makeFacadeState({
+      formData: {
+        id: 'membership-1',
+        name: 'Founders Club',
+        description: '',
+        type: 'MEMBERSHIP',
+        price: 25,
+      },
+    });
+
+    mockUseProductFormFacade.mockReturnValue(state);
+
+    render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(mockEvaluateMembershipReadiness).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includedProducts: [
+            expect.objectContaining({
+              id: 'download-1',
+              status: 'PUBLISHED',
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('keeps Membership readiness available when switching builder tabs', async () => {
+    mockUseProductFormFacade.mockReturnValue(
+      makeFacadeState({
+        formData: {
+          id: 'membership-1',
+          name: 'Founders Club',
+          description: '',
+          type: 'MEMBERSHIP',
+          price: 25,
+        },
+      }),
+    );
+
+    render(<ProductForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('builder-sidebar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('tab-pricing'));
+    fireEvent.click(screen.getByTestId('tab-membership-content'));
+
+    expect(mockProductHeader).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        membershipReadiness: expect.any(Object),
+      }),
+    );
   });
 
   it('when showRestOfForm is true for a MEMBERSHIP, shows membership content after effect', async () => {


### PR DESCRIPTION
## Summary

Adds frontend-only Membership readiness evaluation and Publish guidance to the Product Builder.

Memberships can now clearly communicate whether they are ready to publish based on the current builder state, without introducing real publication or backend persistence.

### Readiness evaluation

Added a pure `evaluateMembershipReadiness` helper that evaluates the current Membership builder state.

Blocking requirements:

* Membership must have a non-empty name.
* Membership must have a valid recurring price.
* Membership must contain at least one published native content item or published included Product.

Non-blocking warnings:

* no thumbnail
* draft native content exists
* hidden native content exists
* no native Membership content
* no included Products

Readiness is derived from current state rather than stored separately.

### Included Product readiness

Included Product status is resolved from the existing creator product-summary store.

No new product-fetching path was introduced.

Published Courses or Downloads can satisfy the Membership content-readiness requirement alongside published Posts, Videos, or Resources.

### Publish UX

The Membership Product Builder header now shows a compact readiness state with blockers and warnings.

When requirements are not met:

* Publish is disabled.
* Missing requirements are visible to the Creator.

When the Membership is ready:

* Publish becomes enabled.
* Clicking it does not publish or mutate Product state.
* The Creator is informed that real Membership publishing will be enabled once Membership persistence is available.

This intentionally avoids creating a false published state while Membership-specific data is still frontend-only.

## Architecture

Membership readiness remains entirely frontend/domain-level.

It is not added to:

* Product DTOs
* `ProductDraft`
* Redux Product state
* autosave payloads
* Product update payloads

No Product status mutation or backend publish call is introduced.

The existing Product mapper behavior remains unchanged.

## Out of Scope

This PR does not implement:

* real Product publishing
* Product status mutation
* Membership backend persistence
* Membership content APIs
* recurring-pricing persistence
* included-product persistence
* ordering persistence
* buyer-facing Membership hub
* generic readiness rules for Course / Download / Consultation

## Verification

* `npm run tsc` ✅
* `npm test -- --runInBand` ✅ — 54 suites, 326 tests
* `npm run lint` ✅ — 0 errors; existing repository warnings remain

A follow-up documentation update is recommended for the new creator-facing Membership readiness UX and current frontend-only persistence boundary.
