### PR TITLE
Creator Redesign — Sidebar Account Footer

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -58,11 +58,13 @@ Creator/Admin management routes are visually and structurally separated from buy
 
 - `CreatorAppShell` lives in `src/domains/app/layouts/creator-app-shell/creator-app-shell.component.tsx`.
 - Creator navigation is rendered by `SidebarNav` in `src/domains/app/widgets/sidebar-nav/sidebar-nav.component.tsx` using `appRoutes` from `src/core/constants/routes.ts`.
-- Desktop Creator management uses a persistent collapsible sidebar and a separate account/user control.
-- Tablet/mobile Creator management uses a compact top bar with a drawer navigation.
+- Desktop Creator management uses a persistent collapsible sidebar and does not render the marketplace/shared `TopNavbar`.
+- Creator account controls live in the bottom/footer of the Creator sidebar. The footer reuses `GalUserDropdown`; account, logout, and dev-role behavior must not be duplicated in sidebar code.
+- Expanded sidebar account footer shows the user avatar, display name, primary role label, and dropdown affordance. Collapsed/compact sidebar shows an avatar-only account trigger with an accessible label/title.
+- Tablet/mobile Creator management retains the compact top bar with drawer navigation and the existing account dropdown trigger in that mobile top bar.
 - Product builder routes (`/app/products/create`, `/app/products/edit/*`, and `/app/admin/products/create`) intentionally render outside `CreatorAppShell` so editing can use a focused product workspace.
 - Routes can request the Creator sidebar collapse through `collapseSidebarOnLoad` route metadata. Product edit routes and the Storefront Builder use this existing shell/sidebar behavior.
-- Marketplace/customer routes still use the older `TopNavbar` shell; the marketplace Explore/Search experience is not part of the Creator management IA. The public Storefront route intentionally bypasses both Creator management chrome and the older marketplace chrome.
+- Marketplace/customer routes such as `/app/explore` still use the older `TopNavbar` shell; the marketplace Explore/Search experience is not part of the Creator management IA. The public Storefront route intentionally bypasses both Creator management chrome and the older marketplace chrome.
 
 Current Creator IA:
 
@@ -455,7 +457,7 @@ Responsive Creator UI should change composition intentionally rather than simply
 
 Implemented examples:
 
-- Creator sidebar becomes compact/collapsible on desktop and a mobile drawer at tablet/mobile widths.
+- Creator sidebar becomes compact/collapsible on desktop; its account footer follows expanded/collapsed presentation, while tablet/mobile retains the existing top-bar plus drawer navigation model.
 - Dashboard metrics change layout across breakpoints and panel order changes when content becomes sequential.
 - Products desktop list/table becomes mobile management cards.
 - Customers desktop/tablet list/table becomes mobile customer cards while preserving the stacked mobile filter controls.

--- a/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.component.tsx
+++ b/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.component.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
+import clsx from 'clsx';
+import { HiChevronUpDown } from 'react-icons/hi2';
 
 import {
   AppDispatch,
@@ -8,7 +10,7 @@ import {
   rolePrecedence,
   UserRole,
 } from 'core/api/models';
-import { GalDropdown, UserAvatar } from '@shared/ui';
+import { GalDropdown, GalIcon, UserAvatar } from '@shared/ui';
 import {
   selectAuthUser,
   changeDevUserRole,
@@ -19,12 +21,22 @@ import { getProfileNameInitials } from '@shared/utils';
 
 import './gal-user-dropdown.styles.scss';
 
-const GalUserDropdown: React.FC = () => {
+interface GalUserDropdownProps {
+  variant?: 'default' | 'sidebar';
+  collapsed?: boolean;
+}
+
+const GalUserDropdown: React.FC<GalUserDropdownProps> = ({
+  variant = 'default',
+  collapsed = false,
+}) => {
   const user = useSelector(selectAuthUser);
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const primaryRole = getPrimaryRole(user?.roles);
   const roleOptions = rolePrecedence.filter((role) => role !== primaryRole);
+  const displayName = `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim();
+  const isSidebarTrigger = variant === 'sidebar';
 
   const handleRoleChange = (role: UserRole) => {
     dispatch(changeDevUserRole(role));
@@ -50,22 +62,54 @@ const GalUserDropdown: React.FC = () => {
   }
 
   return (
-    <div className="gal-user-dropdown">
+    <div
+      className={clsx('gal-user-dropdown', {
+        'gal-user-dropdown--sidebar': variant === 'sidebar',
+        'gal-user-dropdown--collapsed': collapsed,
+      })}
+    >
       <GalDropdown
         customClassName="galactica-nav"
         trigger={({ toggle }) => (
           <button
+            type="button"
             onClick={toggle}
             className="user-profile-button inline"
-            aria-label={getProfileNameInitials(user.firstName, user.lastName)}
+            aria-label={
+              isSidebarTrigger
+                ? `Open account menu for ${displayName}`
+                : getProfileNameInitials(user.firstName, user.lastName)
+            }
+            title={
+              isSidebarTrigger && collapsed
+                ? `Open account menu for ${displayName}`
+                : undefined
+            }
           >
-            <span className="user-name">
-              {user.firstName} {user.lastName}
-            </span>
-            <UserAvatar
-              imageUrl={user.imageUrl ?? ''}
-              alt={`${user.firstName} ${user.lastName}`}
-            />
+            {isSidebarTrigger ? (
+              <>
+                <UserAvatar imageUrl={user.imageUrl ?? ''} alt={displayName} />
+                {!collapsed && (
+                  <>
+                    <span className="user-profile-button__identity">
+                      <span className="user-name">{displayName}</span>
+                      <span className="user-role">{primaryRole}</span>
+                    </span>
+                    <GalIcon
+                      icon={HiChevronUpDown}
+                      color="currentColor"
+                      size={16}
+                      className="user-profile-button__chevron"
+                    />
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                <span className="user-name">{displayName}</span>
+                <UserAvatar imageUrl={user.imageUrl ?? ''} alt={displayName} />
+              </>
+            )}
           </button>
         )}
         menu={() => (

--- a/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.styles.scss
+++ b/src/domains/app/components/gal-user-dropdown/gal-user-dropdown.styles.scss
@@ -13,6 +13,42 @@
     color: var(--text-primary);
   }
 
+  .user-role {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .user-profile-button {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-2;
+    border: 1px solid transparent;
+    border-radius: $radius-md;
+    background: transparent;
+    color: var(--text-primary);
+
+    &:focus-visible {
+      outline: none;
+      box-shadow:
+        0 0 0 2px var(--surface-canvas),
+        0 0 0 4px var(--focus-ring);
+    }
+  }
+
+  .user-profile-button__identity {
+    display: grid;
+    min-width: 0;
+    gap: 2px;
+    text-align: left;
+  }
+
+  .user-profile-button__chevron {
+    color: var(--text-secondary);
+    margin-left: auto;
+  }
+
   .galactica-nav {
     width: 350px;
     background: var(--surface-panel-elevated);
@@ -51,6 +87,97 @@
           background: var(--surface-interactive-hover);
         }
       }
+    }
+  }
+}
+
+.gal-user-dropdown--sidebar {
+  display: block;
+  width: 100%;
+
+  .galactica-dropdown {
+    display: block;
+    width: 100%;
+  }
+
+  .user-profile-button {
+    width: 100%;
+    min-height: 54px;
+    padding: $spacing-2;
+
+    &:hover {
+      background: var(--surface-interactive);
+      border-color: var(--border-subtle);
+    }
+  }
+
+  .user-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .galactica-nav {
+    right: auto;
+    left: calc(100% + #{$spacing-3});
+    bottom: 0;
+    top: auto;
+    margin-top: 0;
+  }
+}
+
+.gal-user-dropdown--collapsed {
+  .user-profile-button {
+    width: 44px;
+    min-height: 44px;
+    justify-content: center;
+    margin: 0 auto;
+    padding: 0;
+  }
+}
+
+@media (max-width: $bp-laptop) {
+  .gal-user-dropdown--sidebar {
+    .user-profile-button {
+      width: 44px;
+      min-height: 44px;
+      justify-content: center;
+      margin: 0 auto;
+      padding: 0;
+    }
+
+    .user-profile-button__identity,
+    .user-profile-button__chevron {
+      display: none;
+    }
+  }
+}
+
+@media (max-width: $bp-tablet) {
+  .gal-user-dropdown--sidebar {
+    .user-profile-button {
+      width: 100%;
+      min-height: 54px;
+      justify-content: flex-start;
+      margin: 0;
+      padding: $spacing-2;
+    }
+
+    .user-profile-button__identity {
+      display: grid;
+    }
+
+    .user-profile-button__chevron {
+      display: block;
+    }
+
+    .galactica-nav {
+      left: 0;
+      right: auto;
+      bottom: auto;
+      top: 100%;
+      width: min(350px, calc(100vw - 48px));
+      margin-top: $spacing-2;
     }
   }
 }

--- a/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.test.tsx
+++ b/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.test.tsx
@@ -4,16 +4,12 @@ import React from 'react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { UserRole } from 'core/api/models';
 import authReducer from 'core/store/auth-store/auth.slice';
 import { SidebarLayoutProvider } from 'domains/app/widgets/sidebar-nav';
 import CreatorAppShell from './creator-app-shell.component';
-
-jest.mock('domains/app/components', () => ({
-  GalUserDropdown: () => <div data-testid="user-dropdown" />,
-}));
 
 const renderShell = (initialEntry: string) => {
   const testStore = configureStore({
@@ -60,5 +56,17 @@ describe('CreatorAppShell', () => {
         screen.getByRole('button', { name: 'Expand sidebar' }),
       ).toBeInTheDocument();
     });
+  });
+
+  it('opens the existing user dropdown from the sidebar footer', async () => {
+    renderShell('/app/storefront');
+
+    const accountButton = await screen.findByRole('button', {
+      name: 'Open account menu for Maya Rivera',
+    });
+    fireEvent.click(accountButton);
+
+    expect(screen.getByText('maya@example.test')).toBeInTheDocument();
+    expect(screen.getByText('Role: CREATOR')).toBeInTheDocument();
   });
 });

--- a/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.tsx
+++ b/src/domains/app/layouts/creator-app-shell/creator-app-shell.component.tsx
@@ -78,9 +78,6 @@ const CreatorAppShell: React.FC = () => {
       )}
 
       <div className="creator-app-shell__main">
-        <div className="creator-app-shell__account">
-          <GalUserDropdown />
-        </div>
         <main className="creator-app-shell__content">
           <Outlet />
         </main>

--- a/src/domains/app/layouts/creator-app-shell/creator-app-shell.styles.scss
+++ b/src/domains/app/layouts/creator-app-shell/creator-app-shell.styles.scss
@@ -20,13 +20,6 @@
     position: relative;
   }
 
-  &__account {
-    position: absolute;
-    top: $spacing-5;
-    right: $spacing-6;
-    z-index: var(--z-sticky);
-  }
-
   &__content {
     min-height: 100dvh;
     padding: $spacing-8 $spacing-7 $spacing-8;
@@ -69,8 +62,7 @@
     display: block;
     padding-top: 64px;
 
-    &__sidebar,
-    &__account {
+    &__sidebar {
       display: none;
     }
 

--- a/src/domains/app/pages/app-layout/app-layout.component.test.tsx
+++ b/src/domains/app/pages/app-layout/app-layout.component.test.tsx
@@ -1,0 +1,93 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+
+import { UserRole } from 'core/api/models';
+import authReducer from 'core/store/auth-store/auth.slice';
+import AppLayout from './app-layout.component';
+
+jest.mock('domains/app/widgets/top-navbar', () => ({
+  TopNavbar: () => <nav data-testid="top-navbar">Top navbar</nav>,
+}));
+
+jest.mock('domains/app/layouts/creator-app-shell', () => ({
+  CreatorAppShell: () => (
+    <section data-testid="creator-shell">
+      Creator shell
+      <Outlet />
+    </section>
+  ),
+}));
+
+const renderLayout = (initialEntry: string, roles = [UserRole.CREATOR]) => {
+  const testStore = configureStore({
+    reducer: {
+      auth: authReducer,
+    },
+    preloadedState: {
+      auth: {
+        user: {
+          id: 'user-1',
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'test@example.test',
+          roles,
+        },
+        loading: false,
+        error: null,
+        isUserLoggedIn: true,
+      },
+    },
+  });
+
+  return render(
+    <Provider store={testStore}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/app" element={<AppLayout />}>
+            <Route index element={<div>Creator dashboard</div>} />
+            <Route path="explore" element={<div>Explore page</div>} />
+            <Route path="products/create" element={<div>Product builder</div>} />
+            <Route path="storefront" element={<div>Storefront builder</div>} />
+            <Route path="store/:creatorId" element={<div>Public Storefront</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+describe('AppLayout shell ownership', () => {
+  it('does not render TopNavbar for Creator management routes', () => {
+    renderLayout('/app');
+
+    expect(screen.getByTestId('creator-shell')).toBeInTheDocument();
+    expect(screen.queryByTestId('top-navbar')).toBeNull();
+  });
+
+  it('does not render TopNavbar for Storefront Builder', () => {
+    renderLayout('/app/storefront');
+
+    expect(screen.getByTestId('creator-shell')).toBeInTheDocument();
+    expect(screen.queryByTestId('top-navbar')).toBeNull();
+  });
+
+  it('keeps TopNavbar for marketplace routes that use shared app navigation', () => {
+    renderLayout('/app/explore', [UserRole.USER]);
+
+    expect(screen.getByTestId('top-navbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('creator-shell')).toBeNull();
+  });
+
+  it('keeps Product Builder outside Creator shell and marketplace top nav', () => {
+    renderLayout('/app/products/create');
+
+    expect(screen.getByText('Product builder')).toBeInTheDocument();
+    expect(screen.queryByTestId('creator-shell')).toBeNull();
+    expect(screen.queryByTestId('top-navbar')).toBeNull();
+  });
+});

--- a/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.test.tsx
+++ b/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
@@ -11,6 +11,14 @@ import { SidebarLayoutProvider } from './sidebar-layout.context';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+}));
+
+jest.mock('domains/app/components', () => ({
+  GalUserDropdown: ({ collapsed }: { collapsed?: boolean }) => (
+    <button type="button">
+      {collapsed ? 'Account footer collapsed' : 'Account footer expanded'}
+    </button>
+  ),
 }));
 
 const renderSidebar = (roles: UserRole[]) => {
@@ -84,5 +92,23 @@ describe('SidebarNav', () => {
       'aria-disabled',
       'true',
     );
+  });
+
+  it('renders the account dropdown trigger in the expanded sidebar footer', () => {
+    renderSidebar([UserRole.CREATOR]);
+
+    expect(
+      screen.getByRole('button', { name: 'Account footer expanded' }),
+    ).toBeInTheDocument();
+  });
+
+  it('passes collapsed state to the sidebar account footer trigger', () => {
+    renderSidebar([UserRole.CREATOR]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Account footer collapsed' }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.tsx
+++ b/src/domains/app/widgets/sidebar-nav/sidebar-nav.component.tsx
@@ -9,6 +9,7 @@ import { hasAnyRole } from 'core/api/models';
 import { selectAuthUser } from 'core/store/auth-store';
 import { GalIcon } from '@shared/ui';
 import { getCssVar } from '@shared/utils';
+import { GalUserDropdown } from 'domains/app/components';
 import { useSidebarLayout } from './sidebar-layout.context';
 
 import './sidebar-nav.styles.scss';
@@ -99,6 +100,9 @@ const SidebarNav: React.FC<SidebarNavProps> = ({ onNavigate }) => {
           <li key={route.path}>{renderRoute(route)}</li>
         ))}
       </ul>
+      <div className="sidebar-nav__account">
+        <GalUserDropdown variant="sidebar" collapsed={isSidebarCollapsed} />
+      </div>
       <button
         type="button"
         className="sidebar-nav-toggle"

--- a/src/domains/app/widgets/sidebar-nav/sidebar-nav.styles.scss
+++ b/src/domains/app/widgets/sidebar-nav/sidebar-nav.styles.scss
@@ -31,6 +31,10 @@
         }
       }
     }
+
+    .sidebar-nav__account {
+      padding: $spacing-3 0 0;
+    }
   }
 
   .logo-container {
@@ -108,6 +112,13 @@
     }
   }
 
+  &__account {
+    flex: 0 0 auto;
+    margin-top: $spacing-3;
+    padding-top: $spacing-3;
+    border-top: 1px solid var(--border-subtle);
+  }
+
   .sidebar-nav-toggle {
     position: absolute;
     right: -16px;
@@ -168,6 +179,10 @@
     .sidebar-nav-toggle {
       display: none;
     }
+
+    .sidebar-nav__account {
+      padding: $spacing-3 0 0;
+    }
   }
 }
 
@@ -191,6 +206,10 @@
       span {
         display: inline;
       }
+    }
+
+    .sidebar-nav__account {
+      padding: $spacing-3 $spacing-3 0;
     }
   }
 }


### PR DESCRIPTION
## Summary

Cleans up the Creator shell by moving account controls from the redundant desktop overlay into the Creator sidebar footer.

## Changes

- Removed the floating desktop account/dropdown control from `CreatorAppShell`.
- Added the existing `GalUserDropdown` trigger to the bottom of `SidebarNav`.
- Expanded sidebar shows avatar, display name, role, and chevron.
- Collapsed/compact sidebar shows an avatar-only account trigger.
- Reused the existing dropdown and account/logout/dev-role behavior.
- Preserved marketplace/shared `TopNavbar` behavior.
- Preserved Product Builder and Storefront Builder collapsed-shell behavior.
- Preserved the existing mobile Creator drawer/top-bar model.
- Added accessible button semantics, labels, titles, and focus behavior.

## Validation

- Focused shell/sidebar/router tests passed.
- TypeScript passed.
- Full Jest suite passed: 79 suites / 438 tests.
- Lint passed with 0 errors and the existing warning backlog.