### PR TITLE
Creator Redesign — Product Overview V1

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -62,6 +62,7 @@ Creator/Admin management routes are visually and structurally separated from buy
 - Creator account controls live in the bottom/footer of the Creator sidebar. The footer reuses `UserDropdown`; account, logout, and dev-role behavior must not be duplicated in sidebar code.
 - Expanded sidebar account footer shows the user avatar, display name, primary role label, and dropdown affordance. Collapsed/compact sidebar shows an avatar-only account trigger with an accessible label/title.
 - Tablet/mobile Creator management retains the compact top bar with drawer navigation and the existing account dropdown trigger in that mobile top bar.
+- Product Overview routes (`/app/products/:productId`) render inside `CreatorAppShell` as Creator/Admin management inspection pages for individual Products.
 - Product builder routes (`/app/products/create`, `/app/products/edit/*`, and `/app/admin/products/create`) intentionally render outside `CreatorAppShell` so editing can use a focused product workspace.
 - Routes can request the Creator sidebar collapse through `collapseSidebarOnLoad` route metadata. Product edit routes and the Storefront Builder use this existing shell/sidebar behavior.
 - Marketplace/customer routes such as `/app/explore` still use the older `TopNavbar` shell; the marketplace Explore/Search experience is not part of the Creator management IA. The public Storefront route intentionally bypasses both Creator management chrome and the older marketplace chrome.
@@ -124,6 +125,42 @@ Product workspace terminology:
 
 Individual product types share `ProductWorkspaceShell`, while their domain-specific editors remain separate inside `src/domains/app/features/product-form`.
 
+## Product Overview V1
+
+Creator/Admin Product Overview is the management home for one Product. Route separation is intentional:
+
+- Product Overview: `/app/products/:productId`.
+- Focused Product Workspace: `/app/products/edit/:id`.
+- Legacy/type-bearing Product Workspace path: `/app/products/edit/:type/:id`.
+
+Product Overview lives under `src/domains/app/pages/creator-specific/products/product-overview`, renders inside `CreatorAppShell`, and does not use `ProductWorkspaceShell`. Product create/edit Workspace routes continue to render outside `CreatorAppShell`.
+
+Product Overview reuses the existing single-Product read path: Product service → `getProductById` thunk → Product Redux `currentProduct` → existing Product selectors and normalizers. It does not define or require a new Product Overview backend API. The page clears `currentProduct` before loading a route Product ID and renders loaded Product data only when `currentProduct.id` matches the route `productId`, preventing stale previous-product details during route transitions.
+
+Current Product Overview content:
+
+- Back to Products navigation.
+- Product thumbnail when available, Product name, Product type, semantic Product status, description, and updated date.
+- Compact Product details: status, type, price, created date, and updated date.
+- Primary `Edit product` action to Product Workspace.
+- Published-only `View public page` action to the existing buyer-facing Product page.
+
+Type-specific read-only summaries:
+
+- `COURSE`: section/module count, lesson count, and compact section outline.
+- `DOWNLOAD`: section count, file count where loaded Product data supports it, and compact section outline.
+- `CONSULTATION`: configured details such as duration, meeting method, buffers, max sessions per day, messages/policies, and calendar information when present.
+- `MEMBERSHIP`: generic Product information and configured recurring pricing only.
+
+Product Overview V1 intentionally does not include product-scoped revenue, order counts, customer counts, subscribers/members, conversion, charts, recent orders, ratings/reviews, Storefront visibility controls, access/entitlement management, duplicate/archive, explicit publish/unpublish workflow, landing-page customization, SEO, or new backend APIs. Do not use deterministic mocks to imply those capabilities exist.
+
+Creator product navigation principle:
+
+- Product identity links should generally navigate to Product Overview.
+- Explicit editing/building actions should navigate directly to Product Workspace.
+
+This principle currently applies to Creator Products list identities, Creator Dashboard product destinations, Creator Analytics product ranking rows, and Creator Sales product identity links in the ledger and Order Detail. Explicit edit/build actions, such as `Edit product`, builder CTAs, Dashboard attention actions that mean "fix/edit this product", and Admin explicit Edit actions, remain Product Workspace links.
+
 Intentional model decisions:
 
 - Product union types live in `src/core/api/models/product`.
@@ -164,6 +201,7 @@ Implemented / reasonably wired:
 - Creator management shell with Dashboard, Products, Customers, Sales, Analytics, Storefront, and Settings destinations; Help is visible as a disabled planned destination.
 - Creator Dashboard redesign with business metrics, recent activity, top products, and needs-attention panels.
 - Creator Products management redesign with local search/filter/sort, list/table desktop composition, mobile management cards, and distinct empty/loading/error states.
+- Creator Product Overview V1 at `/app/products/:productId` with Product identity/details, real Product-owned type-specific summaries, and edit/public-page actions.
 - Creator Customers management area with a customer list and dedicated customer detail route.
 - Creator Sales management area with overview metrics, an orders ledger, local search/filter/sort/date preset controls, local pagination, responsive layout, empty/no-result states, and contextual order detail inspection.
 - Creator Analytics management area with period-scoped business metrics, performance visualization, product ranking, customer growth, membership health, and payment health.
@@ -220,7 +258,7 @@ Deliberate temporary implementations:
 - `REACT_APP_USE_MOCKS=true` also enables deterministic Creator visual-inspection data for authenticated Creator identity, Products, Dashboard, Analytics, Storefront, and Membership. Customers, Sales, Analytics, Dashboard, Storefront, and Membership use Redux/services/Axios and receive deterministic data from ignored local HTTP mocks rather than feature-level fixture branches. Production must not fake unsupported Creator business metrics, customer records, sales/order/payment records, analytics aggregates, storefront configuration, membership content/feed state, or customer-domain states.
 - Blank section/lesson drafts exist locally until enough data is present for backend creation.
 - Creator Dashboard uses a frontend contract, service, Redux store integration, and ignored local HTTP mock response for the aggregate summary. When the backend contract is unavailable, Dashboard metric panels intentionally render unavailable business states rather than fabricated values.
-- Creator Dashboard Top products rows currently navigate directly to Product Workspace edit routes (`/app/products/edit/{productId}`) because there is no Product Overview destination yet. Future Creator product-entity navigation should prefer Product Overview, with editing/building as a secondary action from that overview.
+- Creator product identity navigation now prefers Product Overview (`/app/products/{productId}`), with explicit editing/building actions kept on Product Workspace (`/app/products/edit/{productId}`).
 - Creator Products inspection fixtures currently come through ignored local mock data in `src/core/api/_mocks.ts` when mocks are enabled.
 - Creator Customers runtime data path is Component → Redux → thunk → Customer service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Creator Sales runtime data path is Component → Redux → thunk → Sales service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
@@ -248,7 +286,7 @@ Implemented Dashboard concepts:
 - Metric direction and metric sentiment are modeled separately in the dashboard inspection fixture types. UI copy is concise while preserving semantic styling and accessible trend labels.
 - Revenue and Sales metric cards navigate to Sales when deterministic inspection data is enabled.
 - Recent activity, Top products, and Needs attention are separate components under `src/domains/app/pages/creator-specific/creator-dashboard/components`.
-- Top products navigate to Product Workspace edit routes when a destination exists.
+- Top products navigate to Product Overview routes when a destination exists.
 - Recent activity rows are only interactive when a meaningful destination exists; customer/member-only activity states without real destinations remain non-interactive.
 - Needs attention actions navigate only when an action path exists.
 - Responsive ordering is intentional: metrics remain first, and when panels become sequential the actionable Needs attention panel takes priority before historical Recent activity.
@@ -276,7 +314,7 @@ Current Sales page patterns:
 - Metrics are scoped to the selected date preset. Ledger results also apply search, status, product, and sort refinements.
 - Desktop uses a compact orders ledger with Date, Customer, Product, Status, Type, and Amount.
 - Tablet/mobile reduce columns and transform ledger rows into compact transaction cards rather than shrinking the desktop table.
-- Order identity opens the contextual Order Detail drawer. Customer identity links to Customer Detail when a customer ID exists. Product identity links to Product Workspace when a product ID exists.
+- Order identity opens the contextual Order Detail drawer. Customer identity links to Customer Detail when a customer ID exists. Product identity links to Product Overview when a product ID exists.
 - Local controls include search by customer/email/order ID, date preset filter, order status filter, product filter, sorting, result count, Clear filters, and local pagination.
 - Empty states distinguish no sales, search-no-results, filter-no-results, and production unavailable states.
 - Mobile uses the shared `Drawer` for filter controls.
@@ -313,7 +351,7 @@ Current Analytics page patterns:
 - Page-level period selection is limited to `Last 7 days`, `Last 30 days`, and `Last 90 days`. There is no custom date-range UI or contract.
 - Summary metrics are Revenue, Orders, Customers, and Active memberships.
 - The Performance visualization supports Revenue and Orders modes over the selected period.
-- Product Performance ranks products by revenue share while showing revenue, orders, share percentage, share meters, rank, and Product Workspace links.
+- Product Performance ranks products by revenue share while showing revenue, orders, share percentage, share meters, rank, and Product Overview links.
 - Customer Growth, Memberships, and Payment Health are separate lower-page sections.
 - Membership analytics currently present active, new, cancelled, churn-rate, and movement visualization when inspection data exists.
 - Payment Health currently presents refund-rate and failed-payment aggregates plus a compact trend visualization.
@@ -401,7 +439,7 @@ Current implemented patterns:
 
 - Desktop uses a compact list/table hybrid with Product, Status, Price, Updated, and Actions columns.
 - Mobile transforms rows into management cards rather than shrinking the desktop table.
-- Product identity/title is the primary navigation to Product Workspace (`/app/products/edit/{product.id}`).
+- Product identity/title is the primary navigation to Product Overview (`/app/products/{product.id}`). Explicit editing actions should use Product Workspace (`/app/products/edit/{product.id}`).
 - There are no permanent Edit buttons and no fake/permanent Publish buttons in the list.
 - Overflow menus render only when meaningful secondary actions exist. Published products can expose Preview (`/app/product/{product.id}`); products with no secondary action do not render an ellipsis just for symmetry.
 - Lifecycle status is shown with compact badges.
@@ -480,12 +518,13 @@ Recent Git history includes admin role/product ownership work, Membership fronte
 - Creator management shell and IA centered on Dashboard, Products, Customers, Sales, Analytics, Storefront, plus Settings utility navigation; Help remains disabled and Marketing is removed from the Creator MVP IA.
 - Creator Dashboard, Products, Customers, Sales, Analytics, and Storefront Builder visual redesigns.
 - Public Storefront implementation at `/app/store/:creatorId`, sharing Storefront presentation/view-model logic with the Creator Storefront Builder.
+- Product Overview V1 at `/app/products/:productId`, establishing Product identity navigation to Overview and edit/build navigation to Product Workspace.
 - Focused Product Workspace shell for product editing.
 
 Likely next steps:
 
 - Polish/fix admin product owner filtering UX beyond raw owner ID.
-- Complete product detail UI using real backend fields.
+- Complete the buyer-facing Product detail/landing page using real backend fields; `/app/product/:id` and `/app/product/:id/:type` remain placeholder-heavy and are not production-ready product landing-page functionality.
 - Implement backend Storefront contracts before relying on production persistence for Storefront configuration; define separate contracts before adding arbitrary page-builder blocks, custom domains, SEO, or analytics.
 - Fix known warnings and cart removal bug.
 - Verify product builder contracts for lesson content, quiz persistence, media upload, and consultation scheduling.

--- a/src/core/api/test-fixtures/creator-dashboard-http.mock.ts
+++ b/src/core/api/test-fixtures/creator-dashboard-http.mock.ts
@@ -62,7 +62,7 @@ export const creatorDashboardSummaryTestFixture: CreatorDashboardSummary = {
       title: 'Product updated',
       context: 'Launch Toolkit',
       timestamp: 'Yesterday',
-      destinationPath: '/app/products/edit/prod-launch-toolkit',
+      destinationPath: '/app/products/prod-launch-toolkit',
     },
   ],
   topProducts: [
@@ -72,7 +72,7 @@ export const creatorDashboardSummaryTestFixture: CreatorDashboardSummary = {
       type: 'Course',
       revenue: '€1,192',
       revenueShare: 100,
-      destinationPath: '/app/products/edit/prod-course-growth',
+      destinationPath: '/app/products/prod-course-growth',
     },
     {
       id: 'prod-launch-toolkit',
@@ -80,7 +80,7 @@ export const creatorDashboardSummaryTestFixture: CreatorDashboardSummary = {
       type: 'Download',
       revenue: '€392',
       revenueShare: 33,
-      destinationPath: '/app/products/edit/prod-launch-toolkit',
+      destinationPath: '/app/products/prod-launch-toolkit',
     },
   ],
   attentionItems: [

--- a/src/core/store/product-store/product.slice.ts
+++ b/src/core/store/product-store/product.slice.ts
@@ -755,4 +755,11 @@ export const updateLessonDetails = updateCourseLesson;
 export const deleteLesson = deleteCourseLesson;
 export const getProductByProductId = getProductById;
 
+export const {
+  clearCurrentProduct,
+  deleteProductFromStore,
+  deleteSectionFromStore,
+  deleteLessonFromStore,
+} = productsSlice.actions;
+
 export default productsSlice.reducer;

--- a/src/domains/app/pages/app-layout/app-layout.component.tsx
+++ b/src/domains/app/pages/app-layout/app-layout.component.tsx
@@ -15,6 +15,7 @@ const CREATOR_ROUTES = [
   '/app',
   '/app/admin/*',
   '/app/products',
+  '/app/products/:productId',
   '/app/customers/*',
   '/app/sales',
   '/app/analytics',

--- a/src/domains/app/pages/creator-specific/creator-analytics/components/product-performance-section.component.tsx
+++ b/src/domains/app/pages/creator-specific/creator-analytics/components/product-performance-section.component.tsx
@@ -32,9 +32,9 @@ const ProductPerformanceSection: React.FC<ProductPerformanceSectionProps> = ({
       {products.map((product, index) => (
         <Link
           key={product.id}
-          to={appRoutes.productsEdit(product.id)}
+          to={appRoutes.productsOverview(product.id)}
           className="analytics-product-ranking__row"
-          aria-label={`Open ${product.name} product workspace`}
+          aria-label={`Open ${product.name} product overview`}
           title={product.name}
         >
           <span className="analytics-product-ranking__rank">{index + 1}</span>

--- a/src/domains/app/pages/creator-specific/creator-analytics/creator-analytics.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/creator-analytics/creator-analytics.component.test.tsx
@@ -60,8 +60,8 @@ const renderAnalytics = () => {
         <Routes>
           <Route path="/app/analytics" element={<CreatorAnalytics />} />
           <Route
-            path="/app/products/edit/:productId"
-            element={<div>Product workspace route</div>}
+            path="/app/products/:productId"
+            element={<div>Product overview route</div>}
           />
         </Routes>
       </MemoryRouter>
@@ -151,9 +151,9 @@ describe('Creator Analytics', () => {
     expect(screen.getByText('34.8%')).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Open Creator Product Growth System product workspace',
+        name: 'Open Creator Product Growth System product overview',
       }),
-    ).toHaveAttribute('href', '/app/products/edit/prod-course-growth');
+    ).toHaveAttribute('href', '/app/products/prod-course-growth');
   });
 
   it('renders customer growth, membership health, and payment health summaries', async () => {

--- a/src/domains/app/pages/creator-specific/creator-dashboard/components/product-performance-list.component.tsx
+++ b/src/domains/app/pages/creator-specific/creator-dashboard/components/product-performance-list.component.tsx
@@ -47,7 +47,7 @@ const ProductPerformanceList: React.FC<ProductPerformanceListProps> = ({
             key={item.id}
             className="product-performance-list__row product-performance-list__row--interactive"
             to={item.destinationPath}
-            aria-label={`Edit ${item.name}`}
+            aria-label={`Open ${item.name} product overview`}
           >
             {content}
           </Link>

--- a/src/domains/app/pages/creator-specific/creator-dashboard/creator-dashboard.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/creator-dashboard/creator-dashboard.component.test.tsx
@@ -172,16 +172,20 @@ describe('<CreatorDashboard />', () => {
     ).toBeNull();
   });
 
-  it('links top products to their product workspaces', async () => {
+  it('links top products to Product Overview routes', async () => {
     renderDashboard();
 
     await screen.findByText('€3,429');
     expect(
-      screen.getByRole('link', { name: /edit creator product growth system/i }),
-    ).toHaveAttribute('href', '/app/products/edit/prod-course-growth');
-    expect(screen.getByRole('link', { name: /edit launch toolkit/i })).toHaveAttribute(
+      screen.getByRole('link', {
+        name: /open creator product growth system product overview/i,
+      }),
+    ).toHaveAttribute('href', '/app/products/prod-course-growth');
+    expect(
+      screen.getByRole('link', { name: /open launch toolkit product overview/i }),
+    ).toHaveAttribute(
       'href',
-      '/app/products/edit/prod-launch-toolkit',
+      '/app/products/prod-launch-toolkit',
     );
   });
 
@@ -191,7 +195,7 @@ describe('<CreatorDashboard />', () => {
     await screen.findByText('€3,429');
     expect(
       screen.getByRole('link', { name: /open product updated: launch toolkit/i }),
-    ).toHaveAttribute('href', '/app/products/edit/prod-launch-toolkit');
+    ).toHaveAttribute('href', '/app/products/prod-launch-toolkit');
     expect(screen.queryByRole('link', { name: /open new sale/i })).toBeNull();
     expect(screen.queryByRole('link', { name: /open payment failed/i })).toBeNull();
   });

--- a/src/domains/app/pages/creator-specific/products/index.ts
+++ b/src/domains/app/pages/creator-specific/products/index.ts
@@ -1,2 +1,3 @@
+export * from './product-overview';
 export * from './product-form';
 export * from './products-list';

--- a/src/domains/app/pages/creator-specific/products/product-overview/index.ts
+++ b/src/domains/app/pages/creator-specific/products/product-overview/index.ts
@@ -1,0 +1,1 @@
+export { default as ProductOverview } from './product-overview.component';

--- a/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.test.tsx
@@ -1,0 +1,211 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import MockAdapter from 'axios-mock-adapter';
+import { Provider } from 'react-redux';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import httpClient from 'core/api/http-client';
+import productReducer from 'core/store/product-store/product.slice';
+import { AbstractProduct } from 'core/api/models';
+
+import ProductOverview from './product-overview.component';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const courseProduct: AbstractProduct = {
+  id: 'course-1',
+  type: 'COURSE',
+  name: 'Creator Product Growth System',
+  description: 'A complete system for packaging and launching creator offers.',
+  status: 'PUBLISHED',
+  price: 149,
+  createdAt: new Date('2026-07-01T09:00:00.000Z'),
+  updatedAt: new Date('2026-08-08T09:00:00.000Z'),
+  sections: [
+    {
+      id: 'section-1',
+      title: 'Positioning foundations',
+      description: 'Clarify the buyer, promise, and launch thesis.',
+      position: 1,
+      lessons: [
+        {
+          id: 'lesson-1',
+          sectionId: 'section-1',
+          title: 'Define the transformation',
+          description: 'Frame the business outcome buyers actually want.',
+          type: 'VIDEO',
+        },
+        {
+          id: 'lesson-2',
+          sectionId: 'section-1',
+          title: 'Price the offer',
+          description: 'Choose a clear price point.',
+          type: 'ARTICLE',
+        },
+      ],
+    },
+  ],
+};
+
+const membershipProduct: AbstractProduct = {
+  id: 'membership-1',
+  type: 'MEMBERSHIP',
+  name: 'Creator Systems Lab membership',
+  status: 'DRAFT',
+  price: 39,
+  pricingModel: 'RECURRING',
+  billingInterval: 'MONTH',
+  currency: 'EUR',
+  createdAt: new Date('2026-07-27T09:00:00.000Z'),
+  updatedAt: new Date('2026-08-10T09:00:00.000Z'),
+};
+
+const renderOverview = (
+  initialEntry = '/app/products/course-1',
+  preloadedCurrentProduct: AbstractProduct | null = null,
+) => {
+  const testStore = configureStore({
+    reducer: {
+      products: productReducer,
+    },
+    preloadedState: {
+      products: {
+        products: null,
+        productSummaries: null,
+        currentProduct: preloadedCurrentProduct,
+        loading: false,
+        error: null,
+      },
+    },
+  });
+
+  return render(
+    <Provider store={testStore}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/app/products/:productId" element={<ProductOverview />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+describe('<ProductOverview />', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mock = new MockAdapter(httpClient, { delayResponse: 0 });
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('renders a loaded Course product with status, pricing, dates, and content summary', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderOverview();
+
+    expect(await screen.findByRole('heading', {
+      name: 'Creator Product Growth System',
+    })).toBeInTheDocument();
+    expect(screen.getAllByText('Published').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Course').length).toBeGreaterThan(0);
+    expect(screen.getByText('€149')).toBeInTheDocument();
+    expect(screen.getByText('Positioning foundations')).toBeInTheDocument();
+    expect(screen.getByText('2 lessons')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Course content' })).toBeInTheDocument();
+  });
+
+  it('clears stale product details and shows loading while the requested product loads', () => {
+    mock.onGet('api/products/course-1').reply(() => new Promise(() => undefined));
+
+    renderOverview('/app/products/course-1', membershipProduct);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByText('Creator Systems Lab membership')).toBeNull();
+  });
+
+  it('renders an unavailable state when the product request fails', async () => {
+    mock.onGet('api/products/course-1').reply(404, { message: 'Not found' });
+
+    renderOverview();
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Product data is not available yet',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('navigates to Product Workspace from Edit product', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderOverview();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit product' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/products/edit/course-1');
+  });
+
+  it('shows the public page action only for published products', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderOverview();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'View public page' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/app/product/course-1/COURSE');
+
+    mock.resetHandlers();
+    mock.onGet('api/products/membership-1').reply(200, membershipProduct);
+    renderOverview('/app/products/membership-1');
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Creator Systems Lab membership',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: 'View public page' }),
+    ).toHaveLength(1);
+    expect(
+      within(
+        screen.getByRole('heading', {
+          name: 'Membership setup',
+        }).closest('.product-overview-page') as HTMLElement,
+      ).queryByRole('button', {
+        name: 'View public page',
+      }),
+    ).toBeNull();
+  });
+
+  it('renders recurring Membership pricing without unsupported member metrics', async () => {
+    mock.onGet('api/products/membership-1').reply(200, membershipProduct);
+
+    renderOverview('/app/products/membership-1');
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Creator Systems Lab membership',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('€39 / month')).toBeInTheDocument();
+    expect(screen.getByText(/Member counts, subscriber access/i)).toBeInTheDocument();
+    expect(screen.queryByText(/subscriber count/i)).toBeNull();
+  });
+});

--- a/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.tsx
@@ -1,0 +1,545 @@
+import React, { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import { HiArrowLeft } from 'react-icons/hi';
+
+import {
+  AbstractProduct,
+  AppDispatch,
+  ProductStatus,
+} from 'core/api/models';
+import {
+  clearCurrentProduct,
+  getProductById,
+  selectCurrentProduct,
+  selectProductsError,
+  selectProductsLoading,
+} from 'core/store/product-store';
+import { PRODUCT_TYPE_REGISTRY } from 'core/constants';
+import { Button, Icon, StatusBadge, StatusBadgeTone } from '@shared/ui';
+import { getCssVar } from '@shared/utils';
+import { appRoutes } from 'domains/app/routes/routes';
+
+import {
+  formatProductDate,
+  formatProductPrice,
+  getProductStatusLabel,
+  getProductTypeLabel,
+} from '../products-list/products-list.utils';
+
+import './product-overview.styles.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const placeholderImage = require('../../../../../../assets/image-placeholder.png');
+
+const productStatusTone: Record<ProductStatus, StatusBadgeTone> = {
+  PUBLISHED: 'success',
+  DRAFT: 'neutral',
+  HIDDEN: 'warning',
+};
+
+const meetingMethodLabel: Record<string, string> = {
+  ZOOM: 'Zoom',
+  GOOGLE_MEET: 'Google Meet',
+  PHONE: 'Phone',
+  OTHER: 'Other',
+};
+
+const getProductTitle = (product: AbstractProduct) =>
+  product.name?.trim() || 'Untitled product';
+
+const getLastUpdatedLabel = (product: AbstractProduct) => {
+  const updated = formatProductDate(product.updatedAt ?? product.createdAt, 'Not updated');
+
+  return updated.iso ? (
+    <time dateTime={updated.iso} title={updated.fullLabel}>
+      Updated {updated.shortLabel}
+    </time>
+  ) : (
+    updated.shortLabel
+  );
+};
+
+const countLessons = (product: AbstractProduct) => {
+  if (product.type !== 'COURSE') {
+    return 0;
+  }
+
+  return product.sections?.reduce(
+    (total, section) => total + (section.lessons?.length ?? 0),
+    0,
+  ) ?? 0;
+};
+
+const countFiles = (product: AbstractProduct) => {
+  if (product.type !== 'DOWNLOAD') {
+    return 0;
+  }
+
+  return product.sections?.reduce(
+    (total, section) => total + (section.files?.length ?? 0),
+    0,
+  ) ?? 0;
+};
+
+const DefinitionList: React.FC<{
+  rows: Array<{ label: string; value?: React.ReactNode }>;
+}> = ({ rows }) => {
+  const visibleRows = rows.filter(
+    (row) => row.value !== undefined && row.value !== null && row.value !== '',
+  );
+
+  if (visibleRows.length === 0) {
+    return null;
+  }
+
+  return (
+    <dl className="product-overview-definition-list">
+      {visibleRows.map((row) => (
+        <div key={row.label}>
+          <dt>{row.label}</dt>
+          <dd>{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+};
+
+const SectionOutline: React.FC<{ product: Extract<AbstractProduct, { type: 'COURSE' | 'DOWNLOAD' }> }> = ({
+  product,
+}) => {
+  const sections = product.sections ?? [];
+  const isCourse = product.type === 'COURSE';
+
+  if (sections.length === 0) {
+    return (
+      <p className="product-overview-empty-copy">
+        {isCourse
+          ? 'No course sections have been added yet.'
+          : 'No download sections have been added yet.'}
+      </p>
+    );
+  }
+
+  return (
+    <div className="product-overview-outline">
+      {sections.map((section, index) => {
+        const itemCount = isCourse
+          ? section.lessons?.length ?? 0
+          : section.files?.length ?? 0;
+        const itemLabel = isCourse
+          ? `${itemCount} ${itemCount === 1 ? 'lesson' : 'lessons'}`
+          : `${itemCount} ${itemCount === 1 ? 'file' : 'files'}`;
+
+        return (
+          <article key={section.id ?? `${section.title}-${index}`}>
+            <div>
+              <h3>{section.title || `Section ${index + 1}`}</h3>
+              {section.description && <p>{section.description}</p>}
+            </div>
+            <span>{itemLabel}</span>
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+const ProductContentSummary: React.FC<{
+  product: AbstractProduct;
+  onEditProduct: () => void;
+}> = ({
+  product,
+  onEditProduct,
+}) => {
+  if (product.type === 'COURSE') {
+    const sectionCount = product.sections?.length ?? 0;
+    const lessonCount = countLessons(product);
+
+    return (
+      <section className="product-overview-panel product-overview-panel--wide">
+        <div className="product-overview-section-heading">
+          <div>
+            <h2>Course content</h2>
+            <p>Read-only outline from the current product sections.</p>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onEditProduct}
+          >
+            Edit curriculum
+          </Button>
+        </div>
+        <div className="product-overview-summary-strip" aria-label="Course summary">
+          <article>
+            <span>Sections</span>
+            <strong>{sectionCount}</strong>
+          </article>
+          <article>
+            <span>Lessons</span>
+            <strong>{lessonCount}</strong>
+          </article>
+        </div>
+        <SectionOutline product={product} />
+      </section>
+    );
+  }
+
+  if (product.type === 'DOWNLOAD') {
+    const sectionCount = product.sections?.length ?? 0;
+    const fileCount = countFiles(product);
+
+    return (
+      <section className="product-overview-panel product-overview-panel--wide">
+        <div className="product-overview-section-heading">
+          <div>
+            <h2>Download contents</h2>
+            <p>Read-only package summary from the loaded download sections.</p>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onEditProduct}
+          >
+            Edit files
+          </Button>
+        </div>
+        <div className="product-overview-summary-strip" aria-label="Download summary">
+          <article>
+            <span>Sections</span>
+            <strong>{sectionCount}</strong>
+          </article>
+          <article>
+            <span>Files</span>
+            <strong>{fileCount}</strong>
+          </article>
+        </div>
+        <SectionOutline product={product} />
+      </section>
+    );
+  }
+
+  if (product.type === 'CONSULTATION') {
+    const details = product.consultationDetails;
+
+    return (
+      <section className="product-overview-panel product-overview-panel--wide">
+        <div className="product-overview-section-heading">
+          <div>
+            <h2>Consultation setup</h2>
+            <p>Configured appointment details for this product.</p>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onEditProduct}
+          >
+            Edit availability
+          </Button>
+        </div>
+        {details ? (
+          <DefinitionList
+            rows={[
+              {
+                label: 'Duration',
+                value: details.durationMinutes
+                  ? `${details.durationMinutes} minutes`
+                  : undefined,
+              },
+              {
+                label: 'Meeting method',
+                value: details.meetingMethod
+                  ? meetingMethodLabel[details.meetingMethod] ?? details.meetingMethod
+                  : undefined,
+              },
+              { label: 'Location', value: details.customLocation },
+              {
+                label: 'Buffer before',
+                value:
+                  details.bufferBeforeMinutes !== undefined
+                    ? `${details.bufferBeforeMinutes} minutes`
+                    : undefined,
+              },
+              {
+                label: 'Buffer after',
+                value:
+                  details.bufferAfterMinutes !== undefined
+                    ? `${details.bufferAfterMinutes} minutes`
+                    : undefined,
+              },
+              {
+                label: 'Max sessions per day',
+                value: details.maxSessionsPerDay,
+              },
+              {
+                label: 'Connected calendars',
+                value:
+                  details.connectedCalendars && details.connectedCalendars.length > 0
+                    ? `${details.connectedCalendars.length} connected`
+                    : undefined,
+              },
+              { label: 'Confirmation message', value: details.confirmationMessage },
+              { label: 'Cancellation policy', value: details.cancellationPolicy },
+            ]}
+          />
+        ) : (
+          <p className="product-overview-empty-copy">
+            Consultation details have not been configured yet.
+          </p>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section className="product-overview-panel product-overview-panel--wide">
+      <div className="product-overview-section-heading">
+        <div>
+          <h2>Membership setup</h2>
+          <p>
+            Membership Overview V1 shows only Product-owned information and
+            configured recurring pricing.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onEditProduct}
+        >
+          Edit membership
+        </Button>
+      </div>
+      <p className="product-overview-empty-copy">
+        Member counts, subscriber access, revenue, and Membership content summaries
+        need dedicated backend-backed contracts before they appear here.
+      </p>
+    </section>
+  );
+};
+
+const ProductOverview: React.FC = () => {
+  const { productId } = useParams();
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const product = useSelector(selectCurrentProduct);
+  const loading = useSelector(selectProductsLoading);
+  const error = useSelector(selectProductsError);
+
+  useEffect(() => {
+    dispatch(clearCurrentProduct());
+
+    if (productId) {
+      dispatch(getProductById({ productId }));
+    }
+  }, [dispatch, productId]);
+
+  const loadedProduct = product?.id === productId ? product : null;
+  const productTitle = loadedProduct ? getProductTitle(loadedProduct) : '';
+  const productTypeLabel = loadedProduct
+    ? getProductTypeLabel(loadedProduct.type)
+    : 'Product';
+  const productIcon = loadedProduct
+    ? PRODUCT_TYPE_REGISTRY[loadedProduct.type].displayIcon
+    : undefined;
+  const productStatus = loadedProduct?.status ?? 'DRAFT';
+  const created = useMemo(
+    () => formatProductDate(loadedProduct?.createdAt, 'Not created'),
+    [loadedProduct?.createdAt],
+  );
+  const updated = useMemo(
+    () => formatProductDate(loadedProduct?.updatedAt, 'Not updated'),
+    [loadedProduct?.updatedAt],
+  );
+
+  if (!productId) {
+    return (
+      <div className="product-overview-page">
+        <Button
+          type="button"
+          variant="tertiary"
+          className="product-overview-back"
+          onClick={() => navigate(appRoutes.products)}
+        >
+          <Icon icon={HiArrowLeft} size={18} color={getCssVar('--brand-primary')} />
+          <span>Products</span>
+        </Button>
+        <div className="product-overview-state">
+          <h2>Product not found</h2>
+          <p>This product route is missing a product ID.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading && !loadedProduct) {
+    return (
+      <div className="product-overview-page">
+        <Button
+          type="button"
+          variant="tertiary"
+          className="product-overview-back"
+          onClick={() => navigate(appRoutes.products)}
+        >
+          <Icon icon={HiArrowLeft} size={18} color={getCssVar('--brand-primary')} />
+          <span>Products</span>
+        </Button>
+        <div className="product-overview-state product-overview-state--loading" role="status">
+          <div className="product-overview-skeleton product-overview-skeleton--hero" />
+          <div className="product-overview-skeleton" />
+          <div className="product-overview-skeleton" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="product-overview-page">
+        <Button
+          type="button"
+          variant="tertiary"
+          className="product-overview-back"
+          onClick={() => navigate(appRoutes.products)}
+        >
+          <Icon icon={HiArrowLeft} size={18} color={getCssVar('--brand-primary')} />
+          <span>Products</span>
+        </Button>
+        <div className="product-overview-state" role="alert">
+          <h2>Product data is not available yet</h2>
+          <p>{error}</p>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => dispatch(getProductById({ productId }))}
+          >
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loadedProduct) {
+    return (
+      <div className="product-overview-page">
+        <Button
+          type="button"
+          variant="tertiary"
+          className="product-overview-back"
+          onClick={() => navigate(appRoutes.products)}
+        >
+          <Icon icon={HiArrowLeft} size={18} color={getCssVar('--brand-primary')} />
+          <span>Products</span>
+        </Button>
+        <div className="product-overview-state">
+          <h2>Product not found</h2>
+          <p>This product is not available.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="product-overview-page">
+      <Button
+        type="button"
+        variant="tertiary"
+        className="product-overview-back"
+        onClick={() => navigate(appRoutes.products)}
+      >
+        <Icon icon={HiArrowLeft} size={18} color={getCssVar('--brand-primary')} />
+        <span>Products</span>
+      </Button>
+
+      <header className="product-overview-hero">
+        <img
+          className="product-overview-hero__thumbnail"
+          src={loadedProduct.imageUrl || placeholderImage}
+          alt=""
+          aria-hidden="true"
+        />
+        <div className="product-overview-hero__identity">
+          <div className="product-overview-hero__eyebrow">
+            <span aria-hidden="true">{productIcon}</span>
+            <span>{productTypeLabel}</span>
+            <StatusBadge
+              label={getProductStatusLabel(productStatus)}
+              tone={productStatusTone[productStatus] ?? 'neutral'}
+              size="sm"
+            />
+          </div>
+          <h1>{productTitle}</h1>
+          {loadedProduct.description ? (
+            <p>{loadedProduct.description}</p>
+          ) : (
+            <p className="product-overview-muted">No description has been added yet.</p>
+          )}
+          <div className="product-overview-hero__updated">
+            {getLastUpdatedLabel(loadedProduct)}
+          </div>
+        </div>
+        <div className="product-overview-hero__actions">
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => navigate(appRoutes.productsEdit(loadedProduct.id))}
+          >
+            Edit product
+          </Button>
+          {loadedProduct.status === 'PUBLISHED' && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() =>
+                navigate(appRoutes.product(loadedProduct.id, loadedProduct.type))
+              }
+            >
+              View public page
+            </Button>
+          )}
+        </div>
+      </header>
+
+      <div className="product-overview-grid">
+        <section className="product-overview-panel">
+          <h2>Product details</h2>
+          <DefinitionList
+            rows={[
+              { label: 'Status', value: getProductStatusLabel(productStatus) },
+              { label: 'Product type', value: productTypeLabel },
+              { label: 'Price', value: formatProductPrice(loadedProduct) },
+              {
+                label: 'Created',
+                value: created.iso ? (
+                  <time dateTime={created.iso} title={created.fullLabel}>
+                    {created.shortLabel}
+                  </time>
+                ) : (
+                  created.shortLabel
+                ),
+              },
+              {
+                label: 'Updated',
+                value: updated.iso ? (
+                  <time dateTime={updated.iso} title={updated.fullLabel}>
+                    {updated.shortLabel}
+                  </time>
+                ) : (
+                  updated.shortLabel
+                ),
+              },
+            ]}
+          />
+        </section>
+
+        <ProductContentSummary
+          product={loadedProduct}
+          onEditProduct={() => navigate(appRoutes.productsEdit(loadedProduct.id))}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ProductOverview;

--- a/src/domains/app/pages/creator-specific/products/product-overview/product-overview.styles.scss
+++ b/src/domains/app/pages/creator-specific/products/product-overview/product-overview.styles.scss
@@ -1,0 +1,343 @@
+@use '../../../../../../styles/index.scss' as *;
+
+.product-overview-page {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-5;
+}
+
+.product-overview-back {
+  width: fit-content;
+}
+
+.product-overview-hero {
+  display: grid;
+  grid-template-columns: 128px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: $spacing-5;
+  padding: $spacing-5;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-1);
+
+  &__thumbnail {
+    width: 128px;
+    aspect-ratio: 1;
+    object-fit: cover;
+    border: 1px solid var(--border-subtle);
+    border-radius: $radius-md;
+    background: var(--surface-2);
+  }
+
+  &__identity {
+    min-width: 0;
+
+    h1 {
+      margin: $spacing-2 0;
+      color: var(--text-primary);
+      font-size: 2.25rem;
+      line-height: 1.05;
+    }
+
+    p {
+      max-width: 58rem;
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+  }
+
+  &__eyebrow,
+  &__updated {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: $spacing-2;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    font-weight: 800;
+  }
+
+  &__updated {
+    margin-top: $spacing-3;
+    font-weight: 600;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: $spacing-2;
+  }
+}
+
+.product-overview-muted,
+.product-overview-empty-copy {
+  color: var(--text-secondary);
+}
+
+.product-overview-grid {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.8fr) minmax(0, 1.4fr);
+  gap: $spacing-4;
+  align-items: start;
+}
+
+.product-overview-panel {
+  padding: $spacing-5;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-1);
+
+  h2 {
+    margin: 0 0 $spacing-4;
+    color: var(--text-primary);
+    font-size: 1.125rem;
+  }
+
+  &--wide {
+    min-width: 0;
+  }
+}
+
+.product-overview-section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: $spacing-4;
+  margin-bottom: $spacing-4;
+
+  h2 {
+    margin-bottom: $spacing-1;
+  }
+
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+}
+
+.product-overview-definition-list {
+  display: grid;
+  gap: $spacing-3;
+  margin: 0;
+
+  div {
+    display: grid;
+    grid-template-columns: minmax(8rem, 0.45fr) minmax(0, 1fr);
+    gap: $spacing-3;
+    padding: $spacing-3 0;
+    border-bottom: 1px solid var(--border-subtle);
+
+    &:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  dt {
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
+
+  dd {
+    min-width: 0;
+    margin: 0;
+    color: var(--text-primary);
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+}
+
+.product-overview-summary-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: $spacing-3;
+  margin-bottom: $spacing-4;
+
+  article {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-1;
+    padding: $spacing-4;
+    border: 1px solid var(--border-subtle);
+    border-radius: $radius-sm;
+    background: var(--surface-2);
+  }
+
+  span {
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    font-weight: 700;
+  }
+
+  strong {
+    color: var(--text-primary);
+    font-size: 1.6rem;
+    line-height: 1;
+  }
+}
+
+.product-overview-outline {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+
+  article {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) max-content;
+    align-items: center;
+    gap: $spacing-3;
+    padding: $spacing-3 $spacing-4;
+    border: 1px solid var(--border-subtle);
+    border-radius: $radius-sm;
+    background: var(--surface-2);
+  }
+
+  h3,
+  p {
+    margin: 0;
+  }
+
+  h3 {
+    color: var(--text-primary);
+    font-size: 0.95rem;
+  }
+
+  p,
+  span {
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+  }
+
+  span {
+    font-weight: 800;
+    white-space: nowrap;
+  }
+}
+
+.product-overview-state {
+  display: flex;
+  min-height: 18rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-3;
+  padding: $spacing-6;
+  text-align: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: $radius-md;
+  background: var(--surface-1);
+
+  h2,
+  p {
+    margin: 0;
+  }
+
+  p {
+    max-width: 34rem;
+    color: var(--text-secondary);
+  }
+}
+
+.product-overview-state--loading {
+  align-items: stretch;
+}
+
+.product-overview-skeleton {
+  height: 76px;
+  border-radius: $radius-md;
+  background: linear-gradient(
+    90deg,
+    var(--surface-2),
+    var(--surface-interactive),
+    var(--surface-2)
+  );
+  background-size: 200% 100%;
+  animation: product-overview-skeleton 1.4s ease-in-out infinite;
+
+  &--hero {
+    height: 156px;
+  }
+}
+
+@keyframes product-overview-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+@media (max-width: $bp-laptop) {
+  .product-overview-hero {
+    grid-template-columns: 104px minmax(0, 1fr);
+
+    &__thumbnail {
+      width: 104px;
+    }
+
+    &__actions {
+      grid-column: 1 / -1;
+      justify-content: flex-start;
+    }
+  }
+
+  .product-overview-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: $bp-mobile) {
+  .product-overview-page {
+    gap: $spacing-4;
+  }
+
+  .product-overview-hero {
+    grid-template-columns: 1fr;
+    padding: $spacing-4;
+
+    &__thumbnail {
+      width: 100%;
+      max-width: 180px;
+    }
+
+    &__identity h1 {
+      font-size: 1.75rem;
+    }
+
+    &__actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
+
+  .product-overview-panel {
+    padding: $spacing-4;
+  }
+
+  .product-overview-section-heading {
+    flex-direction: column;
+  }
+
+  .product-overview-definition-list div {
+    grid-template-columns: 1fr;
+    gap: $spacing-1;
+  }
+
+  .product-overview-summary-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .product-overview-outline article {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/domains/app/pages/creator-specific/products/products-list/product-management-row.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/products-list/product-management-row.component.tsx
@@ -5,6 +5,7 @@ import { FiExternalLink, FiMoreHorizontal } from 'react-icons/fi';
 import { ProductMinimised } from 'core/api/models';
 import { Button, Dropdown, Icon } from '@shared/ui';
 import { getCssVar } from '@shared/utils';
+import { appRoutes } from 'domains/app/routes/routes';
 
 import {
   formatProductPrice,
@@ -27,7 +28,7 @@ const ProductManagementRow: React.FC<ProductManagementRowProps> = ({
   showInspectionRecurringMembership = false,
 }) => {
   const productName = getProductName(product);
-  const workspacePath = `/app/products/edit/${product.id}`;
+  const overviewPath = appRoutes.productsOverview(product.id);
   const status = product.status ?? 'DRAFT';
   const statusLabel = getProductStatusLabel(status);
   const updated = formatProductUpdatedDate(product);
@@ -42,9 +43,9 @@ const ProductManagementRow: React.FC<ProductManagementRowProps> = ({
     <article className="products-management-row">
       <div className="products-management-row__product">
         <Link
-          to={workspacePath}
+          to={overviewPath}
           className="products-management-row__identity"
-          aria-label={`Open ${productName} workspace`}
+          aria-label={`Open ${productName} product overview`}
         >
           <img
             className="products-management-row__thumbnail"
@@ -113,7 +114,11 @@ const ProductManagementRow: React.FC<ProductManagementRowProps> = ({
             )}
             menu={({ close }) => (
               <>
-                <Link to={`/app/product/${product.id}`} role="menuitem" onClick={close}>
+                <Link
+                  to={appRoutes.product(product.id)}
+                  role="menuitem"
+                  onClick={close}
+                >
                   <Icon
                     icon={FiExternalLink}
                     size={15}

--- a/src/domains/app/pages/creator-specific/products/products-list/products-list.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/products-list/products-list.component.test.tsx
@@ -169,14 +169,14 @@ describe('<ProductsList />', () => {
     expect(mockNavigate).toHaveBeenCalledWith('create');
   });
 
-  it('links product identity to the existing Product Workspace route', () => {
+  it('links product identity to the Product Overview route', () => {
     renderProductsList();
 
     expect(
       screen.getByRole('link', {
-        name: 'Open Creator Product Growth System workspace',
+        name: 'Open Creator Product Growth System product overview',
       }),
-    ).toHaveAttribute('href', '/app/products/edit/course-1');
+    ).toHaveAttribute('href', '/app/products/course-1');
   });
 
   it('does not expose permanent Edit or fake Publish buttons', () => {

--- a/src/domains/app/pages/creator-specific/products/products-list/products-list.utils.ts
+++ b/src/domains/app/pages/creator-specific/products/products-list/products-list.utils.ts
@@ -1,5 +1,18 @@
-import { ProductMinimised, ProductStatus, ProductType } from 'core/api/models';
+import {
+  ProductBillingInterval,
+  ProductMinimised,
+  ProductPricingModel,
+  ProductStatus,
+  ProductType,
+} from 'core/api/models';
 import { PRODUCT_TYPE_REGISTRY } from 'core/constants';
+
+interface ProductPricingFields {
+  price?: number | 'free';
+  pricingModel?: ProductPricingModel;
+  billingInterval?: ProductBillingInterval;
+  type?: ProductType;
+}
 
 export type ProductsStatusFilter = 'all' | ProductStatus;
 export type ProductsTypeFilter = 'all' | ProductType;
@@ -51,8 +64,46 @@ export const getProductStatusLabel = (status?: ProductStatus) => {
   return 'Draft';
 };
 
+const billingIntervalLabel: Record<ProductBillingInterval, string> = {
+  MONTH: 'month',
+  YEAR: 'year',
+};
+
+export const formatProductDate = (
+  value?: Date | string | null,
+  fallbackLabel = 'Unavailable',
+) => {
+  if (!value) {
+    return {
+      shortLabel: fallbackLabel,
+      fullLabel: fallbackLabel,
+      iso: undefined,
+    };
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return {
+      shortLabel: fallbackLabel,
+      fullLabel: fallbackLabel,
+      iso: undefined,
+    };
+  }
+
+  return {
+    shortLabel: new Intl.DateTimeFormat('en', {
+      month: 'short',
+      day: 'numeric',
+    }).format(date),
+    fullLabel: new Intl.DateTimeFormat('en', {
+      dateStyle: 'full',
+    }).format(date),
+    iso: date.toISOString(),
+  };
+};
+
 export const formatProductPrice = (
-  product: ProductMinimised,
+  product: ProductPricingFields,
   options: { showInspectionRecurringMembership?: boolean } = {},
 ) => {
   if (product.price === 'free' || product.price === 0) {
@@ -69,10 +120,11 @@ export const formatProductPrice = (
     maximumFractionDigits: Number.isInteger(product.price) ? 0 : 2,
   }).format(product.price);
 
-  if (
-    options.showInspectionRecurringMembership &&
-    product.type === 'MEMBERSHIP'
-  ) {
+  if (product.pricingModel === 'RECURRING' && product.billingInterval) {
+    return `${formatted} / ${billingIntervalLabel[product.billingInterval]}`;
+  }
+
+  if (options.showInspectionRecurringMembership && product.type === 'MEMBERSHIP') {
     return `${formatted} / month`;
   }
 
@@ -81,33 +133,8 @@ export const formatProductPrice = (
 
 export const formatProductUpdatedDate = (product: ProductMinimised) => {
   const value = product.updatedAt ?? product.createdAt;
-  if (!value) {
-    return {
-      shortLabel: 'Not updated',
-      fullLabel: 'No updated date available',
-      iso: undefined,
-    };
-  }
 
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return {
-      shortLabel: 'Not updated',
-      fullLabel: 'No updated date available',
-      iso: undefined,
-    };
-  }
-
-  return {
-    shortLabel: new Intl.DateTimeFormat('en', {
-      month: 'short',
-      day: 'numeric',
-    }).format(date),
-    fullLabel: new Intl.DateTimeFormat('en', {
-      dateStyle: 'full',
-    }).format(date),
-    iso: date.toISOString(),
-  };
+  return formatProductDate(value, 'Not updated');
 };
 
 export const filterAndSortProducts = (

--- a/src/domains/app/pages/creator-specific/sales-page/sales-page.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/sales-page/sales-page.component.test.tsx
@@ -38,8 +38,8 @@ describe('Creator Sales', () => {
               element={<div>Customer detail route</div>}
             />
             <Route
-              path="/app/products/edit/:productId"
-              element={<div>Product workspace route</div>}
+              path="/app/products/:productId"
+              element={<div>Product overview route</div>}
             />
           </Routes>
         </MemoryRouter>
@@ -195,9 +195,9 @@ describe('Creator Sales', () => {
     ).toHaveAttribute('href', '/app/customers/cust-maya-johnson');
     expect(
       screen.getByRole('link', {
-        name: 'Open Creator Product Growth System workspace',
+        name: 'Open Creator Product Growth System product overview',
       }),
-    ).toHaveAttribute('href', '/app/products/edit/prod-course-growth');
+    ).toHaveAttribute('href', '/app/products/prod-course-growth');
   });
 
   it('renders honest unavailable state when the backend contract is missing', async () => {

--- a/src/domains/app/pages/creator-specific/sales-page/sales-page.component.tsx
+++ b/src/domains/app/pages/creator-specific/sales-page/sales-page.component.tsx
@@ -36,6 +36,7 @@ import {
   salesStatusOptions,
   subscriptionStateLabel,
 } from './creator-sales.utils';
+import { appRoutes } from 'domains/app/routes/routes';
 
 import './sales-page.styles.scss';
 
@@ -422,8 +423,8 @@ const OrderLedgerRow: React.FC<OrderLedgerRowProps> = ({ order, onOpen }) => {
       <div className="sales-ledger-row__product">
         {order.product.id ? (
           <Link
-            to={`/app/products/edit/${order.product.id}`}
-            aria-label={`Open ${order.product.name} workspace`}
+            to={appRoutes.productsOverview(order.product.id)}
+            aria-label={`Open ${order.product.name} product overview`}
           >
             {productContent}
           </Link>
@@ -500,8 +501,8 @@ const OrderDetailDrawer: React.FC<OrderDetailDrawerProps> = ({
               <p className="order-detail__primary">{order.product.name}</p>
               <p>{order.product.type}</p>
               {order.product.id && (
-                <Link to={`/app/products/edit/${order.product.id}`}>
-                  Open product workspace
+                <Link to={appRoutes.productsOverview(order.product.id)}>
+                  View product overview
                 </Link>
               )}
             </div>

--- a/src/domains/app/routes/app-router.test.tsx
+++ b/src/domains/app/routes/app-router.test.tsx
@@ -46,6 +46,7 @@ jest.mock('../pages', () => {
     LibraryPage: MockOutletPage,
     Onboarding: makePage('Onboarding'),
     ProductForm: makePage('Product form'),
+    ProductOverview: makePage('Product overview'),
     ProductPage: makePage('Product page'),
     ProductsList: makePage('Products list'),
     SalesPage: makePage('Sales'),
@@ -115,6 +116,16 @@ describe('AppRouter role routing', () => {
     renderRouter([UserRole.CREATOR], '/customers/cust-1');
 
     expect(screen.getByText('Customer detail')).toBeInTheDocument();
+  });
+
+  it('renders the Product Overview route without colliding with Product Workspace routes', () => {
+    renderRouter([UserRole.CREATOR], '/products/product-1');
+
+    expect(screen.getByText('Product overview')).toBeInTheDocument();
+
+    renderRouter([UserRole.CREATOR], '/products/edit/product-1');
+
+    expect(screen.getByText('Product form')).toBeInTheDocument();
   });
 
   it('renders the Creator Storefront route and redirects the legacy preview route', () => {

--- a/src/domains/app/routes/app-router.tsx
+++ b/src/domains/app/routes/app-router.tsx
@@ -21,6 +21,7 @@ import {
   LibraryPage,
   Onboarding,
   ProductForm,
+  ProductOverview,
   ProductPage,
   ProductsList,
   CustomersList,
@@ -114,6 +115,7 @@ const AppRouter: React.FC = () => (
           <Route path="create" element={<ProductForm />} />
           <Route path="edit/:id" element={<ProductForm />} />
           <Route path="edit/:type/:id" element={<ProductForm />} />
+          <Route path=":productId" element={<ProductOverview />} />
         </Route>
 
         <Route

--- a/src/domains/app/routes/routes.ts
+++ b/src/domains/app/routes/routes.ts
@@ -7,6 +7,7 @@ export const appRoutes = {
   store: (creatorId = ':creatorId') => `/app/store/${creatorId}`,
 
   products: '/app/products',
+  productsOverview: (productId = ':productId') => `/app/products/${productId}`,
   productsCreate: '/app/products/create',
   productsEdit: (id = ':id') => `/app/products/edit/${id}`,
   customers: '/app/customers',


### PR DESCRIPTION
Adds a dedicated Creator/Admin Product Overview as the default management destination for individual products.

- Adds /app/products/:productId inside CreatorAppShell
- Keeps /app/products/edit/:id as the focused Product Workspace
- Adds responsive Overview identity, product details, pricing, status, and type-specific content summaries
- Adds Edit and published public-page actions
- Migrates product identity navigation from Products, Dashboard, Analytics, and Sales to Product Overview
- Reuses the existing single-Product loading architecture with stale-product protection
- Updates PROJECT_CONTEXT.md with the new route, navigation model, data boundaries, and V1 limitations
- Does not add product-scoped analytics, unsupported actions, new backend APIs, or landing-page customization

Verification

6 test suites passed
49 tests passed
TypeScript passed
Lint passed with existing warnings only