### PR TITLE
Creator Redesign — Storefront Builder V2

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -61,6 +61,7 @@ Creator/Admin management routes are visually and structurally separated from buy
 - Desktop Creator management uses a persistent collapsible sidebar and a separate account/user control.
 - Tablet/mobile Creator management uses a compact top bar with a drawer navigation.
 - Product builder routes (`/app/products/create`, `/app/products/edit/*`, and `/app/admin/products/create`) intentionally render outside `CreatorAppShell` so editing can use a focused product workspace.
+- Routes can request the Creator sidebar collapse through `collapseSidebarOnLoad` route metadata. Product edit routes and the Storefront Builder use this existing shell/sidebar behavior.
 - Marketplace/customer routes still use the older `TopNavbar` shell; the marketplace Explore/Search experience is not part of the Creator management IA. The public Storefront route intentionally bypasses both Creator management chrome and the older marketplace chrome.
 
 Current Creator IA:
@@ -164,7 +165,7 @@ Implemented / reasonably wired:
 - Creator Customers management area with a customer list and dedicated customer detail route.
 - Creator Sales management area with overview metrics, an orders ledger, local search/filter/sort/date preset controls, local pagination, responsive layout, empty/no-result states, and contextual order detail inspection.
 - Creator Analytics management area with period-scoped business metrics, performance visualization, product ranking, customer growth, membership health, and payment health.
-- Creator Storefront management area with public URL/copy affordance, profile summary, product visibility information, featured-product selection, product ordering controls, and a live public preview.
+- Creator Storefront Builder at `/app/storefront`, where the shared public Storefront presentation is the live editing surface for profile fields, theme, featured product, and product ordering.
 - Public Storefront page at `/app/store/:creatorId` with creator identity/profile information, featured product when applicable, and a customer-facing published-product catalogue.
 - Product create/edit builder for course/download/consultation/membership basics.
 - Membership builder integration with a Membership Content tab.
@@ -209,7 +210,7 @@ Confirmed:
 - Creator Customers has frontend contracts, services, Redux store integration, and HTTP mock responses for read-only list/detail data, but the production backend endpoints are not implemented yet. Purchase/order, entitlement/access, subscription/customer membership-state, waitlist, tags/notes persistence, and manual access-management backend ownership still need backend confirmation.
 - Creator Sales has frontend contracts, services, Redux store integration, and HTTP mock responses for summary, orders ledger, and order detail data, but the production backend endpoints are not implemented yet. Provider-safe financial mutations, refund/payment retry actions, subscription management, and entitlement mutation contracts are intentionally not implemented.
 - Creator Analytics has frontend contracts, services, Redux store integration, and HTTP mock responses for aggregate overview data, but the production backend endpoint is not implemented yet. Traffic, attribution, conversion, engagement, payout, cohort, and custom date-range analytics are intentionally not implemented.
-- Creator Storefront has frontend contracts, services, Redux store integration, and HTTP mock responses for the public read model and Creator configuration, but the production backend endpoints are not implemented yet. Theme/page-builder, custom-domain, SEO, and Storefront analytics contracts are intentionally not implemented.
+- Creator Storefront has frontend contracts, services, Redux store integration, and HTTP mock responses for the public read model and Creator configuration, but the production backend endpoints are not implemented yet. Storefront theme/config fields are frontend-wired through the backend-pending Storefront contracts; arbitrary page-builder blocks, custom-domain, SEO, and Storefront analytics contracts are intentionally not implemented.
 
 Deliberate temporary implementations:
 
@@ -224,7 +225,7 @@ Deliberate temporary implementations:
 - Creator Analytics runtime data path is Component → Redux → thunk → Analytics service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Creator Dashboard runtime data path is Component → Redux → thunk → Dashboard service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Public Storefront runtime data path is Component → Redux → thunk → Storefront service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
-- Creator Storefront config runtime data path is Component → Redux → thunk → Storefront service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
+- Creator Storefront Builder config runtime data path is Component → Redux → thunk → Storefront service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Membership domain runtime data path is Component → Redux → thunk → Membership service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Download upload deduping is local to the section editor instance.
 - Membership editor drafts, selected File objects, chooser/picker state, active editor state, and active builder tab remain local UI state.
@@ -335,38 +336,60 @@ Important Analytics boundary:
 
 ## Creator Storefront
 
-The Storefront work is split between an authenticated Creator/Admin management surface and a public customer-facing Storefront, with shared Storefront view-model and presentation logic under `src/domains/app/features/storefront`.
+Storefront V2 is split between an authenticated Creator/Admin Storefront Builder and a public customer-facing Storefront. Both routes share Storefront view-model utilities and the `StorefrontPublicPage` presentation under `src/domains/app/features/storefront`.
 
 Routes and shell integration:
 
-- Creator/Admin Storefront management workspace: `/app/storefront`.
+- Creator/Admin Storefront Builder: `/app/storefront`.
 - Public buyer-facing Storefront route: `/app/store/:creatorId`.
 - Legacy `/app/my-page-preview` redirects to `/app/storefront`; the old `user-page-preview` implementation has been removed.
-- Storefront management renders inside `CreatorAppShell`.
+- Storefront Builder renders inside `CreatorAppShell`, and the `/app/storefront` route uses `collapseSidebarOnLoad` route metadata so the Creator sidebar collapses with the same shell/sidebar pattern used by builder-style routes.
 - The public Storefront route renders outside Creator management chrome and outside the older marketplace `TopNavbar` shell.
 
-Current Storefront management patterns:
+Current Storefront Builder patterns:
 
-- The management page shows Storefront status, public URL, copy-link affordance, public profile summary, product visibility information, featured-product selection, product ordering controls, and a live preview.
-- Public profile information reuses existing account/profile user fields such as name, title, tagline, bio, website, image, and social links instead of introducing a separate Storefront profile model.
-- Featured selection and ordering controls persist through the backend-pending Creator Storefront config contract. Profile fields remain User/Profile-owned; product identities, statuses, prices, and thumbnails remain Product-owned.
-- The live preview uses the same shared `StorefrontPublicPage` presentation as the public Storefront route, with preview styling applied by prop.
+- `/app/storefront` is a live Storefront Builder, not the previous management-controls plus separate preview layout.
+- The builder itself consumes the same `StorefrontPublicPage` used by the public route, so the shared public presentation is the live preview/editing surface.
+- Builder chrome is compact and includes unsaved-state copy, `Open public Storefront`, copy-link, `Reset changes`, and `Save changes` actions.
+- Public-facing profile fields are editable inline where implemented: display name, title, tagline, bio, website, and public email. Inline editors use edit buttons, Save/Cancel actions, existing shared input/textarea/button/popover primitives, and `updateUserDetails` from the Auth/User profile flow.
+- Avatar/image inline editing is not implemented. The Settings image UI does not currently expose a clean reusable persisted upload flow for Storefront Builder to reuse.
+- Public profile information reuses existing User/Profile fields instead of introducing a separate Storefront profile model. Storefront config must not duplicate display name, title, tagline, bio, website, image, social links, or public email.
+- `publicEmail` is User/Profile-owned. The Storefront view model uses `publicEmail` when set and falls back to the login email when no separate public email is configured. Settings and Storefront share the same public-email concept and the same info-popover copy: "This is the email shown on your storefront. It can be different from the email you use to sign in."
+- Storefront-owned configuration is edited as one local draft containing `theme`, `featuredProductId`, and `productOrderIds`.
+- Theme, featured-product, and ordering changes update the rendered builder immediately but do not PATCH individually.
+- `Save changes` persists the full draft Storefront config through `PATCH api/creator/storefront`; `Reset changes` restores the last persisted Redux config.
+- Product status visibility remains explicit in the builder controls, but Draft/Hidden products are not rendered through the shared public Storefront presentation.
+
+Current Storefront theme/customization patterns:
+
+- `StorefrontTheme` supports `appearance`, `accentColor`, and `typography`.
+- Appearance options are `LIGHT` and `DARK`.
+- Typography options are `MODERN`, `CLASSIC`, and `FRIENDLY`.
+- Brand color supports curated swatches plus a custom color input.
+- Theme rendering is Storefront-scoped through `StorefrontPublicPage` classes and CSS variables such as `--storefront-accent`; it does not switch the global Creator app theme.
+- Accent color affects public Storefront CTAs, eyebrow/accent text, creator initials/accent details, borders, and related highlights.
+- The customization UI is a floating FAB and compact panel on larger screens. At mobile width the same controls open through the shared `Drawer` infrastructure.
 
 Current public Storefront patterns:
 
-- `StorefrontPublicPage` renders creator identity/profile information, optional website link, a featured product when the featured product is publicly visible, and a catalogue of public products.
+- `StorefrontPage` loads the public read model through Redux and `GET api/storefronts/:creatorId`, maps it with `getStorefrontViewModelFromPublicStorefront`, and renders `StorefrontPublicPage`.
+- `StorefrontPublicPage` renders creator identity/profile information, optional website link, public email/contact links, social links, a featured product when the featured product is publicly visible, and a catalogue of public products.
+- Public Storefront receives and applies the persisted theme from the public read model, with `DEFAULT_STOREFRONT_THEME` as a fallback when theme is absent.
 - Product visibility is centralized in Storefront utilities: `PUBLISHED` products are publicly visible; `DRAFT` and `HIDDEN` products are not publicly visible.
 - Invalid or unavailable featured-product IDs fall back to the first public product.
-- Course, Download, Consultation, and Membership products are all represented with Storefront type labels.
-- The Storefront uses a fixed customer-facing layout. There is no page builder, theme customization system, custom-domain setup, SEO configuration, Storefront analytics, coupons, campaigns, newsletters, automations, attribution, or Reviews surface.
+- Course, Download, Consultation, and Membership products are all represented with Storefront type labels. Membership remains supported in public rendering.
 - Empty and unavailable states are explicit, including the public empty catalogue state when no products are published.
 
 Current Storefront data boundary:
 
-- The public Storefront route uses the backend-pending `api/storefronts/:creatorId` read-model contract through Redux/services/Axios. The backend should return public creator presentation fields and public products rather than requiring the buyer-facing page to orchestrate User and Product requests.
-- Creator Storefront management uses the backend-pending `api/creator/storefront` config contract through Redux/services/Axios. The config owns `featuredProductId` and `productOrderIds` only.
-- Creator Storefront management combines Storefront config with Product-owned summaries from existing Product Redux/API data and User/Profile-owned account data from Auth.
-- Local deterministic Storefront data exists only behind ignored HTTP mocks when `REACT_APP_USE_MOCKS=true`. Mock creator IDs, profile content, example products, product order, and featured selections are local inspection aids, not product contracts.
+- The public Storefront route uses the backend-pending `api/storefronts/:creatorId` read-model contract through Redux/services/Axios. The backend should return public creator presentation fields, public products, featured product ID, and persisted theme rather than requiring the buyer-facing page to orchestrate User, Product, and Storefront config requests.
+- Creator Storefront Builder uses the backend-pending `api/creator/storefront` config contract through Redux/services/Axios. The config owns only `theme`, `featuredProductId`, and `productOrderIds`.
+- Storefront service functions live under `src/core/api/services/storefront`, thunks/state live in `src/core/store/storefront-store/storefront.slice.ts`, and selectors are intentionally kept in `src/core/store/storefront-store/storefront.selectors.ts`.
+- Product remains the owner of catalogue/product data, statuses, prices, thumbnails, and public visibility eligibility.
+- User/Profile remains the owner of public profile identity and contact fields, including `publicEmail`.
+- Creator Storefront Builder combines Storefront config with Product-owned summaries from existing Product Redux/API data and User/Profile-owned account data from Auth.
+- Local deterministic Storefront data exists only behind ignored HTTP mocks when `REACT_APP_USE_MOCKS=true`. Mock creator IDs, profile content, theme values, example products, product order, and featured selections are local inspection aids, not product contracts.
+- Storefront V2 does not implement arbitrary page-builder blocks, custom domains, SEO management, Storefront analytics, coupons, campaigns, newsletters, automations, attribution, or Reviews surfaces.
 
 ## Creator Products Management
 
@@ -438,7 +461,7 @@ Implemented examples:
 - Customers desktop/tablet list/table becomes mobile customer cards while preserving the stacked mobile filter controls.
 - Sales desktop orders ledger becomes tablet/mobile transaction cards, and mobile secondary filters move into the shared Drawer.
 - Analytics desktop chart/product/secondary grids collapse into single-column tablet/mobile layouts, with product ranking rows reflowing instead of overflowing.
-- Storefront management stacks controls and preview on narrower screens, while the public Storefront hero and product catalogue reflow into single-column customer-facing layouts.
+- Storefront Builder uses compact builder chrome, a floating customization control, and mobile Drawer-based customization behavior while the shared public Storefront hero and product catalogue reflow into single-column customer-facing layouts.
 - Product workspace navigation adapts on narrow screens while preserving the focused editing shell.
 
 Avoid hardcoding viewport-specific pixel values into this document; inspect the SCSS breakpoints and component styles when implementing a responsive change.
@@ -453,15 +476,15 @@ Recent Git history includes admin role/product ownership work, Membership fronte
 - Membership added as a first-class frontend Product type.
 - Membership uses the shared builder shell, its own Membership Content tab, Product-backed recurring pricing controls, and Product-scoped Membership contracts for Course/Download included-product associations plus Post/Video/Resource content metadata.
 - Creator management shell and IA centered on Dashboard, Products, Customers, Sales, Analytics, Storefront, plus Settings utility navigation; Help remains disabled and Marketing is removed from the Creator MVP IA.
-- Creator Dashboard, Products, Customers, Sales, Analytics, and Storefront management visual redesigns.
-- Public Storefront implementation at `/app/store/:creatorId`, sharing Storefront presentation/view-model logic with the Creator live preview.
+- Creator Dashboard, Products, Customers, Sales, Analytics, and Storefront Builder visual redesigns.
+- Public Storefront implementation at `/app/store/:creatorId`, sharing Storefront presentation/view-model logic with the Creator Storefront Builder.
 - Focused Product Workspace shell for product editing.
 
 Likely next steps:
 
 - Polish/fix admin product owner filtering UX beyond raw owner ID.
 - Complete product detail UI using real backend fields.
-- Implement backend Storefront contracts before relying on production persistence for featured-product selection and product ordering; define separate contracts before adding Storefront-specific settings such as themes, page builder, custom domains, SEO, or analytics.
+- Implement backend Storefront contracts before relying on production persistence for Storefront configuration; define separate contracts before adding arbitrary page-builder blocks, custom domains, SEO, or analytics.
 - Fix known warnings and cart removal bug.
 - Verify product builder contracts for lesson content, quiz persistence, media upload, and consultation scheduling.
 - Define backend contracts for Membership native content, included-product relationships, recurring pricing, subscription checkout, and entitlement/member access before persisting Membership-specific fields.

--- a/src/core/api/models/storefront/storefront.ts
+++ b/src/core/api/models/storefront/storefront.ts
@@ -1,13 +1,24 @@
 import { ProductStatus, ProductType } from '../product';
 import { User } from '../user';
 
+export type StorefrontAppearance = 'LIGHT' | 'DARK';
+
+export type StorefrontTypography = 'MODERN' | 'CLASSIC' | 'FRIENDLY';
+
+export interface StorefrontTheme {
+  appearance: StorefrontAppearance;
+  accentColor: string;
+  typography: StorefrontTypography;
+}
 export interface PublicStorefrontCreator {
   id: string;
   displayName: string;
+  email?: string;
   title?: string;
   tagline?: string;
   bio?: string;
   website?: string;
+  publicEmail?: string;
   imageUrl?: string;
   socialLinks?: User['socialLinks'];
 }
@@ -27,16 +38,19 @@ export interface PublicStorefront {
   creator: PublicStorefrontCreator;
   featuredProductId?: string;
   products: PublicStorefrontProduct[];
+  theme: StorefrontTheme;
 }
 
 export interface CreatorStorefrontConfig {
   id?: string;
   featuredProductId?: string | null;
   productOrderIds: string[];
+  theme: StorefrontTheme;
   updatedAt?: string;
 }
 
 export interface CreatorStorefrontConfigUpdateRequest {
   featuredProductId?: string | null;
   productOrderIds: string[];
+  theme: StorefrontTheme;
 }

--- a/src/core/api/models/user/update-user-request.ts
+++ b/src/core/api/models/user/update-user-request.ts
@@ -2,10 +2,13 @@ import { SocialMediaLink } from '../socials/social-media-link';
 
 export interface UpdateUserRequest {
   userId?: string;
+  firstName?: string;
+  lastName?: string;
   title?: string;
   bio?: string;
   taglineMission?: string;
   website?: string;
+  publicEmail?: string;
   city?: string;
   country?: string;
   socialLinks?: SocialMediaLink[];

--- a/src/core/api/models/user/user.ts
+++ b/src/core/api/models/user/user.ts
@@ -13,6 +13,7 @@ export interface User {
   bio?: string;
   taglineMission?: string;
   website?: string;
+  publicEmail?: string;
   city?: string;
   country?: string;
   lat?: string;

--- a/src/core/api/services/storefront/storefront-api.test.ts
+++ b/src/core/api/services/storefront/storefront-api.test.ts
@@ -50,12 +50,22 @@ describe('storefront-api', () => {
     await updateCreatorStorefrontConfigAPI({
       featuredProductId: 'product-2',
       productOrderIds: ['product-2', 'product-1'],
+      theme: {
+        appearance: 'DARK',
+        accentColor: '#ffbd41',
+        typography: 'MODERN',
+      },
     });
 
     expect(mock.history.patch[0].url).toBe('api/creator/storefront');
     expect(JSON.parse(mock.history.patch[0].data)).toEqual({
       featuredProductId: 'product-2',
       productOrderIds: ['product-2', 'product-1'],
+      theme: {
+        appearance: 'DARK',
+        accentColor: '#ffbd41',
+        typography: 'MODERN',
+      },
     });
   });
 });

--- a/src/core/api/test-fixtures/creator-storefront-http.mock.ts
+++ b/src/core/api/test-fixtures/creator-storefront-http.mock.ts
@@ -36,7 +36,8 @@ export const storefrontProductSummariesTestFixture: ProductMinimised[] = [
   {
     id: 'sf-consultation-1',
     title: 'Launch Strategy Session',
-    description: 'A focused consultation to review your product offer and launch plan.',
+    description:
+      'A focused consultation to review your product offer and launch plan.',
     type: 'CONSULTATION',
     status: 'PUBLISHED',
     price: 220,
@@ -47,7 +48,8 @@ export const storefrontProductSummariesTestFixture: ProductMinimised[] = [
   {
     id: 'sf-membership-1',
     title: 'Creator Lab Membership',
-    description: 'Monthly workshops, critiques, and member-only operating systems.',
+    description:
+      'Monthly workshops, critiques, and member-only operating systems.',
     type: 'MEMBERSHIP',
     status: 'PUBLISHED',
     price: 39,
@@ -69,7 +71,8 @@ export const storefrontProductSummariesTestFixture: ProductMinimised[] = [
   {
     id: 'sf-hidden-1',
     title: 'Retired Preset Pack',
-    description: 'Hidden product intentionally excluded from public Storefront.',
+    description:
+      'Hidden product intentionally excluded from public Storefront.',
     type: 'DOWNLOAD',
     status: 'HIDDEN',
     price: 19,
@@ -85,16 +88,22 @@ export const publicStorefrontTestFixture: PublicStorefront = {
     id: 'creator-1',
     displayName: 'Maya Rivera',
     title: 'Independent filmmaker and creator educator',
-    tagline: 'Practical cinematic systems for creators building paid audiences.',
-    bio:
-      'Maya helps video creators package their knowledge into focused courses, downloads, consultations, and membership communities.',
+    tagline:
+      'Practical cinematic systems for creators building paid audiences.',
+    bio: 'Maya helps video creators package their knowledge into focused courses, downloads, consultations, and membership communities.',
     website: 'https://maya.example.com',
+    publicEmail: 'hello@maya.example.com',
     socialLinks: [
       { platform: SocialPlatforms.YT, url: 'https://youtube.com/@mayarivera' },
       { platform: SocialPlatforms.IG, url: 'https://instagram.com/mayarivera' },
     ],
   },
   featuredProductId: 'sf-course-1',
+  theme: {
+    appearance: 'DARK',
+    accentColor: '#ffbd41',
+    typography: 'MODERN',
+  },
   products: storefrontProductSummariesTestFixture.map((product) => ({
     id: product.id ?? '',
     title: product.title ?? '',
@@ -121,6 +130,11 @@ export const registerCreatorStorefrontTestMocks = (mock: MockAdapter) => {
   let config: CreatorStorefrontConfig = {
     id: 'creator-storefront-config',
     featuredProductId: 'sf-course-1',
+    theme: {
+      appearance: 'DARK',
+      accentColor: '#ffbd41',
+      typography: 'MODERN',
+    },
     productOrderIds: storefrontProductSummariesTestFixture.map(
       (product) => product.id ?? '',
     ),
@@ -159,6 +173,7 @@ export const registerCreatorStorefrontTestMocks = (mock: MockAdapter) => {
       ...config,
       featuredProductId: payload.featuredProductId ?? null,
       productOrderIds: payload.productOrderIds,
+      theme: payload.theme,
       updatedAt: '2026-08-12T11:00:00.000Z',
     };
 

--- a/src/core/constants/routes.ts
+++ b/src/core/constants/routes.ts
@@ -49,6 +49,7 @@ export const appRoutes: Route[] = [
     label: 'Storefront',
     icon: IoStorefrontOutline,
     group: 'primary',
+    collapseSidebarOnLoad: true,
   },
   {
     path: '/app/admin',

--- a/src/core/store/storefront-store/index.ts
+++ b/src/core/store/storefront-store/index.ts
@@ -1,1 +1,2 @@
 export * from './storefront.slice';
+export * from './storefront.selectors';

--- a/src/core/store/storefront-store/storefront.selectors.ts
+++ b/src/core/store/storefront-store/storefront.selectors.ts
@@ -1,0 +1,28 @@
+import { RootState } from 'core/api/models';
+
+export const selectPublicStorefrontByCreatorId = (
+  state: RootState,
+  creatorId?: string,
+) =>
+  creatorId ? (state.storefront.publicByCreatorId[creatorId] ?? null) : null;
+
+export const selectPublicStorefrontLoading = (state: RootState) =>
+  state.storefront.publicLoading;
+
+export const selectPublicStorefrontError = (state: RootState) =>
+  state.storefront.publicError;
+
+export const selectCreatorStorefrontConfig = (state: RootState) =>
+  state.storefront.creatorConfig;
+
+export const selectCreatorStorefrontConfigLoading = (state: RootState) =>
+  state.storefront.configLoading;
+
+export const selectCreatorStorefrontConfigError = (state: RootState) =>
+  state.storefront.configError;
+
+export const selectCreatorStorefrontConfigSaveLoading = (state: RootState) =>
+  state.storefront.configSaveLoading;
+
+export const selectCreatorStorefrontConfigSaveError = (state: RootState) =>
+  state.storefront.configSaveError;

--- a/src/core/store/storefront-store/storefront.slice.test.ts
+++ b/src/core/store/storefront-store/storefront.slice.test.ts
@@ -59,6 +59,11 @@ describe('storefront slice', () => {
       updateCreatorStorefrontConfig({
         featuredProductId: 'sf-download-1',
         productOrderIds: ['sf-download-1', 'sf-course-1'],
+        theme: {
+          appearance: 'DARK',
+          accentColor: '#ffbd41',
+          typography: 'MODERN',
+        },
       }),
     );
 

--- a/src/core/store/storefront-store/storefront.slice.ts
+++ b/src/core/store/storefront-store/storefront.slice.ts
@@ -4,7 +4,6 @@ import {
   CreatorStorefrontConfig,
   CreatorStorefrontConfigUpdateRequest,
   PublicStorefront,
-  RootState,
 } from 'core/api/models';
 import {
   getCreatorStorefrontConfigAPI,
@@ -39,13 +38,16 @@ export const fetchPublicStorefront = createAsyncThunk<
   PublicStorefront,
   string,
   { rejectValue: string }
->('storefront/fetchPublicStorefront', async (creatorId, { rejectWithValue }) => {
-  try {
-    return await getPublicStorefrontAPI(creatorId);
-  } catch (error: unknown) {
-    return rejectWithValue(extractErrorMessage(error));
-  }
-});
+>(
+  'storefront/fetchPublicStorefront',
+  async (creatorId, { rejectWithValue }) => {
+    try {
+      return await getPublicStorefrontAPI(creatorId);
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error));
+    }
+  },
+);
 
 export const fetchCreatorStorefrontConfig = createAsyncThunk<
   CreatorStorefrontConfig,
@@ -130,24 +132,5 @@ const storefrontSlice = createSlice({
       });
   },
 });
-
-export const selectPublicStorefrontByCreatorId = (
-  state: RootState,
-  creatorId?: string,
-) => (creatorId ? state.storefront.publicByCreatorId[creatorId] ?? null : null);
-export const selectPublicStorefrontLoading = (state: RootState) =>
-  state.storefront.publicLoading;
-export const selectPublicStorefrontError = (state: RootState) =>
-  state.storefront.publicError;
-export const selectCreatorStorefrontConfig = (state: RootState) =>
-  state.storefront.creatorConfig;
-export const selectCreatorStorefrontConfigLoading = (state: RootState) =>
-  state.storefront.configLoading;
-export const selectCreatorStorefrontConfigError = (state: RootState) =>
-  state.storefront.configError;
-export const selectCreatorStorefrontConfigSaveLoading = (state: RootState) =>
-  state.storefront.configSaveLoading;
-export const selectCreatorStorefrontConfigSaveError = (state: RootState) =>
-  state.storefront.configSaveError;
 
 export default storefrontSlice.reducer;

--- a/src/domains/app/features/settings/index.ts
+++ b/src/domains/app/features/settings/index.ts
@@ -1,1 +1,2 @@
 export * from './settings-tabs';
+export * from './settings.constants';

--- a/src/domains/app/features/settings/settings-tabs/settings-profile-tab.component.tsx
+++ b/src/domains/app/features/settings/settings-tabs/settings-profile-tab.component.tsx
@@ -12,10 +12,10 @@ import {
   Textarea,
   UserAvatar,
 } from '@shared/ui';
-import { getProfileNameInitials } from '@shared/utils';
 import { SettingsSection } from '../settings-section';
 import { SocialInput } from '../social-input';
 import { PageHeader } from 'domains/app/components';
+import { PUBLIC_EMAIL_POPOVER_COPY } from '../settings.constants';
 
 export interface ProfileFormData {
   firstName: string;
@@ -250,10 +250,7 @@ const SettingsProfileTab: React.FC = () => {
             />
 
             <InfoPopover className="info-popover" position="left">
-              <span>
-                This is the email showed on your storefront and what your
-                clients can see.
-              </span>
+              <span>{PUBLIC_EMAIL_POPOVER_COPY}</span>
             </InfoPopover>
           </div>
           <Controller

--- a/src/domains/app/features/settings/settings.constants.ts
+++ b/src/domains/app/features/settings/settings.constants.ts
@@ -1,0 +1,2 @@
+export const PUBLIC_EMAIL_POPOVER_COPY =
+  'This is the email shown on your storefront. It can be different from the email you use to sign in.';

--- a/src/domains/app/features/storefront/components/storefront-public-page.component.test.tsx
+++ b/src/domains/app/features/storefront/components/storefront-public-page.component.test.tsx
@@ -9,9 +9,15 @@ import {
   publicStorefrontTestFixture,
   storefrontProductSummariesTestFixture,
 } from 'core/api/test-fixtures/creator-storefront-http.mock';
-import { getStorefrontViewModel } from '../storefront.utils';
+import {
+  getStorefrontViewModel,
+  getStorefrontViewModelFromPublicStorefront,
+} from '../storefront.utils';
 
-jest.mock('../../../../../assets/image-placeholder.png', () => 'placeholder.png');
+jest.mock(
+  '../../../../../assets/image-placeholder.png',
+  () => 'placeholder.png',
+);
 
 const renderStorefront = (products = storefrontProductSummariesTestFixture) =>
   render(
@@ -25,9 +31,11 @@ const renderStorefront = (products = storefrontProductSummariesTestFixture) =>
             tagline: publicStorefrontTestFixture.creator.tagline,
             bio: publicStorefrontTestFixture.creator.bio,
             website: publicStorefrontTestFixture.creator.website,
+            publicEmail: publicStorefrontTestFixture.creator.publicEmail,
           },
           products,
           featuredProductId: publicStorefrontTestFixture.featuredProductId,
+          theme: publicStorefrontTestFixture.theme,
         })}
       />
     </MemoryRouter>,
@@ -37,7 +45,9 @@ describe('StorefrontPublicPage', () => {
   it('renders published products and hides draft or hidden products', () => {
     renderStorefront();
 
-    expect(screen.getAllByText('Creator Launch Studio').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Creator Launch Studio').length).toBeGreaterThan(
+      0,
+    );
     expect(screen.getByText('Content Calendar Kit')).toBeInTheDocument();
     expect(screen.getByText('Creator Lab Membership')).toBeInTheDocument();
     expect(screen.queryByText('Unannounced Workshop')).toBeNull();
@@ -51,6 +61,44 @@ describe('StorefrontPublicPage', () => {
     expect(membershipCards.length).toBeGreaterThan(0);
   });
 
+  it('applies returned Storefront theme to the shared presentation', () => {
+    const { container } = renderStorefront();
+    const storefront = container.querySelector('.storefront-public');
+
+    expect(storefront).toHaveClass('storefront-public--dark');
+    expect(storefront).toHaveClass('storefront-public--type-modern');
+    expect(storefront).toHaveStyle('--storefront-accent: #ffbd41');
+  });
+
+  it('renders public email from the profile read model', () => {
+    renderStorefront();
+
+    expect(
+      screen.getByRole('link', { name: 'hello@maya.example.com' }),
+    ).toHaveAttribute('href', 'mailto:hello@maya.example.com');
+  });
+
+  it('falls back to creator email when public email is absent in the public read model', () => {
+    render(
+      <MemoryRouter>
+        <StorefrontPublicPage
+          storefront={getStorefrontViewModelFromPublicStorefront({
+            ...publicStorefrontTestFixture,
+            creator: {
+              ...publicStorefrontTestFixture.creator,
+              email: 'login@maya.example.com',
+              publicEmail: undefined,
+            },
+          })}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'login@maya.example.com' }),
+    ).toHaveAttribute('href', 'mailto:login@maya.example.com');
+  });
+
   it('renders a graceful empty state when no products are published', () => {
     renderStorefront(
       storefrontProductSummariesTestFixture.map((product) => ({
@@ -59,7 +107,9 @@ describe('StorefrontPublicPage', () => {
       })),
     );
 
-    expect(screen.getByText('No products are public right now')).toBeInTheDocument();
+    expect(
+      screen.getByText('No products are public right now'),
+    ).toBeInTheDocument();
     expect(screen.queryByText('Featured product')).toBeNull();
   });
 });

--- a/src/domains/app/features/storefront/components/storefront-public-page.component.tsx
+++ b/src/domains/app/features/storefront/components/storefront-public-page.component.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FiExternalLink } from 'react-icons/fi';
 import clsx from 'clsx';
 
 import { Button, GalIcon } from '@shared/ui';
+import { SocialPlatforms } from 'core/api/models/socials/social-media-link';
 
 import { StorefrontViewModel } from '../storefront.types';
 import {
@@ -19,13 +21,33 @@ const placeholderImage = require('../../../../../assets/image-placeholder.png');
 interface StorefrontPublicPageProps {
   storefront: StorefrontViewModel;
   preview?: boolean;
+  editableFields?: Partial<
+    Record<
+      | 'displayName'
+      | 'title'
+      | 'tagline'
+      | 'bio'
+      | 'website'
+      | 'publicEmail',
+      (value: string) => React.ReactNode
+    >
+  >;
 }
+
+const socialLabels: Record<SocialPlatforms, string> = {
+  [SocialPlatforms.FB]: 'Facebook',
+  [SocialPlatforms.IG]: 'Instagram',
+  [SocialPlatforms.X]: 'X',
+  [SocialPlatforms.TT]: 'TikTok',
+  [SocialPlatforms.YT]: 'YouTube',
+};
 
 const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
   storefront,
   preview = false,
+  editableFields,
 }) => {
-  const { profile, products, featuredProductId } = storefront;
+  const { profile, products, featuredProductId, theme } = storefront;
   const featuredProduct = products.find(
     (product) => product.id === featuredProductId,
   );
@@ -36,12 +58,33 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
     .join('')
     .slice(0, 2)
     .toUpperCase();
+  const renderEditable = (
+    field:
+      | 'displayName'
+      | 'title'
+      | 'tagline'
+      | 'bio'
+      | 'website'
+      | 'publicEmail',
+    value = '',
+    fallback?: React.ReactNode,
+  ) => editableFields?.[field]?.(value) ?? fallback ?? value;
 
   return (
     <article
-      className={clsx('storefront-public', {
-        'storefront-public--preview': preview,
-      })}
+      className={clsx(
+        'storefront-public',
+        `storefront-public--${theme.appearance.toLowerCase()}`,
+        `storefront-public--type-${theme.typography.toLowerCase()}`,
+        {
+          'storefront-public--preview': preview,
+        },
+      )}
+      style={
+        {
+          '--storefront-accent': theme.accentColor,
+        } as React.CSSProperties
+      }
     >
       <header className="storefront-public__nav">
         <a href="#storefront-products" className="storefront-public__brand">
@@ -54,6 +97,7 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
         </a>
         <nav aria-label="Storefront sections">
           <a href="#storefront-products">Products</a>
+          <a href="#storefront-contact">Contact</a>
           {profile.website && (
             <a href={profile.website} target="_blank" rel="noreferrer">
               Website
@@ -65,23 +109,39 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
       <section className="storefront-public__hero">
         <div className="storefront-public__hero-copy">
           <span className="storefront-public__eyebrow">Creator Storefront</span>
-          <h1>{profile.displayName}</h1>
+          <h1>{renderEditable('displayName', profile.displayName)}</h1>
+          {(profile.title || editableFields?.title) && (
+            <p className="storefront-public__title">
+              {renderEditable('title', profile.title, 'Creator')}
+            </p>
+          )}
           <p className="storefront-public__tagline">
-            {profile.tagline || profile.title || 'Digital products from this creator.'}
+            {renderEditable(
+              'tagline',
+              profile.tagline || '',
+              profile.tagline ||
+                profile.title ||
+                'Digital products from this creator.',
+            )}
           </p>
-          {profile.bio && <p className="storefront-public__bio">{profile.bio}</p>}
+          {(profile.bio || editableFields?.bio) && (
+            <p className="storefront-public__bio">
+              {renderEditable('bio', profile.bio, 'Add a public bio.')}
+            </p>
+          )}
           <div className="storefront-public__hero-actions">
             <a className="storefront-public__cta" href="#storefront-products">
               Browse products
             </a>
-            {profile.website && (
+            {(profile.website || editableFields?.website) && (
               <a
                 className="storefront-public__secondary-link"
-                href={profile.website}
+                href={profile.website || '#storefront-contact'}
                 target="_blank"
                 rel="noreferrer"
               >
-                Creator website <GalIcon icon={FiExternalLink} color="currentColor" size={15} />
+                Creator website{' '}
+                <GalIcon icon={FiExternalLink} color="currentColor" size={15} />
               </a>
             )}
           </div>
@@ -96,17 +156,20 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
       </section>
 
       {featuredProduct && (
-        <section className="storefront-public__featured" aria-labelledby="featured-product-heading">
+        <section
+          className="storefront-public__featured"
+          aria-labelledby="featured-product-heading"
+        >
           <div className="storefront-public__featured-image">
-            <img
-              src={featuredProduct.imageUrl || placeholderImage}
-              alt=""
-            />
+            <img src={featuredProduct.imageUrl || placeholderImage} alt="" />
           </div>
           <div>
             <span className="storefront-public__eyebrow">Featured product</span>
             <h2 id="featured-product-heading">{featuredProduct.title}</h2>
-            <p>{featuredProduct.description || 'A featured offer from this creator.'}</p>
+            <p>
+              {featuredProduct.description ||
+                'A featured offer from this creator.'}
+            </p>
             <div className="storefront-public__product-meta">
               <span>{storefrontProductTypeLabels[featuredProduct.type]}</span>
               <strong>{formatStorefrontPrice(featuredProduct.price)}</strong>
@@ -120,6 +183,53 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
           </div>
         </section>
       )}
+
+      <section
+        id="storefront-contact"
+        className="storefront-public__contact"
+        aria-labelledby="storefront-contact-heading"
+      >
+        <div>
+          <span className="storefront-public__eyebrow">Contact</span>
+          <h2 id="storefront-contact-heading">Connect with the creator</h2>
+        </div>
+        <div className="storefront-public__contact-links">
+          {editableFields?.publicEmail ? (
+            <span className="storefront-public__contact-editable">
+              {renderEditable(
+                'publicEmail',
+                profile.publicEmail,
+                profile.publicEmail || 'Add public email',
+              )}
+            </span>
+          ) : (
+            profile.publicEmail && (
+              <a href={`mailto:${profile.publicEmail || ''}`}>
+                {profile.publicEmail}
+              </a>
+            )
+          )}
+          {editableFields?.website && (
+            <span className="storefront-public__contact-editable">
+              {renderEditable(
+                'website',
+                profile.website,
+                profile.website || 'Add website',
+              )}
+            </span>
+          )}
+          {profile.socialLinks?.map((link) => (
+            <a
+              key={`${link.platform}-${link.url}`}
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {socialLabels[link.platform]}
+            </a>
+          ))}
+        </div>
+      </section>
 
       <section
         id="storefront-products"
@@ -139,12 +249,18 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
         {hasProducts ? (
           <div className="storefront-public__product-grid">
             {products.map((product) => (
-              <article className="storefront-public__product-card" key={product.id}>
+              <article
+                className="storefront-public__product-card"
+                key={product.id}
+              >
                 <img src={product.imageUrl || placeholderImage} alt="" />
                 <div>
                   <span>{storefrontProductTypeLabels[product.type]}</span>
                   <h3>{product.title}</h3>
-                  <p>{product.description || 'Product details are available on the product page.'}</p>
+                  <p>
+                    {product.description ||
+                      'Product details are available on the product page.'}
+                  </p>
                 </div>
                 <div className="storefront-public__product-footer">
                   <strong>{formatStorefrontPrice(product.price)}</strong>
@@ -165,7 +281,9 @@ const StorefrontPublicPage: React.FC<StorefrontPublicPageProps> = ({
         ) : (
           <div className="storefront-public__empty" role="status">
             <h3>No products are public right now</h3>
-            <p>Draft and hidden products are not shown on public Storefronts.</p>
+            <p>
+              Draft and hidden products are not shown on public Storefronts.
+            </p>
           </div>
         )}
       </section>

--- a/src/domains/app/features/storefront/components/storefront-public-page.styles.scss
+++ b/src/domains/app/features/storefront/components/storefront-public-page.styles.scss
@@ -1,11 +1,42 @@
 @use '../../../../../styles/index.scss' as *;
 
 .storefront-public {
+  --storefront-bg: #090a1f;
+  --storefront-bg-soft: #111329;
+  --storefront-surface: rgba(22, 24, 46, 0.88);
+  --storefront-surface-solid: #17192f;
+  --storefront-text: #f8fafc;
+  --storefront-text-muted: #b9c1d9;
+  --storefront-border: rgba(255, 255, 255, 0.12);
+
   min-height: 100%;
   background:
-    radial-gradient(circle at top left, rgba(var(--brand-primary-rgb), 0.14), transparent 30%),
-    linear-gradient(180deg, var(--surface-canvas) 0%, #090a1f 100%);
-  color: var(--text-primary);
+    radial-gradient(
+      circle at top left,
+      color-mix(in srgb, var(--storefront-accent) 18%, transparent),
+      transparent 30%
+    ),
+    linear-gradient(180deg, var(--storefront-bg-soft) 0%, var(--storefront-bg) 100%);
+  color: var(--storefront-text);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+.storefront-public--light {
+  --storefront-bg: #f6f7fb;
+  --storefront-bg-soft: #ffffff;
+  --storefront-surface: rgba(255, 255, 255, 0.88);
+  --storefront-surface-solid: #ffffff;
+  --storefront-text: #161827;
+  --storefront-text-muted: #5d6679;
+  --storefront-border: rgba(22, 24, 39, 0.14);
+}
+
+.storefront-public--type-classic {
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.storefront-public--type-friendly {
+  font-family: 'Trebuchet MS', Verdana, ui-sans-serif, system-ui, sans-serif;
 }
 
 .storefront-public__nav {
@@ -24,7 +55,7 @@
   }
 
   a {
-    color: var(--text-primary);
+    color: var(--storefront-text);
     text-decoration: none;
   }
 }
@@ -43,7 +74,7 @@
     border-radius: 50%;
     place-items: center;
     background: rgba(var(--brand-primary-rgb), 0.18);
-    color: var(--brand-primary);
+    color: var(--storefront-accent);
     font-weight: 800;
   }
 
@@ -56,6 +87,7 @@
 
 .storefront-public__hero,
 .storefront-public__featured,
+.storefront-public__contact,
 .storefront-public__products {
   max-width: 1180px;
   margin: 0 auto;
@@ -80,8 +112,14 @@
   }
 }
 
+.storefront-public__title {
+  margin: 0 0 12px;
+  color: var(--storefront-accent);
+  font-weight: 800;
+}
+
 .storefront-public__eyebrow {
-  color: var(--brand-primary);
+  color: var(--storefront-accent);
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0;
@@ -91,14 +129,14 @@
 .storefront-public__tagline {
   max-width: 760px;
   margin: 0;
-  color: var(--text-primary);
+  color: var(--storefront-text);
   font-size: 1.2rem;
   line-height: 1.55;
 }
 
 .storefront-public__bio {
   max-width: 760px;
-  color: var(--text-secondary);
+  color: var(--storefront-text-muted);
   font-size: 1rem;
   line-height: 1.7;
 }
@@ -118,8 +156,8 @@
   align-items: center;
   justify-content: center;
   border-radius: $radius-sm;
-  background: var(--brand-primary);
-  color: var(--surface-canvas);
+  background: var(--storefront-accent);
+  color: var(--storefront-bg);
   font-weight: 800;
   padding: 0 18px;
   text-decoration: none;
@@ -129,7 +167,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-primary);
+  color: var(--storefront-text);
   font-weight: 700;
   text-decoration: none;
 }
@@ -139,9 +177,13 @@
   width: min(100%, 360px);
   aspect-ratio: 1;
   place-items: center;
-  border: 1px solid rgba(var(--brand-primary-rgb), 0.36);
+  border: 1px solid color-mix(in srgb, var(--storefront-accent) 42%, transparent);
   border-radius: 28px;
-  background: linear-gradient(145deg, rgba(var(--surface-panel-rgb), 0.96), rgba(var(--brand-secondary-rgb), 0.2));
+  background: linear-gradient(
+    145deg,
+    var(--storefront-surface-solid),
+    color-mix(in srgb, var(--storefront-accent) 16%, transparent)
+  );
   justify-self: end;
 
   img {
@@ -152,7 +194,7 @@
   }
 
   span {
-    color: var(--brand-primary);
+    color: var(--storefront-accent);
     font-size: 6rem;
     font-weight: 900;
   }
@@ -163,8 +205,8 @@
   grid-template-columns: 420px minmax(0, 1fr);
   gap: 34px;
   align-items: center;
-  border-top: 1px solid var(--border-subtle);
-  border-bottom: 1px solid var(--border-subtle);
+  border-top: 1px solid var(--storefront-border);
+  border-bottom: 1px solid var(--storefront-border);
 
   h2 {
     margin: 8px 0 12px;
@@ -173,7 +215,7 @@
   }
 
   p {
-    color: var(--text-secondary);
+    color: var(--storefront-text-muted);
     line-height: 1.65;
   }
 }
@@ -181,9 +223,9 @@
 .storefront-public__featured-image,
 .storefront-public__product-card > img {
   overflow: hidden;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--storefront-border);
   border-radius: $radius-md;
-  background: var(--surface-panel);
+  background: var(--storefront-surface-solid);
 
   img {
     display: block;
@@ -206,7 +248,7 @@
 
   span,
   strong {
-    border: 1px solid var(--border-subtle);
+    border: 1px solid var(--storefront-border);
     border-radius: 999px;
     padding: 8px 12px;
   }
@@ -222,7 +264,40 @@
   }
 
   p {
-    color: var(--text-secondary);
+    color: var(--storefront-text-muted);
+  }
+}
+
+.storefront-public__contact {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid var(--storefront-border);
+
+  h2 {
+    margin: 8px 0 0;
+    font-size: clamp(26px, 3vw, 36px);
+  }
+}
+
+.storefront-public__contact-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+
+  a,
+  .storefront-public__contact-editable {
+    border: 1px solid var(--storefront-border);
+    border-radius: 999px;
+    color: var(--storefront-text);
+    padding: 9px 13px;
+    text-decoration: none;
+  }
+
+  .storefront-public__contact-editable {
+    display: inline-flex;
   }
 }
 
@@ -237,9 +312,9 @@
   min-width: 0;
   min-height: 100%;
   flex-direction: column;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--storefront-border);
   border-radius: $radius-md;
-  background: rgba(var(--surface-panel-rgb), 0.8);
+  background: var(--storefront-surface);
   padding: 12px;
 
   > img {
@@ -251,7 +326,7 @@
   span {
     display: inline-block;
     margin-top: 14px;
-    color: var(--brand-primary);
+    color: var(--storefront-accent);
     font-size: 0.76rem;
     font-weight: 800;
     text-transform: uppercase;
@@ -264,7 +339,7 @@
   }
 
   p {
-    color: var(--text-secondary);
+    color: var(--storefront-text-muted);
     font-size: 0.9rem;
     line-height: 1.55;
   }
@@ -280,9 +355,9 @@
 }
 
 .storefront-public__empty {
-  border: 1px dashed var(--border-subtle);
+  border: 1px dashed var(--storefront-border);
   border-radius: $radius-md;
-  background: rgba(var(--surface-panel-rgb), 0.68);
+  background: var(--storefront-surface);
   padding: 28px;
 
   h3 {
@@ -291,13 +366,13 @@
 
   p {
     margin: 0;
-    color: var(--text-secondary);
+    color: var(--storefront-text-muted);
   }
 }
 
 .storefront-public--preview {
   min-height: auto;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--storefront-border);
   border-radius: $radius-md;
 
   .storefront-public__nav {
@@ -306,6 +381,7 @@
 
   .storefront-public__hero,
   .storefront-public__featured,
+  .storefront-public__contact,
   .storefront-public__products {
     padding: 28px 18px;
   }
@@ -349,6 +425,7 @@
 
   .storefront-public__hero,
   .storefront-public__featured,
+  .storefront-public__contact,
   .storefront-public__products {
     padding: 30px 16px;
   }
@@ -365,5 +442,14 @@
   .storefront-public__product-footer {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .storefront-public__contact {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .storefront-public__contact-links {
+    justify-content: flex-start;
   }
 }

--- a/src/domains/app/features/storefront/storefront.types.ts
+++ b/src/domains/app/features/storefront/storefront.types.ts
@@ -2,6 +2,7 @@ import {
   ProductMinimised,
   ProductStatus,
   ProductType,
+  StorefrontTheme,
   User,
 } from 'core/api/models';
 
@@ -12,6 +13,7 @@ export interface StorefrontProfile {
   tagline?: string;
   bio?: string;
   website?: string;
+  publicEmail?: string;
   imageUrl?: string;
   socialLinks?: User['socialLinks'];
 }
@@ -27,12 +29,14 @@ export interface StorefrontViewModel {
   profile: StorefrontProfile;
   products: StorefrontProduct[];
   featuredProductId?: string;
+  theme: StorefrontTheme;
 }
 
 export interface StorefrontViewModelInput {
   profile: StorefrontProfile;
   products: ProductMinimised[];
   featuredProductId?: string;
+  theme: StorefrontTheme;
 }
 
 export type StorefrontLoadState = 'loading' | 'ready' | 'error' | 'unavailable';

--- a/src/domains/app/features/storefront/storefront.utils.ts
+++ b/src/domains/app/features/storefront/storefront.utils.ts
@@ -3,6 +3,7 @@ import {
   ProductStatus,
   ProductType,
   PublicStorefront,
+  StorefrontTheme,
   User,
 } from 'core/api/models';
 
@@ -26,6 +27,12 @@ export const storefrontStatusLabels: Record<ProductStatus, string> = {
   HIDDEN: 'Hidden',
 };
 
+export const DEFAULT_STOREFRONT_THEME: StorefrontTheme = {
+  appearance: 'DARK',
+  accentColor: '#ffbd41',
+  typography: 'MODERN',
+};
+
 export const isPublicStorefrontProduct = (product: ProductMinimised) =>
   product.status === 'PUBLISHED';
 
@@ -46,7 +53,10 @@ export const formatStorefrontPrice = (price?: number | 'free') => {
 };
 
 export const getStorefrontDisplayName = (user?: User | null) => {
-  const name = [user?.firstName, user?.lastName].filter(Boolean).join(' ').trim();
+  const name = [user?.firstName, user?.lastName]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
   return name || 'Creator';
 };
 
@@ -57,6 +67,7 @@ export const getProfileFromUser = (user?: User | null): StorefrontProfile => ({
   tagline: user?.taglineMission,
   bio: user?.bio,
   website: user?.website,
+  publicEmail: user?.publicEmail || user?.email,
   imageUrl: user?.imageUrl,
   socialLinks: user?.socialLinks,
 });
@@ -112,7 +123,9 @@ export const orderStorefrontProducts = (
   const ordered = orderedIds
     .map((id) => byId.get(id))
     .filter((product): product is StorefrontProduct => Boolean(product));
-  const remaining = products.filter((product) => !orderedIds.includes(product.id));
+  const remaining = products.filter(
+    (product) => !orderedIds.includes(product.id),
+  );
 
   return [...ordered, ...remaining];
 };
@@ -121,8 +134,10 @@ export const getStorefrontViewModel = ({
   profile,
   products,
   featuredProductId,
+  theme,
 }: StorefrontViewModelInput): StorefrontViewModel => {
   const publicProducts = getPublicStorefrontProducts(products);
+
   const validFeaturedId = publicProducts.some(
     (product) => product.id === featuredProductId,
   )
@@ -133,6 +148,7 @@ export const getStorefrontViewModel = ({
     profile,
     products: publicProducts,
     featuredProductId: validFeaturedId,
+    theme,
   };
 };
 
@@ -147,6 +163,7 @@ export const getStorefrontViewModelFromPublicStorefront = (
       tagline: storefront.creator.tagline,
       bio: storefront.creator.bio,
       website: storefront.creator.website,
+      publicEmail: storefront.creator.publicEmail || storefront.creator.email,
       imageUrl: storefront.creator.imageUrl,
       socialLinks: storefront.creator.socialLinks,
     },
@@ -155,4 +172,5 @@ export const getStorefrontViewModelFromPublicStorefront = (
       status: product.status ?? 'PUBLISHED',
     })),
     featuredProductId: storefront.featuredProductId,
+    theme: storefront.theme ?? DEFAULT_STOREFRONT_THEME,
   });

--- a/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.test.tsx
+++ b/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.test.tsx
@@ -1,0 +1,64 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { UserRole } from 'core/api/models';
+import authReducer from 'core/store/auth-store/auth.slice';
+import { SidebarLayoutProvider } from 'domains/app/widgets/sidebar-nav';
+import CreatorAppShell from './creator-app-shell.component';
+
+jest.mock('domains/app/components', () => ({
+  GalUserDropdown: () => <div data-testid="user-dropdown" />,
+}));
+
+const renderShell = (initialEntry: string) => {
+  const testStore = configureStore({
+    reducer: {
+      auth: authReducer,
+    },
+    preloadedState: {
+      auth: {
+        user: {
+          id: 'creator-1',
+          firstName: 'Maya',
+          lastName: 'Rivera',
+          email: 'maya@example.test',
+          roles: [UserRole.CREATOR],
+        },
+        loading: false,
+        error: null,
+        isUserLoggedIn: true,
+      },
+    },
+  });
+
+  return render(
+    <Provider store={testStore}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <SidebarLayoutProvider>
+          <Routes>
+            <Route path="/app/storefront" element={<CreatorAppShell />}>
+              <Route index element={<div>Storefront builder</div>} />
+            </Route>
+          </Routes>
+        </SidebarLayoutProvider>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+describe('CreatorAppShell', () => {
+  it('collapses the Creator sidebar on the Storefront builder route', async () => {
+    renderShell('/app/storefront');
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Expand sidebar' }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.tsx
+++ b/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.tsx
@@ -1,18 +1,33 @@
-import React, { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { matchPath, Outlet, useLocation } from 'react-router-dom';
 import { HiMenuAlt2, HiX } from 'react-icons/hi';
 
 import { Button, GalIcon } from '@shared/ui';
+import { appRoutes } from 'core/constants';
 import { getCssVar } from '@shared/utils';
 import { GalUserDropdown } from 'domains/app/components';
-import { SidebarNav } from 'domains/app/widgets/sidebar-nav';
+import { SidebarNav, useSidebarLayout } from 'domains/app/widgets/sidebar-nav';
 
 import './creator-app-shell.styles.scss';
 
 const CreatorAppShell: React.FC = () => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const location = useLocation();
+  const { setIsSidebarCollapsed } = useSidebarLayout();
 
   const closeMobileNav = () => setIsMobileNavOpen(false);
+
+  useEffect(() => {
+    const shouldCollapse = appRoutes.some(
+      (route) =>
+        route.collapseSidebarOnLoad &&
+        Boolean(matchPath(`${route.path}/*`, location.pathname)),
+    );
+
+    if (shouldCollapse) {
+      setIsSidebarCollapsed(true);
+    }
+  }, [location.pathname, setIsSidebarCollapsed]);
 
   return (
     <div className="creator-app-shell">

--- a/src/domains/app/pages/creator-specific/storefront-management-page/storefront-management-page.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/storefront-management-page/storefront-management-page.component.test.tsx
@@ -35,6 +35,7 @@ const renderManagement = (roles = [UserRole.CREATOR]) => {
           title: 'Creator educator',
           bio: 'Creator bio',
           website: 'https://maya.example.com',
+          publicEmail: undefined,
         },
         loading: false,
         error: null,
@@ -58,6 +59,20 @@ describe('CreatorStorefrontPage', () => {
   beforeEach(() => {
     mock = new MockAdapter(httpClient);
     registerCreatorStorefrontTestMocks(mock);
+    mock.onPut('api/user/userInfo').reply((request) => [
+      200,
+      {
+        id: 'creator-1',
+        firstName: 'Maya',
+        lastName: 'Rivera',
+        email: 'maya@example.test',
+        roles: [UserRole.CREATOR],
+        title: 'Creator educator',
+        bio: 'Creator bio',
+        website: 'https://maya.example.com',
+        ...JSON.parse(request.data ?? '{}'),
+      },
+    ]);
   });
 
   afterEach(() => {
@@ -68,12 +83,16 @@ describe('CreatorStorefrontPage', () => {
   it('loads config and product catalogue through Redux-backed HTTP requests', async () => {
     renderManagement();
 
-    expect(screen.getByRole('heading', { name: 'Storefront' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Storefront Builder' }),
+    ).toBeInTheDocument();
     expect(
       (await screen.findAllByText('Creator Launch Studio')).length,
     ).toBeGreaterThan(0);
-    expect(screen.getByText('Public with products')).toBeInTheDocument();
-    expect(screen.getByText('/app/store/creator-1')).toBeInTheDocument();
+    expect(screen.getByText(/4 public, 2 draft or hidden/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Open public Storefront' }),
+    ).toBeInTheDocument();
     expect(mock.history.get.map((request) => request.url)).toEqual(
       expect.arrayContaining([
         'api/products?ownerId=creator-1',
@@ -83,41 +102,62 @@ describe('CreatorStorefrontPage', () => {
   });
 
   it('shows draft and hidden products as not public while preview hides them', async () => {
-    renderManagement();
+    const { container } = renderManagement();
 
     expect(await screen.findByText('Unannounced Workshop')).toBeInTheDocument();
     expect(screen.getByText('Retired Preset Pack')).toBeInTheDocument();
     expect(screen.getAllByText('Not visible on the public Storefront')).toHaveLength(2);
 
-    const preview = screen.getByLabelText('Live Storefront preview');
-    expect(within(preview).queryByText('Unannounced Workshop')).toBeNull();
-    expect(within(preview).queryByText('Retired Preset Pack')).toBeNull();
-    expect(within(preview).getByText('Creator Lab Membership')).toBeInTheDocument();
+    const publicRendering = container.querySelector(
+      '.storefront-public',
+    ) as HTMLElement;
+    expect(within(publicRendering).queryByText('Unannounced Workshop')).toBeNull();
+    expect(within(publicRendering).queryByText('Retired Preset Pack')).toBeNull();
+    expect(
+      within(publicRendering).getByText('Creator Lab Membership'),
+    ).toBeInTheDocument();
   });
 
-  it('persists featured product changes and updates the shared preview', async () => {
-    renderManagement();
+  it('updates featured product in the shared rendering without PATCHing immediately', async () => {
+    const { container } = renderManagement();
 
     await screen.findAllByText('Content Calendar Kit');
     fireEvent.click(screen.getAllByRole('button', { name: 'Set featured' })[0]);
 
-    const preview = screen.getByLabelText('Live Storefront preview');
+    const preview = container.querySelector('.storefront-public') as HTMLElement;
     expect(
       within(preview).getByRole('heading', {
         name: 'Content Calendar Kit',
         level: 2,
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    expect(mock.history.patch).toHaveLength(0);
+  });
 
+  it('saves the full draft Storefront config only when Save changes is clicked', async () => {
+    renderManagement();
+
+    await screen.findAllByText('Content Calendar Kit');
+    fireEvent.click(screen.getAllByRole('button', { name: 'Set featured' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Customize Storefront' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Light' }));
+
+    expect(mock.history.patch).toHaveLength(0);
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
     await waitFor(() => {
       expect(mock.history.patch).toHaveLength(1);
     });
-    expect(JSON.parse(mock.history.patch[0].data).featuredProductId).toBe(
-      'sf-download-1',
+    expect(JSON.parse(mock.history.patch[0].data)).toEqual(
+      expect.objectContaining({
+        featuredProductId: 'sf-download-1',
+        productOrderIds: expect.arrayContaining(['sf-course-1']),
+        theme: expect.objectContaining({ appearance: 'LIGHT' }),
+      }),
     );
   });
 
-  it('persists product ordering changes', async () => {
+  it('keeps product ordering changes in draft until reset or save', async () => {
     renderManagement();
 
     await screen.findAllByText('Content Calendar Kit');
@@ -125,12 +165,14 @@ describe('CreatorStorefrontPage', () => {
       screen.getByRole('button', { name: 'Move Content Calendar Kit up' }),
     );
 
-    await waitFor(() => {
-      expect(mock.history.patch).toHaveLength(1);
-    });
-    expect(JSON.parse(mock.history.patch[0].data).productOrderIds.slice(0, 2)).toEqual(
-      ['sf-download-1', 'sf-course-1'],
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    expect(mock.history.patch).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset changes' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument(),
     );
+    expect(mock.history.patch).toHaveLength(0);
   });
 
   it('renders honest unavailable state when Storefront config is unavailable', async () => {
@@ -140,9 +182,28 @@ describe('CreatorStorefrontPage', () => {
     renderManagement();
 
     expect(
-      await screen.findByText('Unable to load Storefront data'),
+      await screen.findByText('Unable to load or save Storefront data'),
     ).toBeInTheDocument();
     expect(screen.getByText('No products available')).toBeInTheDocument();
+  });
+
+  it('edits public email through the profile API and falls back to login email', async () => {
+    renderManagement();
+
+    expect(await screen.findByText('maya@example.test')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Public Email' }));
+    fireEvent.change(screen.getByLabelText('Public Email'), {
+      target: { value: 'public@maya.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mock.history.put).toHaveLength(1);
+    });
+    expect(JSON.parse(mock.history.put[0].data)).toEqual({
+      publicEmail: 'public@maya.example.com',
+    });
+    expect(mock.history.patch).toHaveLength(0);
   });
 
   it('keeps Storefront management creator-only', () => {

--- a/src/domains/app/pages/creator-specific/storefront-management-page/storefront-management-page.component.tsx
+++ b/src/domains/app/pages/creator-specific/storefront-management-page/storefront-management-page.component.tsx
@@ -1,16 +1,45 @@
+/* eslint-disable indent */
+/* eslint-disable no-unused-vars */
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { FiCopy, FiExternalLink } from 'react-icons/fi';
+import {
+  FiCheck,
+  FiCopy,
+  FiEdit3,
+  FiExternalLink,
+  FiRotateCcw,
+  FiSave,
+  FiSliders,
+  FiX,
+} from 'react-icons/fi';
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md';
 
-import { Button, GalIcon, StatusBadge } from '@shared/ui';
+import {
+  Button,
+  Drawer,
+  GalIcon,
+  InfoPopover,
+  Input,
+  StatusBadge,
+  Textarea,
+} from '@shared/ui';
 import {
   AppDispatch,
+  CreatorStorefrontConfigUpdateRequest,
   hasRole,
   ProductMinimised,
+  StorefrontAppearance,
+  StorefrontTheme,
+  StorefrontTypography,
+  UpdateUserRequest,
   UserRole,
 } from 'core/api/models';
-import { selectAuthUser } from 'core/store/auth-store';
+import {
+  selectAuthError,
+  selectAuthLoading,
+  selectAuthUser,
+  updateUserDetails,
+} from 'core/store/auth-store';
 import {
   getProductSummariesByOwner,
   selectProductSummaries,
@@ -26,7 +55,9 @@ import {
   selectCreatorStorefrontConfigSaveLoading,
   updateCreatorStorefrontConfig,
 } from 'core/store/storefront-store';
+import { PUBLIC_EMAIL_POPOVER_COPY } from 'domains/app/features/settings';
 import {
+  DEFAULT_STOREFRONT_THEME,
   getProfileFromUser,
   getPublicStorefrontProducts,
   getStorefrontViewModel,
@@ -39,29 +70,197 @@ import {
 
 import './storefront-management-page.styles.scss';
 
+type DraftStorefrontConfig = CreatorStorefrontConfigUpdateRequest;
+type EditableProfileField =
+  | 'displayName'
+  | 'title'
+  | 'tagline'
+  | 'bio'
+  | 'website'
+  | 'publicEmail';
+
 const statusTone = {
   PUBLISHED: 'success',
   DRAFT: 'warning',
   HIDDEN: 'neutral',
 } as const;
 
+const accentSwatches = [
+  '#ffbd41',
+  '#18c7a5',
+  '#4f8cff',
+  '#ff6b6b',
+  '#9b6bff',
+  '#111827',
+];
+
+const appearanceOptions: Array<{
+  label: string;
+  value: StorefrontAppearance;
+}> = [
+  { label: 'Light', value: 'LIGHT' },
+  { label: 'Dark', value: 'DARK' },
+];
+
+const typographyOptions: Array<{
+  label: string;
+  value: StorefrontTypography;
+  preview: string;
+}> = [
+  { label: 'Modern', value: 'MODERN', preview: 'Clean Sans' },
+  { label: 'Classic', value: 'CLASSIC', preview: 'Editorial Serif' },
+  { label: 'Friendly', value: 'FRIENDLY', preview: 'Warm Sans' },
+];
+
+const normalizeDraftConfig = (
+  config: DraftStorefrontConfig | null | undefined,
+): DraftStorefrontConfig => ({
+  featuredProductId: config?.featuredProductId ?? null,
+  productOrderIds: config?.productOrderIds ?? [],
+  theme: config?.theme ?? DEFAULT_STOREFRONT_THEME,
+});
+
+const getDisplayNamePayload = (displayName: string): UpdateUserRequest => {
+  const [firstName = '', ...rest] = displayName.trim().split(/\s+/);
+  return {
+    firstName,
+    lastName: rest.join(' '),
+  };
+};
+
+interface InlineProfileEditorProps {
+  label: string;
+  value: string;
+  fallback?: string;
+  multiline?: boolean;
+  helpText?: string;
+  saving?: boolean;
+  onSave: (value: string) => Promise<void>;
+}
+
+const InlineProfileEditor: React.FC<InlineProfileEditorProps> = ({
+  label,
+  value,
+  fallback = 'Not set',
+  multiline = false,
+  helpText,
+  saving = false,
+  onSave,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraft(value);
+    }
+  }, [editing, value]);
+
+  const cancel = () => {
+    setDraft(value);
+    setError(null);
+    setEditing(false);
+  };
+
+  const save = async () => {
+    try {
+      await onSave(draft.trim());
+      setError(null);
+      setEditing(false);
+    } catch {
+      setError(`Unable to save ${label.toLowerCase()}.`);
+    }
+  };
+
+  if (editing) {
+    return (
+      <span className="storefront-inline-edit storefront-inline-edit--active">
+        {multiline ? (
+          <Textarea
+            aria-label={label}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            block
+          />
+        ) : (
+          <Input
+            aria-label={label}
+            name={`storefront-${label}`}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+          />
+        )}
+        <span className="storefront-inline-edit__actions">
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            loading={saving}
+            onClick={save}
+            leadingIcon={<GalIcon icon={FiCheck} color="currentColor" />}
+          >
+            Save
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={saving}
+            onClick={cancel}
+            leadingIcon={<GalIcon icon={FiX} color="currentColor" />}
+          >
+            Cancel
+          </Button>
+        </span>
+        {error && <span className="storefront-inline-edit__error">{error}</span>}
+      </span>
+    );
+  }
+
+  return (
+    <span className="storefront-inline-edit">
+      <span>{value || fallback}</span>
+      {helpText && (
+        <InfoPopover className="storefront-inline-edit__popover">
+          <span>{helpText}</span>
+        </InfoPopover>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={`Edit ${label}`}
+        onClick={() => setEditing(true)}
+      >
+        <GalIcon icon={FiEdit3} color="currentColor" size={15} />
+      </Button>
+    </span>
+  );
+};
+
 const CreatorStorefrontPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const user = useSelector(selectAuthUser);
+  const authLoading = useSelector(selectAuthLoading);
+  const authError = useSelector(selectAuthError);
   const summaries = useSelector(selectProductSummaries);
   const productsLoading = useSelector(selectProductsLoading);
   const productsError = useSelector(selectProductsError);
   const config = useSelector(selectCreatorStorefrontConfig);
   const configLoading = useSelector(selectCreatorStorefrontConfigLoading);
   const configError = useSelector(selectCreatorStorefrontConfigError);
-  const configSaveLoading = useSelector(selectCreatorStorefrontConfigSaveLoading);
+  const configSaveLoading = useSelector(
+    selectCreatorStorefrontConfigSaveLoading,
+  );
   const configSaveError = useSelector(selectCreatorStorefrontConfigSaveError);
   const isCreator = hasRole(user?.roles, UserRole.CREATOR);
-  const [featuredProductId, setFeaturedProductId] = useState<string | undefined>(
-    undefined,
+  const [draftConfig, setDraftConfig] = useState<DraftStorefrontConfig | null>(
+    null,
   );
-  const [orderedProductIds, setOrderedProductIds] = useState<string[]>([]);
   const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle');
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  const [isMobileCustomize, setIsMobileCustomize] = useState(false);
 
   useEffect(() => {
     if (isCreator && user?.id) {
@@ -71,27 +270,36 @@ const CreatorStorefrontPage: React.FC = () => {
   }, [dispatch, isCreator, user?.id]);
 
   useEffect(() => {
+    if (!window.matchMedia) {
+      return undefined;
+    }
+
+    const query = window.matchMedia('(max-width: 640px)');
+    const update = () => setIsMobileCustomize(query.matches);
+    update();
+    query.addEventListener?.('change', update);
+
+    return () => query.removeEventListener?.('change', update);
+  }, []);
+
+  useEffect(() => {
     if (config) {
-      setFeaturedProductId(config.featuredProductId ?? undefined);
-      setOrderedProductIds(config.productOrderIds);
+      setDraftConfig(normalizeDraftConfig(config));
     }
   }, [config]);
 
-  const rawProducts: ProductMinimised[] = useMemo(() => {
-    if (summaries && summaries.length > 0) {
-      return summaries;
-    }
-
-    return [];
-  }, [summaries]);
-
+  const rawProducts: ProductMinimised[] = useMemo(
+    () => summaries ?? [],
+    [summaries],
+  );
   const allProducts = useMemo(
     () => normalizeStorefrontProducts(rawProducts),
     [rawProducts],
   );
+  const draft = draftConfig ?? normalizeDraftConfig(config);
   const orderedProducts = useMemo(
-    () => orderStorefrontProducts(allProducts, orderedProductIds),
-    [allProducts, orderedProductIds],
+    () => orderStorefrontProducts(allProducts, draft.productOrderIds),
+    [allProducts, draft.productOrderIds],
   );
   const publicProducts = useMemo(
     () => getPublicStorefrontProducts(orderedProducts),
@@ -100,44 +308,62 @@ const CreatorStorefrontPage: React.FC = () => {
   const profile = useMemo(() => getProfileFromUser(user), [user]);
   const publicStorefrontUrl = `/app/store/${user?.id || 'creator'}`;
   const absoluteStorefrontUrl = `${window.location.origin}${publicStorefrontUrl}`;
-  const hasPublishableProducts = publicProducts.length > 0;
   const hiddenCount = allProducts.length - publicProducts.length;
+  const hasUnsavedChanges =
+    Boolean(config) &&
+    JSON.stringify(normalizeDraftConfig(config)) !== JSON.stringify(draft);
 
   const storefront = useMemo(
     () =>
       getStorefrontViewModel({
         profile,
         products: orderedProducts,
-        featuredProductId,
+        featuredProductId: draft.featuredProductId ?? undefined,
+        theme: draft.theme,
       }),
-    [featuredProductId, orderedProducts, profile],
+    [draft.featuredProductId, draft.theme, orderedProducts, profile],
   );
 
-  const persistConfig = (
-    nextFeaturedProductId: string | undefined,
-    nextOrderedProductIds: string[],
-  ) => {
-    dispatch(
-      updateCreatorStorefrontConfig({
-        featuredProductId: nextFeaturedProductId ?? null,
-        productOrderIds: nextOrderedProductIds,
-      }),
-    );
+  const updateDraft = (next: Partial<DraftStorefrontConfig>) => {
+    setDraftConfig((current) => ({
+      ...normalizeDraftConfig(current ?? config),
+      ...next,
+    }));
+  };
+
+  const updateTheme = (nextTheme: Partial<StorefrontTheme>) => {
+    updateDraft({
+      theme: {
+        ...draft.theme,
+        ...nextTheme,
+      },
+    });
+  };
+
+  const saveDraft = () => {
+    dispatch(updateCreatorStorefrontConfig(draft));
+  };
+
+  const resetDraft = () => {
+    setDraftConfig(normalizeDraftConfig(config));
   };
 
   const setFeaturedProduct = (productId: string) => {
     const nextOrder =
-      orderedProductIds.length > 0
-        ? orderedProductIds
+      draft.productOrderIds.length > 0
+        ? draft.productOrderIds
         : allProducts.map((product) => product.id);
-    setFeaturedProductId(productId);
-    persistConfig(productId, nextOrder);
+
+    updateDraft({
+      featuredProductId: productId,
+      productOrderIds: nextOrder,
+    });
   };
 
   const moveProduct = (productId: string, direction: -1 | 1) => {
     const currentOrder =
-      orderedProductIds.length > 0
-        ? orderedProductIds
+      draft.productOrderIds.length > 0
+        ? draft.productOrderIds
         : allProducts.map((product) => product.id);
     const index = currentOrder.indexOf(productId);
     const nextIndex = index + direction;
@@ -151,8 +377,76 @@ const CreatorStorefrontPage: React.FC = () => {
       nextOrder[nextIndex],
       nextOrder[index],
     ];
-    setOrderedProductIds(nextOrder);
-    persistConfig(featuredProductId, nextOrder);
+    updateDraft({ productOrderIds: nextOrder });
+  };
+
+  const saveProfileField = async (
+    field: EditableProfileField,
+    value: string,
+  ) => {
+    const payloadByField: Record<EditableProfileField, UpdateUserRequest> = {
+      displayName: getDisplayNamePayload(value),
+      title: { title: value },
+      tagline: { taglineMission: value },
+      bio: { bio: value },
+      website: { website: value },
+      publicEmail: { publicEmail: value },
+    };
+
+    await dispatch(updateUserDetails(payloadByField[field])).unwrap();
+  };
+
+  const editableFields = {
+    displayName: (value: string) => (
+      <InlineProfileEditor
+        label="Display name"
+        value={value}
+        saving={authLoading}
+        onSave={(next) => saveProfileField('displayName', next)}
+      />
+    ),
+    title: (value: string) => (
+      <InlineProfileEditor
+        label="Title"
+        value={value}
+        saving={authLoading}
+        onSave={(next) => saveProfileField('title', next)}
+      />
+    ),
+    tagline: (value: string) => (
+      <InlineProfileEditor
+        label="Tagline"
+        value={value}
+        saving={authLoading}
+        onSave={(next) => saveProfileField('tagline', next)}
+      />
+    ),
+    bio: (value: string) => (
+      <InlineProfileEditor
+        label="Bio"
+        value={value}
+        multiline
+        saving={authLoading}
+        onSave={(next) => saveProfileField('bio', next)}
+      />
+    ),
+    website: (value: string) => (
+      <InlineProfileEditor
+        label="Website"
+        value={value}
+        saving={authLoading}
+        onSave={(next) => saveProfileField('website', next)}
+      />
+    ),
+    publicEmail: (value: string) => (
+      <InlineProfileEditor
+        label="Public Email"
+        value={value}
+        saving={authLoading}
+        helpText={PUBLIC_EMAIL_POPOVER_COPY}
+        onSave={(next) => saveProfileField('publicEmail', next)}
+      />
+    ),
   };
 
   const copyStorefrontLink = async () => {
@@ -165,28 +459,98 @@ const CreatorStorefrontPage: React.FC = () => {
     }
   };
 
+  const customizeControls = (
+    <div className="storefront-customize">
+      <fieldset>
+        <legend>Appearance</legend>
+        <div className="storefront-customize__segments">
+          {appearanceOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={draft.theme.appearance === option.value}
+              onClick={() => updateTheme({ appearance: option.value })}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Brand color</legend>
+        <div className="storefront-customize__swatches">
+          {accentSwatches.map((color) => (
+            <button
+              key={color}
+              type="button"
+              aria-label={`Use brand color ${color}`}
+              aria-pressed={draft.theme.accentColor === color}
+              style={{ backgroundColor: color }}
+              onClick={() => updateTheme({ accentColor: color })}
+            />
+          ))}
+          <input
+            aria-label="Custom brand color"
+            type="color"
+            value={draft.theme.accentColor}
+            onChange={(event) =>
+              updateTheme({ accentColor: event.target.value })
+            }
+          />
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Typography</legend>
+        <div className="storefront-customize__type-options">
+          {typographyOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={`storefront-customize__type-option storefront-customize__type-option--${option.value.toLowerCase()}`}
+              aria-pressed={draft.theme.typography === option.value}
+              onClick={() => updateTheme({ typography: option.value })}
+            >
+              <strong>{option.label}</strong>
+              <span>{option.preview}</span>
+            </button>
+          ))}
+        </div>
+      </fieldset>
+    </div>
+  );
+
   if (!isCreator) {
     return (
       <section className="storefront-management storefront-management__state">
         <h1>Storefront</h1>
-        <p>Storefront management is available when your active role is Creator.</p>
+        <p>
+          Storefront management is available when your active role is Creator.
+        </p>
       </section>
     );
   }
 
-  const unavailable = !summaries && !productsLoading && !productsError && !configLoading && !config;
+  const unavailable =
+    !summaries &&
+    !productsLoading &&
+    !productsError &&
+    !configLoading &&
+    !config;
 
   return (
-    <div className="storefront-management">
-      <header className="storefront-management__header">
+    <div className="storefront-management storefront-builder">
+      <header className="storefront-builder__chrome">
         <div>
-          <h1>Storefront</h1>
+          <h1>Storefront Builder</h1>
           <p>
-            Manage the fixed public page customers see when you share your
-            Storefront link.
+            {hasUnsavedChanges
+              ? 'Unsaved changes'
+              : 'All Storefront configuration changes are saved'}
           </p>
         </div>
-        <div className="storefront-management__header-actions">
+        <div className="storefront-builder__actions">
           <Button
             type="button"
             variant="secondary"
@@ -195,35 +559,46 @@ const CreatorStorefrontPage: React.FC = () => {
               <GalIcon icon={FiExternalLink} color="currentColor" size={15} />
             }
           >
-            Preview
+            Open public Storefront
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="icon"
+            aria-label="Copy public Storefront link"
+            onClick={copyStorefrontLink}
+          >
+            <GalIcon icon={FiCopy} color="currentColor" size={15} />
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!hasUnsavedChanges || configSaveLoading}
+            onClick={resetDraft}
+            leadingIcon={
+              <GalIcon icon={FiRotateCcw} color="currentColor" size={15} />
+            }
+          >
+            Reset changes
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            loading={configSaveLoading}
+            disabled={!hasUnsavedChanges}
+            onClick={saveDraft}
+            leadingIcon={<GalIcon icon={FiSave} color="currentColor" size={15} />}
+          >
+            Save changes
           </Button>
         </div>
       </header>
 
-      <section className="storefront-management__status" aria-label="Storefront status">
-        <div>
-          <span>Storefront status</span>
-          <strong>{hasPublishableProducts ? 'Public with products' : 'Public profile only'}</strong>
-          <p>
-            {hasPublishableProducts
-              ? 'Customers can see your profile and published products. Draft and hidden products stay private.'
-              : 'Customers can see your profile, but no products are public yet.'}
-          </p>
+      {copyState === 'copied' && (
+        <div className="storefront-builder__toast" role="status">
+          Storefront link copied
         </div>
-        <div className="storefront-management__url">
-          <span>Public URL</span>
-          <code>{publicStorefrontUrl}</code>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={copyStorefrontLink}
-            leadingIcon={<GalIcon icon={FiCopy} color="currentColor" size={15} />}
-          >
-            {copyState === 'copied' ? 'Copied' : 'Copy link'}
-          </Button>
-        </div>
-      </section>
+      )}
 
       {unavailable && (
         <section className="storefront-management__notice" role="status">
@@ -235,156 +610,155 @@ const CreatorStorefrontPage: React.FC = () => {
         </section>
       )}
 
-      {(productsError || configError || configSaveError) && (
-        <section className="storefront-management__notice storefront-management__notice--error" role="alert">
-          <h2>Unable to load Storefront data</h2>
-          <p>{productsError || configError || configSaveError}</p>
+      {(productsError || configError || configSaveError || authError) && (
+        <section
+          className="storefront-management__notice storefront-management__notice--error"
+          role="alert"
+        >
+          <h2>Unable to load or save Storefront data</h2>
+          <p>{productsError || configError || configSaveError || authError}</p>
         </section>
       )}
 
-      {configSaveLoading && (
-        <section className="storefront-management__notice" role="status">
-          <h2>Saving Storefront configuration</h2>
-        </section>
-      )}
-
-      <div className="storefront-management__layout">
-        <div className="storefront-management__controls">
-          <section className="storefront-management__panel" aria-labelledby="storefront-profile-heading">
-            <div className="storefront-management__panel-header">
-              <div>
-                <h2 id="storefront-profile-heading">Public profile</h2>
-                <p>Uses the profile fields already available in your account.</p>
-              </div>
-            </div>
-            <div className="storefront-management__profile">
-              <div className="storefront-management__avatar" aria-hidden="true">
-                {profile.imageUrl ? <img src={profile.imageUrl} alt="" /> : profile.displayName.slice(0, 2)}
-              </div>
-              <dl>
-                <div>
-                  <dt>Name</dt>
-                  <dd>{profile.displayName}</dd>
-                </div>
-                <div>
-                  <dt>Title</dt>
-                  <dd>{profile.title || 'Not set'}</dd>
-                </div>
-                <div>
-                  <dt>Tagline</dt>
-                  <dd>{profile.tagline || 'Not set'}</dd>
-                </div>
-                <div>
-                  <dt>Website</dt>
-                  <dd>{profile.website || 'Not set'}</dd>
-                </div>
-              </dl>
-            </div>
-            <p className="storefront-management__boundary">
-              Profile edits are handled by existing account/profile flows. Storefront
-              ordering and featured selection are saved through Storefront configuration.
-            </p>
-          </section>
-
-          <section className="storefront-management__panel" aria-labelledby="storefront-products-heading">
-            <div className="storefront-management__panel-header">
-              <div>
-                <h2 id="storefront-products-heading">Products</h2>
-                <p>
-                  {publicProducts.length} public, {hiddenCount} draft or hidden.
-                </p>
-              </div>
-            </div>
-
-            {productsLoading || configLoading ? (
-              <div className="storefront-management__notice" role="status">
-                <h3>Loading Storefront products</h3>
-              </div>
-            ) : allProducts.length > 0 ? (
-              <ul className="storefront-management__product-list">
-                {orderedProducts.map((product, index) => {
-                  const isVisible = product.status === 'PUBLISHED';
-                  const isFeatured = product.id === storefront.featuredProductId;
-
-                  return (
-                    <li key={product.id}>
-                      <div className="storefront-management__product-main">
-                        <span>{storefrontProductTypeLabels[product.type]}</span>
-                        <h3>{product.title}</h3>
-                        <p>
-                          {isVisible
-                            ? 'Visible publicly'
-                            : 'Not visible on the public Storefront'}
-                        </p>
-                      </div>
-                      <div className="storefront-management__product-actions">
-                        <StatusBadge
-                          label={storefrontStatusLabels[product.status]}
-                          tone={statusTone[product.status]}
-                          size="sm"
-                        />
-                        <Button
-                          type="button"
-                          variant={isFeatured ? 'primary' : 'secondary'}
-                          size="sm"
-                          disabled={!isVisible || configSaveLoading}
-                          onClick={() => setFeaturedProduct(product.id)}
-                        >
-                          {isFeatured ? 'Featured' : 'Set featured'}
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          aria-label={`Move ${product.title} up`}
-                          disabled={index === 0 || configSaveLoading}
-                          onClick={() => moveProduct(product.id, -1)}
-                        >
-                          <GalIcon
-                            icon={MdKeyboardArrowUp}
-                            color="currentColor"
-                            size={18}
-                          />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          aria-label={`Move ${product.title} down`}
-                          disabled={
-                            index === orderedProducts.length - 1 ||
-                            configSaveLoading
-                          }
-                          onClick={() => moveProduct(product.id, 1)}
-                        >
-                          <GalIcon
-                            icon={MdKeyboardArrowDown}
-                            color="currentColor"
-                            size={18}
-                          />
-                        </Button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            ) : (
-              <div className="storefront-management__notice" role="status">
-                <h3>No products available</h3>
-                <p>Create and publish a product before customers can browse offers.</p>
-              </div>
-            )}
-          </section>
+      <section
+        className="storefront-builder__product-strip"
+        aria-labelledby="storefront-products-builder-heading"
+      >
+        <div>
+          <h2 id="storefront-products-builder-heading">Products</h2>
+          <p>
+            {publicProducts.length} public, {hiddenCount} draft or hidden. Draft
+            and hidden products stay out of the shared public rendering.
+          </p>
         </div>
-
-        <aside className="storefront-management__preview" aria-label="Live Storefront preview">
-          <div className="storefront-management__preview-header">
-            <h2>Live preview</h2>
-            <p>Matches what customers see on your public Storefront.</p>
+        {productsLoading || configLoading ? (
+          <div className="storefront-management__notice" role="status">
+            <h3>Loading Storefront products</h3>
           </div>
-          <StorefrontPublicPage storefront={storefront} preview />
-        </aside>
+        ) : allProducts.length > 0 ? (
+          <ul className="storefront-management__product-list">
+            {orderedProducts.map((product, index) => {
+              const isVisible = product.status === 'PUBLISHED';
+              const isFeatured = product.id === storefront.featuredProductId;
+
+              return (
+                <li key={product.id}>
+                  <div className="storefront-management__product-main">
+                    <span>{storefrontProductTypeLabels[product.type]}</span>
+                    <h3>{product.title}</h3>
+                    <p>
+                      {isVisible
+                        ? 'Visible publicly'
+                        : 'Not visible on the public Storefront'}
+                    </p>
+                  </div>
+                  <div className="storefront-management__product-actions">
+                    <StatusBadge
+                      label={storefrontStatusLabels[product.status]}
+                      tone={statusTone[product.status]}
+                      size="sm"
+                    />
+                    <Button
+                      type="button"
+                      variant={isFeatured ? 'primary' : 'secondary'}
+                      size="sm"
+                      disabled={!isVisible || configSaveLoading}
+                      onClick={() => setFeaturedProduct(product.id)}
+                    >
+                      {isFeatured ? 'Featured' : 'Set featured'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Move ${product.title} up`}
+                      disabled={index === 0 || configSaveLoading}
+                      onClick={() => moveProduct(product.id, -1)}
+                    >
+                      <GalIcon
+                        icon={MdKeyboardArrowUp}
+                        color="currentColor"
+                        size={18}
+                      />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Move ${product.title} down`}
+                      disabled={
+                        index === orderedProducts.length - 1 ||
+                        configSaveLoading
+                      }
+                      onClick={() => moveProduct(product.id, 1)}
+                    >
+                      <GalIcon
+                        icon={MdKeyboardArrowDown}
+                        color="currentColor"
+                        size={18}
+                      />
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <div className="storefront-management__notice" role="status">
+            <h3>No products available</h3>
+            <p>Create and publish a product before customers can browse offers.</p>
+          </div>
+        )}
+      </section>
+
+      <StorefrontPublicPage
+        storefront={storefront}
+        editableFields={editableFields}
+      />
+
+      <div className="storefront-builder__customize">
+        {customizeOpen && !isMobileCustomize && (
+          <aside
+            className="storefront-builder__customize-panel"
+            aria-label="Customize Storefront"
+          >
+            <header>
+              <h2>Customize</h2>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Close customization panel"
+                onClick={() => setCustomizeOpen(false)}
+              >
+                <GalIcon icon={FiX} color="currentColor" size={18} />
+              </Button>
+            </header>
+            {customizeControls}
+          </aside>
+        )}
+        <Button
+          type="button"
+          variant="primary"
+          size="icon"
+          shape="round"
+          className="storefront-builder__fab"
+          aria-label="Customize Storefront"
+          aria-expanded={customizeOpen}
+          onClick={() => setCustomizeOpen((open) => !open)}
+        >
+          <GalIcon icon={FiSliders} color="currentColor" size={20} />
+        </Button>
       </div>
+
+      <Drawer
+        open={customizeOpen && isMobileCustomize}
+        title={<h2>Customize</h2>}
+        onClose={() => setCustomizeOpen(false)}
+        className="storefront-builder__customize-drawer"
+      >
+        {customizeControls}
+      </Drawer>
     </div>
   );
 };

--- a/src/domains/app/pages/creator-specific/storefront-management-page/storefront-management-page.styles.scss
+++ b/src/domains/app/pages/creator-specific/storefront-management-page/storefront-management-page.styles.scss
@@ -1,212 +1,77 @@
 @use '../../../../../styles/index.scss' as *;
 
 .storefront-management {
-  display: flex;
   min-width: 0;
-  flex-direction: column;
-  gap: 24px;
 }
 
-.storefront-management__header,
-.storefront-management__status,
-.storefront-management__panel,
-.storefront-management__preview {
-  border: 1px solid var(--border-subtle);
-  border-radius: $radius-lg;
-  background: var(--surface-panel);
+.storefront-builder {
+  position: relative;
+  margin: -24px;
+  background: var(--surface-canvas);
 }
 
-.storefront-management__header {
+.storefront-builder__chrome {
+  position: sticky;
+  z-index: 20;
+  top: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 18px;
-  padding: 26px;
+  gap: 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(var(--surface-panel-rgb), 0.94);
+  backdrop-filter: blur(16px);
+  padding: 14px 18px;
 
   h1 {
-    margin: 0 0 8px;
-    font-size: clamp(2rem, 4vw, 3rem);
+    margin: 0;
+    font-size: 1.05rem;
   }
 
   p {
-    max-width: 720px;
-    margin: 0;
+    margin: 4px 0 0;
     color: var(--text-secondary);
-    line-height: 1.6;
+    font-size: 0.86rem;
   }
 }
 
-.storefront-management__header-actions {
+.storefront-builder__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
-.storefront-management__status {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
-  gap: 18px;
-  padding: 22px;
-
-  span {
-    display: block;
-    color: var(--text-secondary);
-    font-size: 0.8rem;
-    font-weight: 800;
-    text-transform: uppercase;
-  }
-
-  strong {
-    display: block;
-    margin: 8px 0;
-    font-size: 1.2rem;
-  }
-
-  p {
-    margin: 0;
-    color: var(--text-secondary);
-    line-height: 1.55;
-  }
+.storefront-builder__toast {
+  position: fixed;
+  z-index: 60;
+  top: 76px;
+  right: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-sm;
+  background: var(--surface-panel);
+  box-shadow: var(--shadow-md);
+  color: var(--text-primary);
+  padding: 10px 12px;
 }
 
-.storefront-management__url {
-  display: grid;
-  gap: 10px;
-  align-content: start;
-
-  code {
-    overflow: hidden;
-    border: 1px solid var(--border-subtle);
-    border-radius: $radius-sm;
-    background: var(--surface-canvas);
-    color: var(--text-primary);
-    padding: 10px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-
-.storefront-management__layout {
-  display: grid;
-  grid-template-columns: minmax(420px, 0.86fr) minmax(0, 1.14fr);
-  gap: 24px;
-  align-items: start;
-}
-
-.storefront-management__controls {
-  display: grid;
-  gap: 20px;
-  min-width: 0;
-}
-
-.storefront-management__panel {
-  min-width: 0;
-  padding: 22px;
-}
-
-.storefront-management__panel-header,
-.storefront-management__preview-header {
-  margin-bottom: 18px;
-
-  h2 {
-    margin: 0 0 6px;
-  }
-
-  p {
-    margin: 0;
-    color: var(--text-secondary);
-    line-height: 1.55;
-  }
-}
-
-.storefront-management__profile {
-  display: grid;
-  grid-template-columns: 76px minmax(0, 1fr);
-  gap: 18px;
-  align-items: start;
-
-  dl {
-    display: grid;
-    gap: 12px;
-    margin: 0;
-  }
-
-  dt {
-    color: var(--text-secondary);
-    font-size: 0.76rem;
-    font-weight: 800;
-    text-transform: uppercase;
-  }
-
-  dd {
-    margin: 3px 0 0;
-    color: var(--text-primary);
-  }
-}
-
-.storefront-management__avatar {
-  display: grid;
-  width: 76px;
-  height: 76px;
-  place-items: center;
-  border: 1px solid rgba(var(--brand-primary-rgb), 0.36);
-  border-radius: 50%;
-  background: rgba(var(--brand-primary-rgb), 0.15);
-  color: var(--brand-primary);
-  font-weight: 900;
-  text-transform: uppercase;
-
-  img {
-    width: 100%;
-    height: 100%;
-    border-radius: inherit;
-    object-fit: cover;
-  }
-}
-
-.storefront-management__boundary {
-  margin: 18px 0 0;
-  border-left: 3px solid var(--brand-primary);
-  color: var(--text-secondary);
-  line-height: 1.6;
-  padding-left: 12px;
-}
-
-.storefront-management__product-list {
+.storefront-builder__product-strip {
   display: grid;
   gap: 12px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-panel);
+  padding: 16px 18px;
 
-  li {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 14px;
-    align-items: center;
-    border: 1px solid var(--border-subtle);
-    border-radius: $radius-md;
-    background: var(--surface-canvas);
-    padding: 14px;
-  }
-}
-
-.storefront-management__product-main {
-  min-width: 0;
-
-  span {
-    color: var(--brand-primary);
-    font-size: 0.72rem;
-    font-weight: 800;
-    text-transform: uppercase;
+  > div:first-child {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
   }
 
-  h3 {
-    overflow: hidden;
-    margin: 5px 0;
-    font-size: 1rem;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  h2 {
+    margin: 0;
+    font-size: 0.95rem;
   }
 
   p {
@@ -216,18 +81,68 @@
   }
 }
 
+.storefront-management__product-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(260px, 1fr));
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: grid;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    border: 1px solid var(--border-subtle);
+    border-radius: $radius-sm;
+    background: var(--surface-canvas);
+    padding: 10px;
+  }
+}
+
+.storefront-management__product-main {
+  min-width: 0;
+
+  span {
+    color: var(--brand-primary);
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    overflow: hidden;
+    margin: 3px 0;
+    font-size: 0.92rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  p {
+    overflow: hidden;
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 .storefront-management__product-actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
 }
 
 .storefront-management__notice {
+  margin: 16px 18px;
   border: 1px dashed var(--border-subtle);
   border-radius: $radius-md;
-  background: rgba(var(--surface-panel-rgb), 0.72);
-  padding: 18px;
+  background: rgba(var(--surface-panel-rgb), 0.82);
+  padding: 16px;
 
   h2,
   h3 {
@@ -244,35 +159,204 @@
   border-color: var(--error);
 }
 
-.storefront-management__preview {
-  position: sticky;
-  top: 24px;
-  overflow: hidden;
-  background: var(--surface-canvas);
-  padding: 16px;
-}
-
 .storefront-management__state {
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-lg;
+  background: var(--surface-panel);
   padding: 28px;
 }
 
-@media (max-width: 1180px) {
-  .storefront-management__layout,
-  .storefront-management__status {
-    grid-template-columns: minmax(0, 1fr);
-  }
+.storefront-inline-edit {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  gap: 8px;
+  vertical-align: middle;
 
-  .storefront-management__preview {
-    position: static;
+  > span:first-child {
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 }
 
-@media (max-width: 720px) {
-  .storefront-management__header {
+.storefront-inline-edit--active {
+  display: grid;
+  width: min(100%, 620px);
+  gap: 8px;
+
+  .input-wrapper,
+  .textarea-wrapper {
+    width: 100%;
+  }
+}
+
+.storefront-inline-edit__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.storefront-inline-edit__error {
+  color: var(--error);
+  font-size: 0.82rem;
+}
+
+.storefront-inline-edit__popover {
+  color: var(--storefront-text);
+}
+
+.storefront-builder__customize {
+  position: fixed;
+  z-index: 50;
+  right: 24px;
+  bottom: 24px;
+  display: grid;
+  justify-items: end;
+  gap: 12px;
+}
+
+.storefront-builder__fab {
+  box-shadow: var(--shadow-md);
+}
+
+.storefront-builder__customize-panel {
+  width: min(340px, calc(100vw - 48px));
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-panel);
+  box-shadow: var(--shadow-lg);
+  padding: 14px;
+
+  > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+  }
+}
+
+.storefront-customize {
+  display: grid;
+  gap: 16px;
+
+  fieldset {
+    display: grid;
+    gap: 10px;
+    min-width: 0;
+    margin: 0;
+    border: 0;
+    padding: 0;
+  }
+
+  legend {
+    color: var(--text-secondary);
+    font-size: 0.76rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+}
+
+.storefront-customize__segments,
+.storefront-customize__type-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.storefront-customize__segments button,
+.storefront-customize__type-option {
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-sm;
+  background: var(--surface-canvas);
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 10px 12px;
+
+  &[aria-pressed='true'] {
+    border-color: var(--brand-primary);
+    box-shadow: inset 0 0 0 1px var(--brand-primary);
+  }
+}
+
+.storefront-customize__swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+
+  button,
+  input {
+    width: 34px;
+    height: 34px;
+    border: 2px solid var(--border-subtle);
+    border-radius: 50%;
+    cursor: pointer;
+  }
+
+  button[aria-pressed='true'] {
+    border-color: var(--text-primary);
+  }
+
+  input {
+    overflow: hidden;
+    padding: 0;
+  }
+}
+
+.storefront-customize__type-options {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.storefront-customize__type-option {
+  display: grid;
+  gap: 2px;
+  text-align: left;
+
+  span {
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+  }
+}
+
+.storefront-customize__type-option--classic {
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.storefront-customize__type-option--friendly {
+  font-family: 'Trebuchet MS', Verdana, sans-serif;
+}
+
+.storefront-builder__customize-drawer {
+  display: none;
+}
+
+@media (max-width: 1180px) {
+  .storefront-management__product-list {
+    grid-template-columns: repeat(2, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .storefront-builder {
+    margin: -16px;
+  }
+
+  .storefront-builder__chrome,
+  .storefront-builder__product-strip > div:first-child {
+    align-items: stretch;
     flex-direction: column;
   }
 
-  .storefront-management__profile {
+  .storefront-builder__actions {
+    justify-content: flex-start;
+  }
+
+  .storefront-management__product-list {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -281,8 +365,26 @@
   }
 
   .storefront-management__product-actions {
-    align-items: stretch;
     flex-wrap: wrap;
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .storefront-builder__customize-panel {
+    display: none;
+  }
+
+  .storefront-builder__customize {
+    right: 16px;
+    bottom: 16px;
+  }
+
+  .storefront-builder__customize-drawer {
+    display: grid;
+    height: min(78vh, 680px);
+    align-self: end;
+    border-top-left-radius: $radius-lg;
+    border-top-right-radius: $radius-lg;
   }
 }


### PR DESCRIPTION
Redesigns Creator Storefront management into a live, in-context Storefront Builder.

Replaces the previous management/preview layout with the shared Storefront rendering surface.
Collapses the Creator sidebar while building the Storefront.
Adds inline editing for supported public profile information.
Adds public-email support with login-email fallback and shared Settings behavior.
Adds live Storefront customization for appearance, accent color, and typography.
Adds collapsible floating customization controls with responsive mobile behavior.
Introduces draft/save/reset behavior for Storefront configuration.
Persists theme, featured Product, and Product ordering through Storefront config.
Applies persisted customization to the public Storefront.
Preserves User/Profile, Product, and Storefront configuration ownership boundaries.
Keeps Creator Builder and public Storefront on the shared presentation/view-model architecture.
Updates PROJECT_CONTEXT.md for the new Storefront architecture.

Avatar/image inline editing remains intentionally out of scope until a reusable persisted profile-image upload flow exists.