### PR TITLE
DESIGN - Implement Creator Sales management experience

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -84,6 +84,10 @@ The current Creator redesign establishes a dark management application language,
 
 Shared interaction conventions now include semantic `Button` variants/sizes in `src/shared/ui/button`, accessible loading state via `aria-busy`/disabled behavior, calmer hover/focus/active states, and Escape-to-close dropdown behavior in `src/shared/ui/gal-dropdown/gal-dropdown.component.tsx`. The old global animated growing link underline has been removed from application interactions; unclassed prose links now use a simple underline treatment in `src/styles/_base.scss`. Do not assume every legacy UI has been migrated.
 
+Shared status presentation now has a reusable `StatusBadge` in `src/shared/ui/status-badge`. `StatusBadge` owns semantic badge presentation (`success`, `warning`, `danger`, `neutral`, `info`), visible labels, optional icons, and sizing. Feature/domain code remains responsible for deciding which business status maps to which semantic tone. Do not accumulate feature-specific status rules inside the shared primitive. The older `StatusChip` can compose `StatusBadge` where useful, but not every status surface has been migrated.
+
+Shared contextual drawer behavior now lives in `src/shared/ui/drawer`. The shared `Drawer` owns generic interaction/presentation behavior such as overlay rendering, ARIA dialog semantics, Escape-to-close, focus handling/restoration, body scroll locking, scrollable body content, and responsive mobile full-screen treatment. Feature components own drawer content and business behavior. As a convention, use a Page for a substantial destination/workspace with its own navigation depth, a Drawer for contextual inspection or interaction while retaining the parent workspace, and a Modal/Dialog for short focused tasks or confirmations that temporarily interrupt the workflow. Treat this as a convention, not an absolute rule.
+
 ## Product Builder
 
 The builder is centered on:
@@ -155,6 +159,7 @@ Implemented / reasonably wired:
 - Creator Dashboard redesign with business metrics, recent activity, top products, and needs-attention panels.
 - Creator Products management redesign with local search/filter/sort, list/table desktop composition, mobile management cards, and distinct empty/loading/error states.
 - Creator Customers management area with a customer list and dedicated customer detail route.
+- Creator Sales management area with overview metrics, an orders ledger, local search/filter/sort/date preset controls, local pagination, responsive layout, empty/no-result states, and contextual order detail inspection.
 - Product create/edit builder for course/download/consultation/membership basics.
 - Membership builder integration with a Membership Content tab.
 - Generic reusable Product Picker used by Membership included-product selection.
@@ -173,7 +178,7 @@ Partially implemented / placeholder:
 - Product detail page has real loading by product ID but still contains placeholder copy, fake rating/language/duration/creator text, and placeholder image.
 - Storefront page fetches creator products but currently renders mostly empty UI.
 - Creator Analytics and Help navigation destinations are disabled because implementations are not available yet.
-- Creator Sales and Marketing routes exist, but verify their feature completeness before expanding them.
+- Creator Marketing route exists, but verify feature completeness before expanding it.
 - Cart/wishlist exist mostly frontend-side/localStorage; persistence/checkout contract is not clearly backend-backed.
 - Membership included products are limited to existing Course/Download products and held in frontend state only.
 - Native Membership Post, Video, and Resource content have frontend-only create/edit/delete support. Native Video/Resource store selected local file metadata only and have no upload/persistence contract. No native Membership content has backend persistence.
@@ -199,16 +204,18 @@ Confirmed:
 - Membership has no backend recurring pricing contract yet.
 - Membership has no subscription/entitlement/member-access model yet.
 - Creator Customers has no production customer list/detail API, purchase/order API, entitlement/access contract, subscription/customer membership-state contract, waitlist API, tags/notes persistence, production pagination contract, or manual access-management API yet.
+- Creator Sales has no production order/payment/refund/subscription/entitlement services, provider-safe financial mutation contract, or server pagination contract yet.
 
 Deliberate temporary implementations:
 
 - `REACT_APP_USE_MOCKS` can load ignored local `src/core/api/_mocks.ts`.
-- `REACT_APP_USE_MOCKS=true` also enables deterministic Creator visual-inspection data for authenticated Creator identity, Products, Dashboard, Customers, and frontend-only Membership inspection state. Production must not fake unsupported Creator business metrics, customer records, or customer-domain states.
+- `REACT_APP_USE_MOCKS=true` also enables deterministic Creator visual-inspection data for authenticated Creator identity, Products, Dashboard, Customers, Sales, and frontend-only Membership inspection state. Production must not fake unsupported Creator business metrics, customer records, sales/order/payment records, or customer-domain states.
 - Blank section/lesson drafts exist locally until enough data is present for backend creation.
 - Creator Dashboard inspection fixtures live in `src/domains/app/pages/creator-specific/creator-dashboard/fixtures/dashboard-inspection-fixture.ts`. When mocks are off, Dashboard metric panels intentionally render unavailable business states rather than fabricated values.
 - Creator Dashboard Top products rows currently navigate directly to Product Workspace edit routes (`/app/products/edit/{productId}`) because there is no Product Overview destination yet. Future Creator product-entity navigation should prefer Product Overview, with editing/building as a secondary action from that overview.
 - Creator Products inspection fixtures currently come through ignored local mock data in `src/core/api/_mocks.ts` when mocks are enabled.
 - Creator Customers inspection fixtures live under `src/domains/app/pages/creator-specific/customers` and are returned only when `REACT_APP_USE_MOCKS=true`. With mocks off, Customers renders honest unavailable states rather than fabricating customer business data. Fixture data must remain development/inspection infrastructure, not a production fallback.
+- Creator Sales inspection fixtures live under `src/domains/app/pages/creator-specific/sales-page` and are returned only when `REACT_APP_USE_MOCKS=true`. With mocks off, Sales renders an honest unavailable state rather than fabricating order/payment/refund/access data. The `salesEmpty=true` query option and localStorage flag are inspection aids only, not production behavior.
 - Download upload deduping is local to the section editor instance.
 - Membership included-product selection, ordering mode, manual feed order, and feed metadata are local frontend state until a relationship/feed API exists.
 - Membership native content state is local frontend state lifted above the Membership Content tab. Post, Video, and Resource can be created/edited/deleted locally; Video/Resource use selection-only local file metadata. Backend persistence remains undefined.
@@ -239,6 +246,46 @@ Important fixture rule:
 
 - The Dashboard is intentionally future-facing for visual inspection only. Metrics/business states not yet supported by production APIs may be represented by deterministic development-only fixture data when `REACT_APP_USE_MOCKS=true`.
 - Production must not fake those values. With mocks off, the dashboard uses unavailable states from `unavailableDashboard`.
+
+## Creator Sales Management
+
+The Creator Sales area is implemented under `src/domains/app/pages/creator-specific/sales-page` and is the Creator-facing financial operations ledger for inspecting orders, payment outcomes, refund context, and resulting access state.
+
+Routes and contextual state:
+
+- Sales workspace: `/app/sales`.
+- Selected order detail uses query state, for example `/app/sales?order=ORD-2026-00124`.
+- Query-state selection keeps the user in the Sales workspace while opening contextual order inspection, supports refresh/deep links/browser navigation, and preserves the parent ledger context.
+- This query-state drawer pattern is a reusable option for contextual inspection. Do not treat it as a requirement for every detail surface.
+
+Current Sales page patterns:
+
+- The page heading is `Sales`, not `Sales & Analytics`.
+- Overview metrics are Revenue, Orders, Refunds, and Failed payments.
+- Metrics are scoped to the selected date preset. Ledger results also apply search, status, product, and sort refinements.
+- Desktop uses a compact orders ledger with Date, Customer, Product, Status, Type, and Amount.
+- Tablet/mobile reduce columns and transform ledger rows into compact transaction cards rather than shrinking the desktop table.
+- Order identity opens the contextual Order Detail drawer. Customer identity links to Customer Detail when a customer ID exists. Product identity links to Product Workspace when a product ID exists.
+- Local controls include search by customer/email/order ID, date preset filter, order status filter, product filter, sorting, result count, Clear filters, and local pagination.
+- Empty states distinguish no sales, search-no-results, filter-no-results, and production unavailable states.
+- Mobile uses the shared `Drawer` for filter controls.
+
+Current Sales domain model:
+
+- Order statuses represented by the frontend are `Paid`, `Failed`, `Refunded`, and `Pending`.
+- Order types represented by the frontend are `One-time`, `Subscription`, and `Renewal`.
+- Refunds are represented as status/context on the original order, not as a separate Creator-facing refund entity or refund ledger.
+- The Order Detail drawer is read-only. It can show order amount/type/date, customer, product, payment facts, order summary, access outcome, subscription context, refund context, and failed-payment context when fixture data contains those fields.
+- Sales explains access consequences but does not expose entitlement grant/revoke controls.
+- Sales shows subscription context for recurring Membership charges but does not expose subscription-management actions.
+- Sales does not currently include charts, analytics, payouts, invoices, tax reporting, disputes, export tooling, refunds-as-actions, manual retries, or provider administration.
+
+Important Sales boundary:
+
+- Current Sales data comes from deterministic inspection fixtures returned only when `REACT_APP_USE_MOCKS=true`.
+- The current frontend does not define production-backed contracts/services for complete Creator orders, payments, refunds, subscriptions, entitlements/access, provider-safe financial mutations, or server pagination.
+- With mocks off, Sales renders an unavailable state rather than fabricated financial data.
+- Do not introduce production APIs or financial mutation behavior merely to support the current inspection UI.
 
 ## Creator Products Management
 
@@ -308,6 +355,7 @@ Implemented examples:
 - Dashboard metrics change layout across breakpoints and panel order changes when content becomes sequential.
 - Products desktop list/table becomes mobile management cards.
 - Customers desktop/tablet list/table becomes mobile customer cards while preserving the stacked mobile filter controls.
+- Sales desktop orders ledger becomes tablet/mobile transaction cards, and mobile secondary filters move into the shared Drawer.
 - Product workspace navigation adapts on narrow screens while preserving the focused editing shell.
 
 Avoid hardcoding viewport-specific pixel values into this document; inspect the SCSS breakpoints and component styles when implementing a responsive change.
@@ -322,7 +370,7 @@ Recent Git history includes admin role/product ownership work, Membership fronte
 - Membership added as a first-class frontend Product type.
 - Membership uses the shared builder shell, its own Membership Content tab, frontend-only Course/Download included-product selection, frontend-only Post/Video/Resource content creation/editing, and frontend-only recurring pricing controls.
 - Creator management shell and IA centered on Dashboard, Products, Customers, Sales, Marketing, Storefront, plus Settings utility navigation; unavailable destinations such as Analytics and Help remain disabled.
-- Creator Dashboard and Products management visual redesigns.
+- Creator Dashboard, Products, Customers, and Sales management visual redesigns.
 - Focused Product Workspace shell for product editing.
 
 Likely next steps:

--- a/src/domains/app/pages/creator-specific/sales-page/creator-sales.fixtures.ts
+++ b/src/domains/app/pages/creator-specific/sales-page/creator-sales.fixtures.ts
@@ -1,0 +1,280 @@
+import { CreatorSalesDataState, SalesOrder } from './creator-sales.types';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const placeholderImage = require('../../../../../assets/image-placeholder.png');
+
+const orders: SalesOrder[] = [
+  {
+    id: 'ORD-2026-00124',
+    orderedAt: '2026-08-10T14:32:00.000Z',
+    status: 'paid',
+    type: 'one-time',
+    amountCents: 14900,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-maya-johnson',
+      name: 'Maya Johnson',
+      email: 'maya.johnson@example.test',
+    },
+    product: {
+      id: 'prod-course-growth',
+      name: 'Creator Product Growth System',
+      type: 'Course',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Visa ending 4242',
+    transactionId: 'pi_3QcreatorPaid124',
+    paymentDate: '2026-08-10T14:32:00.000Z',
+    summaryRows: [{ label: 'Total', amountCents: 14900 }],
+    access: {
+      state: 'granted',
+      label: 'Access granted',
+      detail: 'Course access is active for this customer.',
+    },
+  },
+  {
+    id: 'ORD-2026-00123',
+    orderedAt: '2026-08-10T09:18:00.000Z',
+    status: 'paid',
+    type: 'renewal',
+    amountCents: 3900,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-alex-rivera',
+      name: 'Alex Rivera',
+      email: 'alex.rivera@example.test',
+    },
+    product: {
+      id: 'prod-membership-lab',
+      name: 'Creator Systems Lab',
+      type: 'Membership',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Mastercard ending 1881',
+    transactionId: 'pi_3QcreatorRenewal123',
+    paymentDate: '2026-08-10T09:18:00.000Z',
+    summaryRows: [{ label: 'Total', amountCents: 3900 }],
+    access: {
+      state: 'granted',
+      label: 'Access granted',
+      detail: 'Membership access remains active after renewal.',
+    },
+    subscription: {
+      priceCents: 3900,
+      currency: 'EUR',
+      interval: 'month',
+      state: 'active',
+      nextBillingAt: '2026-09-10T09:18:00.000Z',
+    },
+  },
+  {
+    id: 'ORD-2026-00122',
+    orderedAt: '2026-08-09T16:08:00.000Z',
+    status: 'paid',
+    type: 'subscription',
+    amountCents: 3900,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-elena-garcia',
+      name: 'Elena Garcia',
+      email: 'elena.garcia@example.test',
+    },
+    product: {
+      id: 'prod-membership-lab',
+      name: 'Creator Systems Lab',
+      type: 'Membership',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Visa ending 0008',
+    transactionId: 'pi_3QcreatorInitial122',
+    paymentDate: '2026-08-09T16:08:00.000Z',
+    summaryRows: [{ label: 'Total', amountCents: 3900 }],
+    access: {
+      state: 'granted',
+      label: 'Access granted',
+      detail: 'Membership access started with this payment.',
+    },
+    subscription: {
+      priceCents: 3900,
+      currency: 'EUR',
+      interval: 'month',
+      state: 'active',
+      nextBillingAt: '2026-09-09T16:08:00.000Z',
+    },
+  },
+  {
+    id: 'ORD-2026-00121',
+    orderedAt: '2026-08-08T11:42:00.000Z',
+    status: 'refunded',
+    type: 'one-time',
+    amountCents: 4900,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-jamie-chen',
+      name: 'Jamie Chen',
+      email: 'jamie.chen@example.test',
+    },
+    product: {
+      id: 'prod-launch-toolkit',
+      name: 'Launch Toolkit',
+      type: 'Download',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Visa ending 2222',
+    transactionId: 'pi_3QcreatorRefund121',
+    paymentDate: '2026-08-08T11:42:00.000Z',
+    summaryRows: [{ label: 'Total', amountCents: 4900 }],
+    access: {
+      state: 'revoked',
+      label: 'Access revoked',
+      detail: 'Download access was removed after the refund.',
+    },
+    refund: {
+      amountCents: 4900,
+      refundedAt: '2026-08-09T10:05:00.000Z',
+      reason: 'Customer request',
+    },
+  },
+  {
+    id: 'ORD-2026-00120',
+    orderedAt: '2026-08-07T08:36:00.000Z',
+    status: 'failed',
+    type: 'renewal',
+    amountCents: 3900,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-mira-patel',
+      name: 'Mira Patel',
+      email: 'mira.patel@example.test',
+    },
+    product: {
+      id: 'prod-membership-lab',
+      name: 'Creator Systems Lab',
+      type: 'Membership',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Card ending 0341',
+    transactionId: 'pi_3QcreatorFailed120',
+    summaryRows: [{ label: 'Total', amountCents: 3900 }],
+    access: {
+      state: 'granted',
+      label: 'Access granted',
+      detail: 'Existing membership access remains active during payment recovery.',
+    },
+    failure: {
+      message: 'Card was declined.',
+      retryAt: '2026-08-12T08:36:00.000Z',
+    },
+    subscription: {
+      priceCents: 3900,
+      currency: 'EUR',
+      interval: 'month',
+      state: 'past_due',
+      nextBillingAt: '2026-08-12T08:36:00.000Z',
+    },
+  },
+  {
+    id: 'ORD-2026-00119',
+    orderedAt: '2026-08-05T13:20:00.000Z',
+    status: 'paid',
+    type: 'one-time',
+    amountCents: 25000,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-noah-smith',
+      name: 'Noah Smith',
+      email: 'noah.smith@example.test',
+    },
+    product: {
+      id: 'prod-consulting',
+      name: 'Founder Positioning Intensive',
+      type: 'Consultation',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Amex ending 1009',
+    transactionId: 'pi_3QcreatorConsult119',
+    paymentDate: '2026-08-05T13:20:00.000Z',
+    summaryRows: [{ label: 'Total', amountCents: 25000 }],
+    access: {
+      state: 'none',
+      label: 'No access granted',
+      detail: 'This purchase booked a consultation rather than product library access.',
+    },
+  },
+  {
+    id: 'ORD-2026-00118',
+    orderedAt: '2026-07-28T18:15:00.000Z',
+    status: 'pending',
+    type: 'one-time',
+    amountCents: 9900,
+    currency: 'EUR',
+    customer: {
+      name: 'Samira Longlastname-With-Company-Identifier',
+      email: 'samira.long.identity@example.test',
+    },
+    product: {
+      id: 'prod-download-system',
+      name: 'The Very Long Product Operations Template Pack for Launch Teams',
+      type: 'Download',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Stripe',
+    paymentMethod: 'Bank transfer',
+    transactionId: 'pi_3QcreatorPending118',
+    summaryRows: [{ label: 'Total', amountCents: 9900 }],
+    access: {
+      state: 'none',
+      label: 'No access granted',
+      detail: 'Access will be granted after payment confirmation.',
+    },
+  },
+  {
+    id: 'ORD-2026-00117',
+    orderedAt: '2026-07-18T10:00:00.000Z',
+    status: 'paid',
+    type: 'one-time',
+    amountCents: 0,
+    currency: 'EUR',
+    customer: {
+      id: 'cust-lina-kowalski',
+      name: 'Lina Kowalski',
+      email: 'lina.kowalski@example.test',
+    },
+    product: {
+      id: 'prod-free-mini',
+      name: 'Free Creator Checklist',
+      type: 'Download',
+      thumbnailUrl: placeholderImage,
+    },
+    provider: 'Internal checkout',
+    transactionId: 'free_2026_00117',
+    paymentDate: '2026-07-18T10:00:00.000Z',
+    summaryRows: [{ label: 'Total', amountCents: 0 }],
+    access: {
+      state: 'granted',
+      label: 'Access granted',
+      detail: 'Free download access is active for this customer.',
+    },
+  },
+];
+
+export const getCreatorSalesData = (): CreatorSalesDataState => {
+  if (process.env.REACT_APP_USE_MOCKS !== 'true') {
+    return { status: 'unavailable', orders: [] };
+  }
+
+  if (
+    window.localStorage.getItem('creator-sales-empty') === 'true' ||
+    new URLSearchParams(window.location.search).get('salesEmpty') === 'true'
+  ) {
+    return { status: 'ready', orders: [] };
+  }
+
+  return { status: 'ready', orders };
+};

--- a/src/domains/app/pages/creator-specific/sales-page/creator-sales.types.ts
+++ b/src/domains/app/pages/creator-specific/sales-page/creator-sales.types.ts
@@ -1,0 +1,70 @@
+export type SalesOrderStatus = 'paid' | 'failed' | 'refunded' | 'pending';
+export type SalesOrderType = 'one-time' | 'subscription' | 'renewal';
+export type SalesProductType = 'Course' | 'Download' | 'Consultation' | 'Membership';
+export type SalesAccessState = 'granted' | 'revoked' | 'none';
+
+export interface SalesCustomerSummary {
+  id?: string;
+  name: string;
+  email: string;
+}
+
+export interface SalesProductSummary {
+  id?: string;
+  name: string;
+  type: SalesProductType;
+  thumbnailUrl?: string;
+}
+
+export interface SalesRefundDetail {
+  amountCents: number;
+  refundedAt: string;
+  reason?: string;
+}
+
+export interface SalesFailureDetail {
+  message: string;
+  retryAt?: string;
+}
+
+export interface SalesSubscriptionContext {
+  priceCents: number;
+  currency: string;
+  interval: 'month' | 'year';
+  state: 'active' | 'past_due' | 'cancelled';
+  nextBillingAt?: string;
+}
+
+export interface SalesOrderSummaryRow {
+  label: string;
+  amountCents: number;
+}
+
+export interface SalesOrder {
+  id: string;
+  orderedAt: string;
+  status: SalesOrderStatus;
+  type: SalesOrderType;
+  amountCents: number;
+  currency: string;
+  customer: SalesCustomerSummary;
+  product: SalesProductSummary;
+  provider?: string;
+  paymentMethod?: string;
+  transactionId?: string;
+  paymentDate?: string;
+  summaryRows: SalesOrderSummaryRow[];
+  access: {
+    state: SalesAccessState;
+    label: string;
+    detail?: string;
+  };
+  refund?: SalesRefundDetail;
+  failure?: SalesFailureDetail;
+  subscription?: SalesSubscriptionContext;
+}
+
+export interface CreatorSalesDataState {
+  status: 'ready' | 'unavailable';
+  orders: SalesOrder[];
+}

--- a/src/domains/app/pages/creator-specific/sales-page/creator-sales.utils.ts
+++ b/src/domains/app/pages/creator-specific/sales-page/creator-sales.utils.ts
@@ -1,0 +1,229 @@
+import { SelectOption } from '@shared/ui';
+import { StatusBadgeTone } from '@shared/ui/status-badge';
+
+import {
+  SalesOrder,
+  SalesOrderStatus,
+  SalesOrderType,
+  SalesProductType,
+} from './creator-sales.types';
+
+export type SalesPeriod = 'today' | '7d' | '30d' | '90d';
+export type SalesStatusFilter = 'all' | SalesOrderStatus;
+export type SalesSortOption = 'newest' | 'oldest' | 'amount-desc' | 'amount-asc';
+
+export interface SalesFilterForm {
+  search: string;
+  period: SalesPeriod;
+  status: SalesStatusFilter;
+  product: string;
+  sort: SalesSortOption;
+}
+
+export const defaultSalesFilterForm: SalesFilterForm = {
+  search: '',
+  period: '30d',
+  status: 'all',
+  product: 'all',
+  sort: 'newest',
+};
+
+export const salesPeriodOptions: SelectOption[] = [
+  { label: 'Today', value: 'today' },
+  { label: 'Last 7 days', value: '7d' },
+  { label: 'Last 30 days', value: '30d' },
+  { label: 'Last 90 days', value: '90d' },
+];
+
+export const salesStatusOptions: SelectOption[] = [
+  { label: 'All statuses', value: 'all' },
+  { label: 'Paid', value: 'paid' },
+  { label: 'Failed', value: 'failed' },
+  { label: 'Refunded', value: 'refunded' },
+  { label: 'Pending', value: 'pending' },
+];
+
+export const salesSortOptions: SelectOption[] = [
+  { label: 'Newest first', value: 'newest' },
+  { label: 'Oldest first', value: 'oldest' },
+  { label: 'Amount: high to low', value: 'amount-desc' },
+  { label: 'Amount: low to high', value: 'amount-asc' },
+];
+
+export const orderStatusLabel: Record<SalesOrderStatus, string> = {
+  paid: 'Paid',
+  failed: 'Failed',
+  refunded: 'Refunded',
+  pending: 'Pending',
+};
+
+export const orderStatusTone: Record<SalesOrderStatus, StatusBadgeTone> = {
+  paid: 'success',
+  failed: 'danger',
+  refunded: 'warning',
+  pending: 'neutral',
+};
+
+export const orderTypeLabel: Record<SalesOrderType, string> = {
+  'one-time': 'One-time',
+  subscription: 'Subscription',
+  renewal: 'Renewal',
+};
+
+export const productTypeLabel: Record<SalesProductType, string> = {
+  Course: 'Course',
+  Download: 'Download',
+  Consultation: 'Consultation',
+  Membership: 'Membership',
+};
+
+export const subscriptionStateLabel: Record<string, string> = {
+  active: 'Active',
+  past_due: 'Past due',
+  cancelled: 'Cancelled',
+};
+
+const periodStartByValue: Record<SalesPeriod, string> = {
+  today: '2026-08-10T00:00:00.000Z',
+  '7d': '2026-08-04T00:00:00.000Z',
+  '30d': '2026-07-12T00:00:00.000Z',
+  '90d': '2026-05-12T00:00:00.000Z',
+};
+
+const parseTimestamp = (value?: string) => {
+  if (!value) {
+    return 0;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+export const formatSalesMoney = (cents: number, currency = 'EUR') =>
+  new Intl.NumberFormat('en-IE', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: Number.isInteger(cents / 100) ? 0 : 2,
+  }).format(cents / 100);
+
+export const formatSalesShortDate = (value?: string) => {
+  const timestamp = parseTimestamp(value);
+  if (!timestamp) {
+    return 'Unavailable';
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(timestamp));
+};
+
+export const formatSalesDateTime = (value?: string) => {
+  const timestamp = parseTimestamp(value);
+  if (!timestamp) {
+    return 'Unavailable';
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(timestamp));
+};
+
+export const getSalesProductOptions = (orders: SalesOrder[]): SelectOption[] => {
+  const productMap = new Map<string, string>();
+
+  orders.forEach((order) => {
+    if (order.product.id) {
+      productMap.set(order.product.id, order.product.name);
+    }
+  });
+
+  return Array.from(productMap.entries()).map(([value, label]) => ({
+    value,
+    label,
+  }));
+};
+
+export const filterAndSortSalesOrders = (
+  orders: SalesOrder[],
+  filterForm: SalesFilterForm,
+) => {
+  const term = filterForm.search.trim().toLowerCase();
+  const periodStart = parseTimestamp(periodStartByValue[filterForm.period]);
+
+  const filtered = orders.filter((order) => {
+    const orderedAt = parseTimestamp(order.orderedAt);
+    const matchesPeriod = orderedAt >= periodStart;
+    const matchesSearch =
+      term === '' ||
+      order.id.toLowerCase().includes(term) ||
+      order.customer.name.toLowerCase().includes(term) ||
+      order.customer.email.toLowerCase().includes(term);
+    const matchesStatus =
+      filterForm.status === 'all' || order.status === filterForm.status;
+    const matchesProduct =
+      filterForm.product === 'all' || order.product.id === filterForm.product;
+
+    return matchesPeriod && matchesSearch && matchesStatus && matchesProduct;
+  });
+
+  return filtered.slice().sort((a, b) => {
+    switch (filterForm.sort) {
+    case 'oldest':
+      return parseTimestamp(a.orderedAt) - parseTimestamp(b.orderedAt);
+    case 'amount-desc':
+      return b.amountCents - a.amountCents;
+    case 'amount-asc':
+      return a.amountCents - b.amountCents;
+    case 'newest':
+    default:
+      return parseTimestamp(b.orderedAt) - parseTimestamp(a.orderedAt);
+    }
+  });
+};
+
+export const getSalesMetrics = (orders: SalesOrder[]) => {
+  const paidOrders = orders.filter((order) => order.status === 'paid');
+  const refundedValueCents = orders.reduce(
+    (total, order) => total + (order.refund?.amountCents ?? 0),
+    0,
+  );
+
+  return [
+    {
+      label: 'Revenue',
+      value: formatSalesMoney(
+        paidOrders.reduce((total, order) => total + order.amountCents, 0),
+      ),
+      direction: 'up',
+      sentiment: 'favorable',
+      comparison: '+8% vs prior period',
+    },
+    {
+      label: 'Orders',
+      value: String(paidOrders.length),
+      direction: 'up',
+      sentiment: 'favorable',
+      comparison: '+2 vs prior period',
+    },
+    {
+      label: 'Refunds',
+      value: formatSalesMoney(refundedValueCents),
+      direction: 'down',
+      sentiment: 'favorable',
+      comparison: '-1 vs prior period',
+    },
+    {
+      label: 'Failed payments',
+      value: String(orders.filter((order) => order.status === 'failed').length),
+      direction: 'down',
+      sentiment: 'favorable',
+      comparison: '-2 vs prior period',
+    },
+  ];
+};

--- a/src/domains/app/pages/creator-specific/sales-page/sales-page.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/sales-page/sales-page.component.test.tsx
@@ -1,0 +1,195 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import SalesPage from './sales-page.component';
+
+const LocationProbe: React.FC = () => {
+  const location = useLocation();
+  return <span data-testid="location-search">{location.search}</span>;
+};
+
+describe('Creator Sales', () => {
+  const originalUseMocks = process.env.REACT_APP_USE_MOCKS;
+
+  const renderSales = (initialEntry = '/app/sales') =>
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <LocationProbe />
+        <Routes>
+          <Route path="/app/sales" element={<SalesPage />} />
+          <Route
+            path="/app/customers/:customerId"
+            element={<div>Customer detail route</div>}
+          />
+          <Route
+            path="/app/products/edit/:productId"
+            element={<div>Product workspace route</div>}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+  beforeEach(() => {
+    process.env.REACT_APP_USE_MOCKS = 'true';
+    window.localStorage.removeItem('creator-sales-empty');
+  });
+
+  afterEach(() => {
+    process.env.REACT_APP_USE_MOCKS = originalUseMocks;
+    window.localStorage.removeItem('creator-sales-empty');
+  });
+
+  it('renders Sales with period-aligned metrics and result count', () => {
+    renderSales();
+
+    expect(screen.getByRole('heading', { name: 'Sales' })).toBeInTheDocument();
+    expect(screen.getByText('8 orders')).toBeInTheDocument();
+    expect(screen.getByText('Revenue')).toBeInTheDocument();
+    expect(screen.getByText('Failed payments')).toBeInTheDocument();
+  });
+
+  it('searches customer, email, or order ID', () => {
+    renderSales();
+
+    fireEvent.change(screen.getByLabelText('Search customer, email, or order ID'), {
+      target: { value: 'mira.patel' },
+    });
+
+    expect(screen.getByText('1 order')).toBeInTheDocument();
+    expect(screen.getByText('Mira Patel')).toBeInTheDocument();
+    expect(screen.queryByText('Maya Johnson')).toBeNull();
+  });
+
+  it('filters by status and product', () => {
+    renderSales();
+
+    fireEvent.change(screen.getByLabelText('Filter orders by status'), {
+      target: { value: 'failed' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter orders by product'), {
+      target: { value: 'prod-membership-lab' },
+    });
+
+    expect(screen.getByText('1 order')).toBeInTheDocument();
+    const ledger = screen.getByRole('region', { name: 'Orders ledger' });
+    expect(within(ledger).getByText('Mira Patel')).toBeInTheDocument();
+    expect(within(ledger).getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('filters by period and sorts by amount', () => {
+    renderSales();
+
+    fireEvent.change(screen.getByLabelText('Select sales date range'), {
+      target: { value: '7d' },
+    });
+    expect(screen.getByText('6 orders')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Sort orders'), {
+      target: { value: 'amount-desc' },
+    });
+    const openButtons = screen.getAllByRole('button', { name: /open ORD/i });
+    expect(openButtons[0]).toHaveAccessibleName('Open ORD-2026-00119 order detail');
+  });
+
+  it('renders true-empty, search-empty, and filter-empty states', () => {
+    window.localStorage.setItem('creator-sales-empty', 'true');
+    const emptyRender = renderSales();
+
+    expect(screen.getByText('No sales yet')).toBeInTheDocument();
+    emptyRender.unmount();
+
+    window.localStorage.removeItem('creator-sales-empty');
+    const searchRender = renderSales();
+    fireEvent.change(screen.getByLabelText('Search customer, email, or order ID'), {
+      target: { value: 'nobody@example.test' },
+    });
+    expect(
+      screen.getByText('No orders match "nobody@example.test".'),
+    ).toBeInTheDocument();
+    searchRender.unmount();
+
+    renderSales();
+    fireEvent.change(screen.getByLabelText('Filter orders by status'), {
+      target: { value: 'pending' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter orders by product'), {
+      target: { value: 'prod-membership-lab' },
+    });
+    expect(screen.getByText('No orders match these filters.')).toBeInTheDocument();
+  });
+
+  it('opens order detail and reflects selection in URL state', () => {
+    renderSales();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open ORD-2026-00124 order detail' }),
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Order #ORD-2026-00124')).toBeInTheDocument();
+    expect(screen.getByText('Access granted')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'View customer' }),
+    ).toHaveAttribute('href', '/app/customers/cust-maya-johnson');
+    expect(screen.getByTestId('location-search')).toHaveTextContent(
+      'order=ORD-2026-00124',
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close drawer' })[1]);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('restores an order detail drawer from a deep link', () => {
+    renderSales('/app/sales?order=ORD-2026-00123');
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Order #ORD-2026-00123')).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByRole('heading', { name: 'Subscription' }),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('€39 / month')).toBeInTheDocument();
+  });
+
+  it('renders refunded and failed order detail contexts', () => {
+    const { unmount } = renderSales('/app/sales?order=ORD-2026-00121');
+
+    const refundDialog = screen.getByRole('dialog');
+    expect(within(refundDialog).getByText('Refund')).toBeInTheDocument();
+    expect(within(refundDialog).getByText('Customer request')).toBeInTheDocument();
+    expect(within(refundDialog).getAllByText('Access revoked').length).toBeGreaterThan(
+      0,
+    );
+    unmount();
+
+    renderSales('/app/sales?order=ORD-2026-00120');
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Failed payment')).toBeInTheDocument();
+    expect(within(dialog).getByText('Card was declined.')).toBeInTheDocument();
+    expect(within(dialog).getByText(/Retry scheduled/)).toBeInTheDocument();
+  });
+
+  it('links customer and product identities from ledger rows', () => {
+    renderSales();
+
+    expect(
+      screen.getByRole('link', { name: 'Open Maya Johnson customer profile' }),
+    ).toHaveAttribute('href', '/app/customers/cust-maya-johnson');
+    expect(
+      screen.getByRole('link', {
+        name: 'Open Creator Product Growth System workspace',
+      }),
+    ).toHaveAttribute('href', '/app/products/edit/prod-course-growth');
+  });
+
+  it('renders honest production unavailable state when inspection mocks are off', () => {
+    process.env.REACT_APP_USE_MOCKS = 'false';
+    renderSales();
+
+    expect(screen.getByText('Sales data is not available yet')).toBeInTheDocument();
+    expect(screen.queryByText('Maya Johnson')).toBeNull();
+  });
+});

--- a/src/domains/app/pages/creator-specific/sales-page/sales-page.component.tsx
+++ b/src/domains/app/pages/creator-specific/sales-page/sales-page.component.tsx
@@ -1,68 +1,567 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { BiSort } from 'react-icons/bi';
+import { FaSearch } from 'react-icons/fa';
+import { MdOutlineCalendarToday, MdOutlineFilterList } from 'react-icons/md';
+import { SiStatuspal } from 'react-icons/si';
+
+import { Button, Drawer, Input, Select, SelectOption, StatusBadge } from '@shared/ui';
+
+import { getCreatorSalesData } from './creator-sales.fixtures';
+import { SalesOrder } from './creator-sales.types';
+import {
+  defaultSalesFilterForm,
+  filterAndSortSalesOrders,
+  formatSalesDateTime,
+  formatSalesMoney,
+  formatSalesShortDate,
+  getSalesMetrics,
+  getSalesProductOptions,
+  orderStatusLabel,
+  orderStatusTone,
+  orderTypeLabel,
+  salesPeriodOptions,
+  salesSortOptions,
+  salesStatusOptions,
+  subscriptionStateLabel,
+} from './creator-sales.utils';
 
 import './sales-page.styles.scss';
 
-const SalesPage: React.FC = () => (
-  <div className="sales-page">
-    <h1>Sales & Analytics</h1>
-    <h3>Transactions</h3>
-    <ol>
-      <li>Transaction 1: $100</li>
-      <li>Transaction 2: $200</li>
-      <li>Transaction 3: $150</li>
-      <li>Transaction 4: $300</li>
-      <li>Transaction 5: $250</li>
-    </ol>
+const PAGE_SIZE = 6;
 
-    <h3>Customers</h3>
-    <ol>
-      <li>Customer 1: John Doe</li>
-      <li>Customer 2: Jane Smith</li>
-      <li>Customer 3: Alice Johnson</li>
-    </ol>
+const trendSymbol: Record<string, string> = {
+  up: '↑',
+  down: '↓',
+  flat: '—',
+};
 
-    <h3>Analytics</h3>
-    <p>Total Sales: $1000</p>
-    <p>Total Customers: 3</p>
-    <p>Average Transaction Value: $200</p>
-    <p>Sales Growth: 10% compared to last month</p>
-    <p>Top Selling Product: Product A</p>
-    <p>Customer Retention Rate: 85%</p>
-    <p>Conversion Rate: 5%</p>
-    <p>Revenue per Visitor: $50</p>
-    <p>Churn Rate: 15%</p>
-    <p>Customer Lifetime Value: $500</p>
-    <p>Sales by Region: North America - 60%, Europe - 30%, Asia - 10%</p>
-    <p>Sales by Channel: Online - 70%, In-Store - 20%, Wholesale - 10%</p>
-    <p>
-      Sales by Product Category: COURSE - 40%, DOWNLOAD - 30%, CONSULTATION -
-      30%
-    </p>
-    <p>
-      Sales by Payment Method: Credit Card - 50%, PayPal - 30%, Bank Transfer -
-      20%
-    </p>
-    <p>
-      Sales by Time Period: Last 30 Days - $500, Last 60 Days - $800, Last 90
-      Days - $1000
-    </p>
+const SalesPage: React.FC = () => {
+  const data = useMemo(() => getCreatorSalesData(), []);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedOrderId = searchParams.get('order');
+  const [filterForm, setFilterForm] = useState(defaultSalesFilterForm);
+  const [page, setPage] = useState(0);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
-    <h3>Sales Trends</h3>
-    <p>
-      Sales have been steadily increasing over the past few months, with a
-      significant spike in the last month due to a successful marketing
-      campaign.
-    </p>
-    <p>
-      The average transaction value has also increased, indicating that
-      customers are purchasing more expensive products.
-    </p>
-    <p>
-      Customer retention rate has improved, suggesting that our customer
-      satisfaction initiatives are paying off.
-    </p>
-    {/* Add more content or components related to sales and analytics here */}
-  </div>
+  const hasOrders = data.orders.length > 0;
+  const productOptions = useMemo<SelectOption[]>(
+    () => [
+      { label: 'All products', value: 'all' },
+      ...getSalesProductOptions(data.orders),
+    ],
+    [data.orders],
+  );
+  const filteredOrders = useMemo(
+    () => filterAndSortSalesOrders(data.orders, filterForm),
+    [data.orders, filterForm],
+  );
+  const periodOrders = useMemo(
+    () =>
+      filterAndSortSalesOrders(data.orders, {
+        ...defaultSalesFilterForm,
+        period: filterForm.period,
+      }),
+    [data.orders, filterForm.period],
+  );
+  const metrics = useMemo(() => getSalesMetrics(periodOrders), [periodOrders]);
+  const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages - 1);
+  const pagedOrders = filteredOrders.slice(
+    currentPage * PAGE_SIZE,
+    currentPage * PAGE_SIZE + PAGE_SIZE,
+  );
+  const selectedOrder = data.orders.find((order) => order.id === selectedOrderId);
+
+  const hasSearch = filterForm.search.trim().length > 0;
+  const hasFilters = filterForm.status !== 'all' || filterForm.product !== 'all';
+  const activeFilterCount =
+    Number(filterForm.status !== 'all') + Number(filterForm.product !== 'all');
+  const hasActiveRefinement = hasSearch || hasFilters;
+  const resultCountLabel = `${filteredOrders.length} ${
+    filteredOrders.length === 1 ? 'order' : 'orders'
+  }`;
+
+  const handleControlChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target;
+    setPage(0);
+    setFilterForm((current) => ({ ...current, [name]: value }));
+  };
+
+  const clearSearch = () => {
+    setPage(0);
+    setFilterForm((current) => ({ ...current, search: '' }));
+  };
+
+  const clearFilters = () => {
+    setPage(0);
+    setFilterForm(defaultSalesFilterForm);
+  };
+
+  const openOrder = (orderId: string) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('order', orderId);
+    setSearchParams(nextParams);
+  };
+
+  const closeOrder = () => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('order');
+    setSearchParams(nextParams);
+  };
+
+  const renderFilters = (compact = false) => (
+    <div className={compact ? 'sales-filter-stack' : 'sales-toolbar__filters'}>
+      <Select
+        name="period"
+        value={filterForm.period}
+        options={salesPeriodOptions}
+        onChange={handleControlChange}
+        customClassName="sales-toolbar__select"
+        prefixIcon={MdOutlineCalendarToday}
+        aria-label="Select sales date range"
+      />
+      <Select
+        name="status"
+        value={filterForm.status}
+        options={salesStatusOptions}
+        onChange={handleControlChange}
+        customClassName="sales-toolbar__select"
+        prefixIcon={SiStatuspal}
+        aria-label="Filter orders by status"
+      />
+      <Select
+        name="product"
+        value={filterForm.product}
+        options={productOptions}
+        onChange={handleControlChange}
+        customClassName="sales-toolbar__select"
+        prefixIcon={MdOutlineFilterList}
+        aria-label="Filter orders by product"
+      />
+      <Select
+        name="sort"
+        value={filterForm.sort}
+        options={salesSortOptions}
+        onChange={handleControlChange}
+        customClassName="sales-toolbar__select sales-toolbar__sort"
+        prefixIcon={BiSort}
+        aria-label="Sort orders"
+      />
+    </div>
+  );
+
+  const renderState = (): React.ReactNode => {
+    if (data.status === 'unavailable') {
+      return (
+        <div className="sales-state" role="status">
+          <h2>Sales data is not available yet</h2>
+          <p>
+            Orders will appear here once order, payment, refund, and entitlement
+            APIs are connected.
+          </p>
+        </div>
+      );
+    }
+
+    if (!hasOrders) {
+      return (
+        <div className="sales-state">
+          <h2>No sales yet</h2>
+          <p>Orders will appear here when customers purchase your products.</p>
+          <Link className="sales-state__link" to="/app/products">
+            View products
+          </Link>
+        </div>
+      );
+    }
+
+    if (filteredOrders.length === 0 && hasSearch) {
+      return (
+        <div className="sales-state">
+          <h2>{`No orders match "${filterForm.search.trim()}".`}</h2>
+          <Button type="button" variant="secondary" onClick={clearSearch}>
+            Clear search
+          </Button>
+        </div>
+      );
+    }
+
+    if (filteredOrders.length === 0 && hasFilters) {
+      return (
+        <div className="sales-state">
+          <h2>No orders match these filters.</h2>
+          <Button type="button" variant="secondary" onClick={clearFilters}>
+            Clear filters
+          </Button>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="sales-page">
+      <header className="sales-header">
+        <div>
+          <h1>Sales</h1>
+          <p>Track orders, payments, refunds, and failed charges.</p>
+        </div>
+      </header>
+
+      {hasOrders && (
+        <section className="sales-metrics" aria-label="Financial summary">
+          {metrics.map((metric) => (
+            <article
+              className={`sales-metric sales-metric--${metric.sentiment}`}
+              key={metric.label}
+            >
+              <span className="sales-metric__label">{metric.label}</span>
+              <strong>{metric.value}</strong>
+              <span className="sales-metric__trend">
+                {trendSymbol[metric.direction]} {metric.comparison}
+              </span>
+            </article>
+          ))}
+        </section>
+      )}
+
+      {hasOrders && (
+        <section className="sales-toolbar" aria-label="Sales controls">
+          <Input
+            value={filterForm.search}
+            prefixIcon={FaSearch}
+            onChange={handleControlChange}
+            placeholder="Search customer, email, or order ID..."
+            name="search"
+            aria-label="Search customer, email, or order ID"
+            className="sales-toolbar__search"
+          />
+          <div className="sales-toolbar__desktop-filters">{renderFilters()}</div>
+          <Button
+            type="button"
+            variant="secondary"
+            className="sales-toolbar__mobile-filter"
+            onClick={() => setFiltersOpen(true)}
+          >
+            Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+          </Button>
+        </section>
+      )}
+
+      {hasOrders && (
+        <div className="sales-collection-meta">
+          <span>{resultCountLabel}</span>
+          {hasActiveRefinement && (
+            <Button type="button" variant="tertiary" size="sm" onClick={clearFilters}>
+              Clear filters
+            </Button>
+          )}
+        </div>
+      )}
+
+      {renderState() || (
+        <>
+          <section className="sales-ledger" aria-label="Orders ledger">
+            <div className="sales-ledger__header" aria-hidden="true">
+              <span>Date</span>
+              <span>Customer</span>
+              <span>Product</span>
+              <span>Status</span>
+              <span>Type</span>
+              <span>Amount</span>
+            </div>
+            <div className="sales-ledger__rows">
+              {pagedOrders.map((order) => (
+                <OrderLedgerRow
+                  key={order.id}
+                  order={order}
+                  onOpen={() => openOrder(order.id)}
+                />
+              ))}
+            </div>
+          </section>
+
+          {totalPages > 1 && (
+            <nav className="sales-pagination" aria-label="Order pages">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={currentPage === 0}
+                onClick={() => setPage((value) => Math.max(0, value - 1))}
+              >
+                Previous
+              </Button>
+              <span>
+                Page {currentPage + 1} of {totalPages}
+              </span>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={currentPage >= totalPages - 1}
+                onClick={() =>
+                  setPage((value) => Math.min(totalPages - 1, value + 1))
+                }
+              >
+                Next
+              </Button>
+            </nav>
+          )}
+        </>
+      )}
+
+      <OrderDetailDrawer order={selectedOrder} open={Boolean(selectedOrder)} onClose={closeOrder} />
+
+      <Drawer
+        open={filtersOpen}
+        title={<h2 className="sales-filter-title">Filters</h2>}
+        onClose={() => setFiltersOpen(false)}
+        className="sales-filters-drawer"
+      >
+        {renderFilters(true)}
+      </Drawer>
+    </div>
+  );
+};
+
+interface OrderLedgerRowProps {
+  order: SalesOrder;
+  onOpen: () => void;
+}
+
+const OrderLedgerRow: React.FC<OrderLedgerRowProps> = ({ order, onOpen }) => {
+  const customerContent = (
+    <>
+      <span className="sales-ledger-row__primary">{order.customer.name}</span>
+      <span>{order.customer.email}</span>
+    </>
+  );
+  const productContent = (
+    <>
+      <span className="sales-ledger-row__primary">{order.product.name}</span>
+      <span>{order.product.type}</span>
+    </>
+  );
+
+  return (
+    <article className="sales-ledger-row">
+      <button
+        type="button"
+        className="sales-ledger-row__date"
+        onClick={onOpen}
+        aria-label={`Open ${order.id} order detail`}
+      >
+        <span>{formatSalesShortDate(order.orderedAt)}</span>
+        <span>{order.id}</span>
+      </button>
+
+      <div className="sales-ledger-row__customer">
+        {order.customer.id ? (
+          <Link
+            to={`/app/customers/${order.customer.id}`}
+            aria-label={`Open ${order.customer.name} customer profile`}
+          >
+            {customerContent}
+          </Link>
+        ) : (
+          <span className="sales-ledger-row__stack">{customerContent}</span>
+        )}
+      </div>
+
+      <div className="sales-ledger-row__product">
+        {order.product.id ? (
+          <Link
+            to={`/app/products/edit/${order.product.id}`}
+            aria-label={`Open ${order.product.name} workspace`}
+          >
+            {productContent}
+          </Link>
+        ) : (
+          <span className="sales-ledger-row__stack">{productContent}</span>
+        )}
+      </div>
+
+      <div className="sales-ledger-row__status">
+        <StatusBadge
+          label={orderStatusLabel[order.status]}
+          tone={orderStatusTone[order.status]}
+        />
+      </div>
+      <div className="sales-ledger-row__type">{orderTypeLabel[order.type]}</div>
+      <div className="sales-ledger-row__amount">
+        {formatSalesMoney(order.amountCents, order.currency)}
+      </div>
+    </article>
+  );
+};
+
+interface OrderDetailDrawerProps {
+  order?: SalesOrder;
+  open: boolean;
+  onClose: () => void;
+}
+
+const OrderDetailDrawer: React.FC<OrderDetailDrawerProps> = ({
+  order,
+  open,
+  onClose,
+}) => {
+  if (!order) {
+    return null;
+  }
+
+  return (
+    <Drawer
+      open={open}
+      title={
+        <div className="order-detail-title">
+          <span>Order #{order.id}</span>
+          <StatusBadge
+            label={orderStatusLabel[order.status]}
+            tone={orderStatusTone[order.status]}
+          />
+        </div>
+      }
+      onClose={onClose}
+      className="order-detail-drawer"
+    >
+      <div className="order-detail">
+        <section className="order-detail-hero" aria-label="Order summary">
+          <strong>{formatSalesMoney(order.amountCents, order.currency)}</strong>
+          <span>{orderTypeLabel[order.type]}</span>
+          <time dateTime={order.orderedAt}>{formatSalesDateTime(order.orderedAt)}</time>
+        </section>
+
+        <DetailSection title="Customer">
+          <p className="order-detail__primary">{order.customer.name}</p>
+          <p>{order.customer.email}</p>
+          {order.customer.id && (
+            <Link to={`/app/customers/${order.customer.id}`}>View customer</Link>
+          )}
+        </DetailSection>
+
+        <DetailSection title="Product">
+          <div className="order-detail-product">
+            {order.product.thumbnailUrl && (
+              <img src={order.product.thumbnailUrl} alt="" aria-hidden="true" />
+            )}
+            <div>
+              <p className="order-detail__primary">{order.product.name}</p>
+              <p>{order.product.type}</p>
+              {order.product.id && (
+                <Link to={`/app/products/edit/${order.product.id}`}>
+                  Open product workspace
+                </Link>
+              )}
+            </div>
+          </div>
+        </DetailSection>
+
+        <DetailSection title="Payment">
+          <DefinitionList
+            rows={[
+              ['Provider', order.provider],
+              ['Payment method', order.paymentMethod],
+              ['Transaction ID', order.transactionId],
+              ['Payment date', formatSalesDateTime(order.paymentDate)],
+              ['Currency', order.currency],
+            ]}
+          />
+        </DetailSection>
+
+        <DetailSection title="Order Summary">
+          <DefinitionList
+            rows={order.summaryRows.map((row) => [
+              row.label,
+              formatSalesMoney(row.amountCents, order.currency),
+            ])}
+          />
+        </DetailSection>
+
+        <DetailSection title="Access">
+          <p className="order-detail__primary">{order.access.label}</p>
+          {order.access.detail && <p>{order.access.detail}</p>}
+        </DetailSection>
+
+        {order.subscription && (
+          <DetailSection title="Subscription">
+            <DefinitionList
+              rows={[
+                ['Membership', order.product.name],
+                [
+                  'Billing price',
+                  `${formatSalesMoney(
+                    order.subscription.priceCents,
+                    order.subscription.currency,
+                  )} / ${order.subscription.interval}`,
+                ],
+                ['State', subscriptionStateLabel[order.subscription.state]],
+                ['Next billing', formatSalesDateTime(order.subscription.nextBillingAt)],
+              ]}
+            />
+          </DetailSection>
+        )}
+
+        {order.refund && (
+          <DetailSection title="Refund">
+            <DefinitionList
+              rows={[
+                [
+                  'Amount refunded',
+                  formatSalesMoney(order.refund.amountCents, order.currency),
+                ],
+                ['Refund date', formatSalesDateTime(order.refund.refundedAt)],
+                ['Reason', order.refund.reason],
+                ['Access result', order.access.label],
+              ]}
+            />
+          </DetailSection>
+        )}
+
+        {order.failure && (
+          <DetailSection title="Failed payment">
+            <p className="order-detail__primary">Payment failed</p>
+            <p>{order.failure.message}</p>
+            {order.failure.retryAt && (
+              <p>Retry scheduled {formatSalesDateTime(order.failure.retryAt)}</p>
+            )}
+          </DetailSection>
+        )}
+      </div>
+    </Drawer>
+  );
+};
+
+const DetailSection: React.FC<{ title: string; children: React.ReactNode }> = ({
+  title,
+  children,
+}) => (
+  <section className="order-detail-section">
+    <h2>{title}</h2>
+    {children}
+  </section>
 );
+
+const DefinitionList: React.FC<{ rows: Array<[string, string | undefined]> }> = ({
+  rows,
+}) => {
+  const visibleRows = rows.filter(([, value]) => Boolean(value));
+
+  return (
+    <dl className="order-detail-definition-list">
+      {visibleRows.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+};
 
 export default SalesPage;

--- a/src/domains/app/pages/creator-specific/sales-page/sales-page.styles.scss
+++ b/src/domains/app/pages/creator-specific/sales-page/sales-page.styles.scss
@@ -1,0 +1,536 @@
+@use '../../../../../styles/index.scss' as *;
+
+.sales-page {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-5;
+}
+
+.sales-header {
+  h1 {
+    margin: 0;
+  }
+
+  p {
+    margin: $spacing-2 0 0;
+    color: var(--text-secondary);
+    font-size: 0.9375rem;
+  }
+}
+
+.sales-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: $spacing-3;
+}
+
+.sales-metric {
+  display: grid;
+  gap: $spacing-1;
+  min-width: 0;
+  padding: $spacing-4;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-1);
+
+  &__label,
+  &__trend {
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    font-weight: 700;
+  }
+
+  strong {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 1.35rem;
+    line-height: 1.15;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &--favorable .sales-metric__trend {
+    color: var(--success);
+  }
+
+  &--unfavorable .sales-metric__trend {
+    color: var(--error);
+  }
+}
+
+.sales-toolbar {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) auto;
+  gap: $spacing-3;
+  align-items: center;
+
+  &__desktop-filters,
+  &__filters {
+    display: contents;
+  }
+
+  &__filters {
+    display: flex;
+    gap: $spacing-3;
+    align-items: center;
+  }
+
+  &__select {
+    min-width: 9.5rem;
+  }
+
+  &__sort {
+    min-width: 12rem;
+  }
+
+  &__mobile-filter {
+    display: none;
+  }
+}
+
+.sales-filter-stack {
+  display: grid;
+  gap: $spacing-3;
+}
+
+.sales-filter-title {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.sales-collection-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 32px;
+  gap: $spacing-3;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.sales-ledger {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+
+  &__header,
+  .sales-ledger-row {
+    display: grid;
+    grid-template-columns:
+      minmax(8rem, 0.48fr) minmax(14rem, 1fr) minmax(14rem, 1fr)
+      minmax(7rem, 0.42fr) minmax(7rem, 0.42fr) minmax(6.5rem, 0.36fr);
+    align-items: center;
+    column-gap: $spacing-4;
+  }
+
+  &__header {
+    padding: 0 $spacing-4;
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  &__rows {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-2;
+  }
+}
+
+.sales-ledger-row {
+  min-height: 84px;
+  padding: $spacing-3 $spacing-4;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-1);
+  transition:
+    background-color $transition-fast,
+    border-color $transition-fast;
+
+  &:hover {
+    border-color: var(--divider-strong);
+    background: var(--surface-interactive);
+  }
+
+  a,
+  &__stack,
+  &__date {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: $spacing-1;
+    align-items: flex-start;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    text-decoration: none;
+  }
+
+  a:hover {
+    color: var(--text-primary);
+  }
+
+  &__date {
+    min-height: 44px;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  &__primary,
+  &__date span:first-child,
+  &__amount,
+  &__type {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 0.9375rem;
+    font-weight: 800;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__amount {
+    text-align: right;
+  }
+
+  &__type {
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+  }
+}
+
+.sales-state {
+  display: flex;
+  min-height: 18rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-3;
+  padding: $spacing-6;
+  text-align: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-1);
+
+  h2 {
+    margin: 0;
+    font-size: 1.25rem;
+  }
+
+  p {
+    max-width: 34rem;
+    margin: 0;
+    color: var(--text-secondary);
+  }
+
+  &__link {
+    color: var(--brand-primary);
+    font-weight: 800;
+    text-decoration: none;
+  }
+}
+
+.sales-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: $spacing-3;
+  color: var(--text-secondary);
+}
+
+.order-detail-title {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-2;
+
+  > span:first-child {
+    color: var(--text-primary);
+    font-size: 1.125rem;
+    font-weight: 900;
+  }
+}
+
+.order-detail {
+  display: grid;
+  gap: $spacing-3;
+
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+  }
+
+  a {
+    color: var(--brand-primary);
+    font-size: 0.8125rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  &__primary {
+    color: var(--text-primary) !important;
+    font-weight: 800;
+  }
+}
+
+.order-detail-hero {
+  display: grid;
+  gap: $spacing-1;
+  padding: $spacing-4;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-2);
+
+  strong {
+    color: var(--text-primary);
+    font-size: 1.75rem;
+    line-height: 1.1;
+  }
+
+  span,
+  time {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+  }
+}
+
+.order-detail-section {
+  display: grid;
+  gap: $spacing-3;
+  padding: $spacing-4;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-2);
+
+  h2 {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+}
+
+.order-detail-product {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: $spacing-3;
+  align-items: center;
+
+  img {
+    width: 56px;
+    height: 56px;
+    object-fit: cover;
+    border: 1px solid var(--border-subtle);
+    border-radius: $radius-sm;
+    background: var(--surface-1);
+  }
+
+  div {
+    display: grid;
+    min-width: 0;
+    gap: $spacing-1;
+  }
+}
+
+.order-detail-definition-list {
+  display: grid;
+  gap: $spacing-2;
+  margin: 0;
+
+  div {
+    display: grid;
+    grid-template-columns: minmax(7rem, 0.45fr) minmax(0, 1fr);
+    gap: $spacing-3;
+  }
+
+  dt {
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    font-weight: 800;
+  }
+
+  dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+  }
+}
+
+@media (max-width: $bp-desktop) {
+  .sales-toolbar {
+    grid-template-columns: 1fr;
+
+    &__desktop-filters {
+      display: block;
+    }
+
+    &__filters {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    &__select,
+    &__sort {
+      min-width: 0;
+    }
+  }
+
+  .sales-ledger {
+    &__header,
+    .sales-ledger-row {
+      grid-template-columns:
+        minmax(13rem, 1fr) minmax(13rem, 1fr) minmax(7rem, auto)
+        minmax(6.5rem, auto);
+    }
+
+    &__header span:nth-child(1),
+    &__header span:nth-child(5) {
+      display: none;
+    }
+  }
+
+  .sales-ledger-row {
+    &__date,
+    &__type {
+      grid-column: 1 / 2;
+      padding-left: 0;
+    }
+
+    &__date {
+      grid-row: 2;
+      min-height: 0;
+      margin-top: -$spacing-2;
+    }
+
+    &__type {
+      display: none;
+    }
+  }
+}
+
+@media (max-width: $bp-tablet) {
+  .sales-page {
+    gap: $spacing-4;
+  }
+
+  .sales-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sales-toolbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+
+    &__desktop-filters {
+      display: none;
+    }
+
+    &__mobile-filter {
+      display: inline-flex;
+    }
+  }
+
+  .sales-ledger {
+    &__header {
+      display: none;
+    }
+
+    .sales-ledger-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas:
+        'customer status'
+        'product product'
+        'amount date'
+        'type type';
+      row-gap: $spacing-2;
+      column-gap: $spacing-3;
+    }
+  }
+
+  .sales-ledger-row {
+    min-height: 0;
+    padding: $spacing-3;
+
+    &__date {
+      grid-area: date;
+      align-items: flex-end;
+      margin: 0;
+    }
+
+    &__date span:nth-child(2) {
+      display: none;
+    }
+
+    &__customer {
+      grid-area: customer;
+      min-width: 0;
+    }
+
+    &__product {
+      grid-area: product;
+      min-width: 0;
+    }
+
+    &__status {
+      grid-area: status;
+      justify-self: end;
+    }
+
+    &__amount {
+      grid-area: amount;
+      align-self: center;
+      text-align: left;
+    }
+
+    &__type {
+      display: block;
+      grid-area: type;
+      padding: 0;
+    }
+  }
+}
+
+@media (max-width: $bp-mobile) {
+  .sales-metrics {
+    gap: $spacing-2;
+  }
+
+  .sales-metric {
+    padding: $spacing-3;
+
+    strong {
+      font-size: 1rem;
+      white-space: normal;
+    }
+  }
+
+  .sales-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sales-toolbar__mobile-filter {
+    width: 100%;
+  }
+
+  .sales-collection-meta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sales-state {
+    min-height: 14rem;
+    padding: $spacing-5 $spacing-4;
+  }
+
+  .sales-pagination {
+    justify-content: space-between;
+  }
+
+  .order-detail-definition-list div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: $spacing-1;
+  }
+}

--- a/src/shared/ui/drawer/drawer.component.test.tsx
+++ b/src/shared/ui/drawer/drawer.component.test.tsx
@@ -1,0 +1,44 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import Drawer from './drawer.component';
+
+describe('<Drawer />', () => {
+  it('closes on Escape', () => {
+    const onClose = jest.fn();
+    render(
+      <Drawer open title="Details" onClose={onClose}>
+        <button type="button">Inside</button>
+      </Drawer>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('restores focus to the trigger after close', () => {
+    const { rerender } = render(
+      <>
+        <button type="button">Open drawer</button>
+        <Drawer open title="Details" onClose={jest.fn()}>
+          <button type="button">Inside</button>
+        </Drawer>
+      </>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Open drawer' });
+    trigger.focus();
+
+    rerender(
+      <>
+        <button type="button">Open drawer</button>
+        <Drawer open={false} title="Details" onClose={jest.fn()}>
+          <button type="button">Inside</button>
+        </Drawer>
+      </>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Open drawer' })).toHaveFocus();
+  });
+});

--- a/src/shared/ui/drawer/drawer.component.tsx
+++ b/src/shared/ui/drawer/drawer.component.tsx
@@ -1,0 +1,148 @@
+import React, { ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import clsx from 'clsx';
+import { HiX } from 'react-icons/hi';
+
+import { Button } from '../button';
+import { GalIcon } from '../gal-icon';
+import { getCssVar } from '@shared/utils';
+
+import './drawer.styles.scss';
+
+interface DrawerProps {
+  open: boolean;
+  title: ReactNode;
+  children: ReactNode;
+  onClose: () => void;
+  footer?: ReactNode;
+  className?: string;
+  closeLabel?: string;
+}
+
+const focusableSelector = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const Drawer: React.FC<DrawerProps> = ({
+  open,
+  title,
+  children,
+  onClose,
+  footer,
+  className,
+  closeLabel = 'Close drawer',
+}) => {
+  const panelRef = useRef<HTMLElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    window.setTimeout(() => {
+      const firstFocusable = panelRef.current?.querySelector<HTMLElement>(
+        focusableSelector,
+      );
+      firstFocusable?.focus();
+    }, 0);
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      previousFocusRef.current?.focus?.();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !panelRef.current) {
+        return;
+      }
+
+      const focusable = Array.from(
+        panelRef.current.querySelectorAll<HTMLElement>(focusableSelector),
+      );
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        panelRef.current.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="drawer-layer">
+      <button
+        type="button"
+        className="drawer-overlay"
+        aria-label={closeLabel}
+        onClick={onClose}
+      />
+      <section
+        ref={panelRef}
+        className={clsx('drawer-panel', className)}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawer-title"
+        tabIndex={-1}
+      >
+        <header className="drawer-header">
+          <div id="drawer-title" className="drawer-title">
+            {title}
+          </div>
+          <Button
+            type="button"
+            variant="tertiary"
+            size="icon"
+            aria-label={closeLabel}
+            onClick={onClose}
+          >
+            <GalIcon icon={HiX} size={20} color={getCssVar('--text-primary')} />
+          </Button>
+        </header>
+        <div className="drawer-body">{children}</div>
+        {footer && <footer className="drawer-footer">{footer}</footer>}
+      </section>
+    </div>,
+    document.body,
+  );
+};
+
+export default Drawer;

--- a/src/shared/ui/drawer/drawer.styles.scss
+++ b/src/shared/ui/drawer/drawer.styles.scss
@@ -1,0 +1,87 @@
+@use '../../../styles/index' as *;
+
+.drawer-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drawer-overlay {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(0, 0, 0, 0.48);
+  cursor: default;
+}
+
+.drawer-panel {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: min(31rem, calc(100vw - 2rem));
+  height: 100%;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  border-left: 1px solid var(--border-strong);
+  background: var(--surface-1);
+  box-shadow: -20px 0 44px rgba(0, 0, 0, 0.28);
+  animation: drawer-enter 180ms ease-out;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.drawer-header,
+.drawer-footer {
+  padding: $spacing-4;
+  border-color: var(--border-subtle);
+}
+
+.drawer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $spacing-3;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.drawer-title {
+  min-width: 0;
+}
+
+.drawer-body {
+  overflow: auto;
+  min-width: 0;
+  padding: $spacing-4;
+}
+
+.drawer-footer {
+  border-top: 1px solid var(--border-subtle);
+}
+
+@keyframes drawer-enter {
+  from {
+    transform: translateX(24px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer-panel {
+    animation: none;
+  }
+}
+
+@media (max-width: $bp-mobile) {
+  .drawer-panel {
+    width: 100vw;
+    border-left: 0;
+  }
+}

--- a/src/shared/ui/drawer/index.ts
+++ b/src/shared/ui/drawer/index.ts
@@ -1,0 +1,1 @@
+export { default as Drawer } from './drawer.component';

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -17,6 +17,8 @@ export * from './rich-text-editor';
 export * from './select';
 export * from './star-rating';
 export * from './status-chip';
+export * from './status-badge';
+export * from './drawer';
 export * from './tabs';
 export * from './textarea';
 export * from './toggle';

--- a/src/shared/ui/status-badge/index.ts
+++ b/src/shared/ui/status-badge/index.ts
@@ -1,0 +1,2 @@
+export { default as StatusBadge } from './status-badge.component';
+export type { StatusBadgeSize, StatusBadgeTone } from './status-badge.component';

--- a/src/shared/ui/status-badge/status-badge.component.test.tsx
+++ b/src/shared/ui/status-badge/status-badge.component.test.tsx
@@ -1,0 +1,17 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import StatusBadge from './status-badge.component';
+
+describe('<StatusBadge />', () => {
+  it('renders visible status text and semantic tone class', () => {
+    render(<StatusBadge label="Paid" tone="success" />);
+
+    expect(screen.getByText('Paid')).toBeVisible();
+    expect(screen.getByText('Paid').closest('.status-badge')).toHaveClass(
+      'status-badge--success',
+    );
+  });
+});

--- a/src/shared/ui/status-badge/status-badge.component.tsx
+++ b/src/shared/ui/status-badge/status-badge.component.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import clsx from 'clsx';
+import { IconType } from 'react-icons';
+
+import { GalIcon } from '../gal-icon';
+
+import './status-badge.styles.scss';
+
+export type StatusBadgeTone = 'success' | 'warning' | 'danger' | 'neutral' | 'info';
+export type StatusBadgeSize = 'sm' | 'md';
+
+interface StatusBadgeProps {
+  label: string;
+  tone?: StatusBadgeTone;
+  icon?: IconType;
+  size?: StatusBadgeSize;
+  className?: string;
+}
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({
+  label,
+  tone = 'neutral',
+  icon,
+  size = 'md',
+  className,
+}) => (
+  <span
+    className={clsx(
+      'status-badge',
+      `status-badge--${tone}`,
+      `status-badge--${size}`,
+      className,
+    )}
+  >
+    {icon && <GalIcon icon={icon} size={size === 'sm' ? 13 : 15} aria-hidden="true" />}
+    <span>{label}</span>
+  </span>
+);
+
+export default StatusBadge;

--- a/src/shared/ui/status-badge/status-badge.styles.scss
+++ b/src/shared/ui/status-badge/status-badge.styles.scss
@@ -1,0 +1,55 @@
+@use '../../../styles/index' as *;
+
+.status-badge {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 28px;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-1;
+  padding: 0 $spacing-3;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-sm;
+  color: var(--text-secondary);
+  background: var(--surface-2);
+  font-size: 0.75rem;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+
+  &--sm {
+    min-height: 24px;
+    padding: 0 $spacing-2;
+    font-size: 0.6875rem;
+  }
+
+  &--success {
+    color: var(--success);
+    border-color: rgba(var(--success-rgb), 0.35);
+    background: rgba(var(--success-rgb), 0.1);
+  }
+
+  &--warning {
+    color: var(--warning);
+    border-color: rgba(var(--brand-primary-rgb), 0.35);
+    background: rgba(var(--brand-primary-rgb), 0.1);
+  }
+
+  &--danger {
+    color: var(--error);
+    border-color: rgba(var(--error-rgb), 0.35);
+    background: rgba(var(--error-rgb), 0.1);
+  }
+
+  &--info {
+    color: var(--info);
+    border-color: rgba(85, 199, 232, 0.35);
+    background: rgba(85, 199, 232, 0.1);
+  }
+
+  &--neutral {
+    color: var(--text-secondary);
+    border-color: var(--divider-default);
+    background: var(--overlay-hover);
+  }
+}

--- a/src/shared/ui/status-chip/status-chip.component.tsx
+++ b/src/shared/ui/status-chip/status-chip.component.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ProductStatus } from 'core/api/models';
+import { StatusBadge, StatusBadgeTone } from '../status-badge';
 
 import './status-chip.styles.scss';
 
@@ -8,10 +9,18 @@ interface TabsProps {
   status: ProductStatus;
 }
 
+const productStatusTone: Record<string, StatusBadgeTone> = {
+  PUBLISHED: 'success',
+  DRAFT: 'neutral',
+  HIDDEN: 'warning',
+};
+
 const StatusChip: React.FC<TabsProps> = ({ status }) => (
-  <div className={`status-chip status-chip__${status}`}>
-    <span>{status}</span>
-  </div>
+  <StatusBadge
+    className={`status-chip status-chip__${status}`}
+    label={status}
+    tone={productStatusTone[status] ?? 'neutral'}
+  />
 );
 
 export default StatusChip;


### PR DESCRIPTION
## Summary

Implements the Creator Sales experience at `/app/sales`, replacing the previous placeholder with a responsive sales ledger and contextual order details.

Sales data remains deterministic fixture data behind mock mode. No production order, payment, refund, subscription, or entitlement APIs are introduced by this PR.

## What changed

- Added Creator Sales metrics:
  - Revenue
  - Orders
  - Refunds
  - Failed payments
- Added responsive orders ledger with:
  - customer/email/order ID search
  - date filtering
  - status filtering
  - product filtering
  - sorting
  - pagination
  - empty and no-result states
- Added order statuses:
  - Paid
  - Failed
  - Refunded
  - Pending
- Added order types:
  - One-time
  - Subscription
  - Renewal
- Added contextual order details using `/app/sales?order=...`
- Added order detail content for customer, product, payment, access, subscription, refund, and failed-payment context where applicable.
- Added deterministic Sales fixtures covering the major transaction states.
- Added responsive desktop, tablet, and mobile layouts.

## Shared UI

- Added reusable `Drawer` primitive with:
  - overlay handling
  - Escape-to-close
  - focus handling/restoration
  - body scroll locking
  - full-screen mobile behavior
- Added reusable semantic `StatusBadge`.
- Updated `StatusChip` to compose `StatusBadge`.
- Kept business/domain status mapping outside the shared presentation primitive.

## Architecture / boundaries

- Sales remains frontend-only fixture UX under `REACT_APP_USE_MOCKS=true`.
- Refunds are represented as status/detail on the original order rather than as a separate ledger entity.
- Order selection is query-state driven to support deep links, refresh, and browser navigation.
- Production order/payment/refund/subscription/entitlement contracts remain future backend work.
- No financial mutation actions such as issuing refunds, retrying payments, or modifying subscriptions are implemented.

## Documentation

Updated `PROJECT_CONTEXT.md` with:

- Creator Sales architecture and current feature state
- Sales fixture/backend boundary
- `/app/sales?order=...` contextual-detail pattern
- shared `Drawer` conventions
- shared `StatusBadge` responsibility boundary
- responsive Sales conventions

## Validation

- `npm run tsc` ✅
- Full Jest suite: 61 suites / 372 tests passed ✅
- `npm run lint` ✅ — no errors; existing warnings remain
- Dashboard, Products, and Customers smoke-checked for visual regressions