### PR TITLE
Creator Redesign — Product Landing Page V2

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -63,6 +63,7 @@ Creator/Admin management routes are visually and structurally separated from buy
 - Expanded sidebar account footer shows the user avatar, display name, primary role label, and dropdown affordance. Collapsed/compact sidebar shows an avatar-only account trigger with an accessible label/title.
 - Tablet/mobile Creator management retains the compact top bar with drawer navigation and the existing account dropdown trigger in that mobile top bar.
 - Product Overview routes (`/app/products/:productId`) render inside `CreatorAppShell` as Creator/Admin management inspection pages for individual Products.
+- Product Landing Page Builder routes (`/app/products/:productId/landing-page`) render inside `CreatorAppShell` and use route metadata to request sidebar collapse, matching the focused live-editing feel of Storefront Builder while remaining in Creator management IA.
 - Product builder routes (`/app/products/create`, `/app/products/edit/*`, and `/app/admin/products/create`) intentionally render outside `CreatorAppShell` so editing can use a focused product workspace.
 - Routes can request the Creator sidebar collapse through `collapseSidebarOnLoad` route metadata. Product edit routes and the Storefront Builder use this existing shell/sidebar behavior.
 - Marketplace/customer routes such as `/app/explore` still use the older `TopNavbar` shell; the marketplace Explore/Search experience is not part of the Creator management IA. The public Storefront route intentionally bypasses both Creator management chrome and the older marketplace chrome.
@@ -132,6 +133,7 @@ Creator/Admin Product Overview is the management home for one Product. Route sep
 - Product Overview: `/app/products/:productId`.
 - Focused Product Workspace: `/app/products/edit/:id`.
 - Legacy/type-bearing Product Workspace path: `/app/products/edit/:type/:id`.
+- Public Product Landing Page: `/app/product/:id` and compatibility path `/app/product/:id/:type`.
 
 Product Overview lives under `src/domains/app/pages/creator-specific/products/product-overview`, renders inside `CreatorAppShell`, and does not use `ProductWorkspaceShell`. Product create/edit Workspace routes continue to render outside `CreatorAppShell`.
 
@@ -143,6 +145,7 @@ Current Product Overview content:
 - Product thumbnail when available, Product name, Product type, semantic Product status, description, and updated date.
 - Compact Product details: status, type, price, created date, and updated date.
 - Primary `Edit product` action to Product Workspace.
+- Secondary `Edit landing page` action to Product Landing Page Builder.
 - Published-only `View public page` action to the existing buyer-facing Product page.
 
 Type-specific read-only summaries:
@@ -152,14 +155,69 @@ Type-specific read-only summaries:
 - `CONSULTATION`: configured details such as duration, meeting method, buffers, max sessions per day, messages/policies, and calendar information when present.
 - `MEMBERSHIP`: generic Product information and configured recurring pricing only.
 
-Product Overview V1 intentionally does not include product-scoped revenue, order counts, customer counts, subscribers/members, conversion, charts, recent orders, ratings/reviews, Storefront visibility controls, access/entitlement management, duplicate/archive, explicit publish/unpublish workflow, landing-page customization, SEO, or new backend APIs. Do not use deterministic mocks to imply those capabilities exist.
+Product Overview V1 intentionally does not include product-scoped revenue, order counts, customer counts, subscribers/members, conversion, charts, recent orders, ratings/reviews, Storefront visibility controls, access/entitlement management, duplicate/archive, explicit publish/unpublish workflow, inline landing-page customization controls, SEO, or new backend APIs. Do not use deterministic mocks to imply those capabilities exist.
 
 Creator product navigation principle:
 
 - Product identity links should generally navigate to Product Overview.
-- Explicit editing/building actions should navigate directly to Product Workspace.
+- Explicit `Edit product` and Product building actions should navigate directly to Product Workspace.
+- Explicit `Edit landing page` actions should navigate to Product Landing Page Builder.
+- Explicit `View public page` actions should navigate to the public Product Landing Page.
 
 This principle currently applies to Creator Products list identities, Creator Dashboard product destinations, Creator Analytics product ranking rows, and Creator Sales product identity links in the ledger and Order Detail. Explicit edit/build actions, such as `Edit product`, builder CTAs, Dashboard attention actions that mean "fix/edit this product", and Admin explicit Edit actions, remain Product Workspace links.
+
+## Product Landing Page V2 Foundation
+
+Public Product Landing Page V2 replaces the legacy placeholder-heavy `ProductPage` presentation behind `/app/product/:id` and `/app/product/:id/:type`.
+
+Current route separation:
+
+- Creator Product Overview: `/app/products/:productId`.
+- Creator Product Landing Page Builder: `/app/products/:productId/landing-page`.
+- Focused Product Workspace: `/app/products/edit/:id` and `/app/products/edit/:type/:id`.
+- Public Product Landing Page: `/app/product/:id`; `/app/product/:id/:type` remains a compatibility path that redirects to the canonical ID-only path when the type segment does not match the loaded Product.
+
+Product Overview and Product Landing Page Builder render within the Creator management architecture. Product Workspace remains the focused editing workspace outside the normal Creator shell. The public Product route owns route params, loading/error/unavailable states, temporary data composition, public visibility checks, and compatibility redirects. It renders the shared `ProductLandingPage` presentation under `src/domains/app/features/product-landing-page`. The authenticated Creator Product Landing Page Builder reuses the same shared presentation as its live preview; Creator-only editing chrome lives around the shared renderer, not inside it.
+
+Current Product Landing Page data boundary:
+
+- Both the public route and Creator builder still use the existing Product service → `getProductById` thunk → Product Redux `currentProduct` path as a temporary frontend source for canonical Product data.
+- The shared presentation consumes a narrow Product Landing Page view model rather than Redux, route params, or raw Product service responses directly.
+- The route clears stale `currentProduct` before loading a route Product ID and only composes the landing page when the loaded Product ID matches the route ID.
+- Product Landing Page config is a narrow backend-pending domain under `src/core/api/models/product-landing-page`, `src/core/api/services/product-landing-page`, and `src/core/store/product-landing-page-store`. Current runtime path is Component → Redux thunk → Product Landing Page service → Axios → production backend or ignored local HTTP mock. Components must not branch directly on `REACT_APP_USE_MOCKS`.
+- Current service shapes are `GET api/products/:productId/landing-page` for public-safe config reads and `GET`/`PATCH api/creator/products/:productId/landing-page` for authenticated Creator reads/writes. Local ignored HTTP mocks support these endpoints under `REACT_APP_USE_MOCKS=true`; do not treat them as production backend implementation.
+- A dedicated public Product read model remains a future backend requirement. That future read model should provide public-safe Product fields, public Creator presentation, persisted landing-page configuration, public visibility enforcement, and checkout/access availability without requiring the buyer-facing route to orchestrate internal Product/User/Storefront reads.
+
+Current public Product Landing Page behavior:
+
+- Renders only `PUBLISHED` Products as public Product pages. `DRAFT` and `HIDDEN` render an unavailable/not-found-style public state. This frontend guard is not a security boundary; production enforcement still belongs in the future public Product read contract.
+- Uses real Product-owned data: Product type, name, description, price, recurring pricing metadata where present, thumbnail/image, and loaded type-specific content.
+- Removes legacy fake Product page claims such as hardcoded creator name, fake ratings/review/customer counts, fake language, fake durations, placeholder includes, hardcoded short description, placeholder-only image behavior, inert `Buy Now`, and inert `Add to Cart`.
+- Shows honest purchase/access unavailable states because checkout, free-product fulfillment, Membership subscription checkout, entitlement/access, and waitlist contracts are not implemented.
+- Inherits the Creator Storefront theme when an existing real Storefront/theme source is available through current frontend architecture; otherwise it falls back to `DEFAULT_STOREFRONT_THEME`. Product-specific theme overrides are not implemented, and this inheritance affects the public Product presentation/Builder preview rather than Creator management chrome.
+- Applies persisted public-safe Product Landing Page config when available, including marketing description, hero layout, supported secondary section visibility, and supported secondary section order. It must still render safely without depending on a Creator-only endpoint.
+- Renders real Creator identity only when available from the existing public Storefront read model or from current authenticated owner profile state. Anonymous/public creator identity must eventually come from the dedicated public Product read model.
+
+Type-specific public summaries:
+
+- `COURSE`: module/section count, lesson count, curriculum outline, lesson titles, and lesson types from loaded Product sections.
+- `DOWNLOAD`: section count, file/resource count where loaded, section outline, and file names only. It does not expose storage URLs or technical file metadata.
+- `CONSULTATION`: public-relevant configured details such as duration, meeting method, session buffers, daily availability, confirmation/cancellation messaging, and connected calendar availability when present.
+- `MEMBERSHIP`: conservative Product-owned Membership positioning and recurring pricing only. It does not claim member counts, subscriber counts, revenue, entitlement state, or Membership feed details.
+
+Creator Product Landing Page Builder current behavior:
+
+- Route `/app/products/:productId/landing-page` is authenticated for Creator/Admin users and is launched from Product Overview via `Edit landing page`.
+- The builder loads canonical Product data, loads the Product Landing Page config, creates a local draft, and maps Product + draft config + Creator/theme inputs into the shared `ProductLandingPage` preview.
+- Draft edits update the live preview immediately and do not PATCH individually. The `Save` action persists the full landing-page config through the backend-pending Creator config service; `Reset` restores the last persisted config/default normalization. Unsaved state is surfaced by enabled/disabled Save/Reset actions, save loading state, and success/error status copy.
+- Config owns only `marketingDescription`, `heroLayout` (`MEDIA_RIGHT`/`MEDIA_LEFT`), supported secondary-section visibility (`ABOUT`, `CONTENTS`, `CREATOR`), and supported secondary-section order for those IDs.
+- Current customization capabilities are limited to additional marketing/about copy, hero media side/layout, supported secondary-section visibility, and supported page-section order. The Builder reorders page sections, not Course modules, Download files, Consultation fields, or other Product content entities.
+- Desktop Builder customization uses a compact controls panel beside the live preview; mobile customization uses the shared `Drawer` infrastructure.
+- Authenticated Builder can render non-public Product states for editing and displays Product status context. Editing a Draft/Hidden Product landing page does not make it publicly available and does not add a publish workflow.
+- Product-owned fields such as name, description, type, status, price, pricing model, currency, thumbnail, and type-specific content remain read-only here and should be edited through Product Workspace.
+- User/Profile-owned Creator display fields and Storefront/theme ownership are not duplicated into Product Landing Page config. Product-specific theme overrides are intentionally not part of Task 2.
+
+Product Landing Page V2 intentionally does not implement galleries, slideshows, promo video/presentation upload, reusable asset library, checkout, Stripe/PayPal, free Product fulfillment, Membership subscriptions, waitlists, entitlement/access, reviews/ratings, Product analytics, SEO, slugs/custom domains, arbitrary page-builder blocks, or new production backend APIs.
 
 Intentional model decisions:
 
@@ -207,6 +265,8 @@ Implemented / reasonably wired:
 - Creator Analytics management area with period-scoped business metrics, performance visualization, product ranking, customer growth, membership health, and payment health.
 - Creator Storefront Builder at `/app/storefront`, where the shared public Storefront presentation is the live editing surface for profile fields, theme, featured product, and product ordering.
 - Public Storefront page at `/app/store/:creatorId` with creator identity/profile information, featured product when applicable, and a customer-facing published-product catalogue.
+- Public Product Landing Page V2 foundation at `/app/product/:id` with a shared public presentation, honest real Product data, frontend `PUBLISHED` visibility guard, Storefront/default theme inheritance, type-specific real-data summaries, and explicit unavailable purchase/access state.
+- Creator Product Landing Page Builder at `/app/products/:productId/landing-page` with shared `ProductLandingPage` live preview, local Save/Reset draft behavior, and backend-pending config contracts for marketing description, hero layout, and supported secondary-section visibility/order.
 - Product create/edit builder for course/download/consultation/membership basics.
 - Membership builder integration with a Membership Content tab.
 - Generic reusable Product Picker used by Membership included-product selection.
@@ -222,9 +282,9 @@ Implemented / reasonably wired:
 
 Partially implemented / placeholder:
 
-- Product detail page has real loading by product ID but still contains placeholder copy, fake rating/language/duration/creator text, and placeholder image.
 - Creator Help navigation destination is disabled because an implementation is not available yet.
 - Cart/wishlist exist mostly frontend-side/localStorage; persistence/checkout contract is not clearly backend-backed.
+- Public Product Landing Page still uses the existing Product read path as a temporary source. Product Landing Page config has frontend contracts, Redux state, and ignored local HTTP mocks, but production config persistence, a dedicated production public Product read model, public creator payload, server-enforced visibility, and checkout/access/waitlist state remain unimplemented.
 - Membership included products are limited to existing Course/Download products and persist as Membership feed Product-ID associations through backend-pending contracts.
 - Native Membership Post, Video, and Resource content have backend-pending frontend contracts, services, Redux state, and ignored local HTTP mocks. Native Video/Resource binary upload remains unresolved beyond selected file metadata/asset reference.
 - Membership recurring pricing is Product-owned via backend-pending Product pricing fields: `pricingModel`, `billingInterval`, and `currency`, with Product `price` as the amount source of truth.
@@ -266,6 +326,7 @@ Deliberate temporary implementations:
 - Creator Dashboard runtime data path is Component → Redux → thunk → Dashboard service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Public Storefront runtime data path is Component → Redux → thunk → Storefront service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Creator Storefront Builder config runtime data path is Component → Redux → thunk → Storefront service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
+- Product Landing Page config runtime data path is Component → Redux thunk → Product Landing Page service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`. Public Product route currently applies public-safe landing-page config through this transitional contract, while a dedicated production public Product read model remains the long-term owner of public Product payload, landing config, visibility, and checkout/access availability.
 - Membership domain runtime data path is Component → Redux → thunk → Membership service → Axios → backend or ignored local HTTP mock; components do not branch on `REACT_APP_USE_MOCKS`.
 - Download upload deduping is local to the section editor instance.
 - Membership editor drafts, selected File objects, chooser/picker state, active editor state, and active builder tab remain local UI state.
@@ -518,13 +579,15 @@ Recent Git history includes admin role/product ownership work, Membership fronte
 - Creator management shell and IA centered on Dashboard, Products, Customers, Sales, Analytics, Storefront, plus Settings utility navigation; Help remains disabled and Marketing is removed from the Creator MVP IA.
 - Creator Dashboard, Products, Customers, Sales, Analytics, and Storefront Builder visual redesigns.
 - Public Storefront implementation at `/app/store/:creatorId`, sharing Storefront presentation/view-model logic with the Creator Storefront Builder.
+- Product Landing Page V2 foundation at `/app/product/:id`, replacing the legacy placeholder Product page with a shared honest public Product presentation, frontend `PUBLISHED` guard, and persisted public-safe config application when available.
+- Creator Product Landing Page Builder at `/app/products/:productId/landing-page`, launched from Product Overview and using the shared public landing page as a live preview for narrow landing config edits.
 - Product Overview V1 at `/app/products/:productId`, establishing Product identity navigation to Overview and edit/build navigation to Product Workspace.
 - Focused Product Workspace shell for product editing.
 
 Likely next steps:
 
 - Polish/fix admin product owner filtering UX beyond raw owner ID.
-- Complete the buyer-facing Product detail/landing page using real backend fields; `/app/product/:id` and `/app/product/:id/:type` remain placeholder-heavy and are not production-ready product landing-page functionality.
+- Define the production public Product read model and Product Landing Page config persistence so `/app/product/:id` can stop orchestrating internal Product/User/Storefront reads and can rely on server-enforced public visibility.
 - Implement backend Storefront contracts before relying on production persistence for Storefront configuration; define separate contracts before adding arbitrary page-builder blocks, custom domains, SEO, or analytics.
 - Fix known warnings and cart removal bug.
 - Verify product builder contracts for lesson content, quiz persistence, media upload, and consultation scheduling.

--- a/src/core/api/models/index.ts
+++ b/src/core/api/models/index.ts
@@ -7,6 +7,7 @@ export * from './customers';
 export * from './dashboard';
 export * from './files';
 export * from './membership';
+export * from './product-landing-page';
 export * from './product';
 export * from './socials';
 export * from './storefront';

--- a/src/core/api/models/product-landing-page/index.ts
+++ b/src/core/api/models/product-landing-page/index.ts
@@ -1,0 +1,1 @@
+export * from './product-landing-page';

--- a/src/core/api/models/product-landing-page/product-landing-page.ts
+++ b/src/core/api/models/product-landing-page/product-landing-page.ts
@@ -1,0 +1,18 @@
+export type ProductLandingPageHeroLayout = 'MEDIA_RIGHT' | 'MEDIA_LEFT';
+
+export type ProductLandingPageSectionId = 'ABOUT' | 'CONTENTS' | 'CREATOR';
+
+export interface ProductLandingPageConfig {
+  id?: string;
+  productId: string;
+  marketingDescription?: string;
+  heroLayout: ProductLandingPageHeroLayout;
+  visibleSections: ProductLandingPageSectionId[];
+  sectionOrder: ProductLandingPageSectionId[];
+  updatedAt?: string;
+}
+
+export type ProductLandingPageConfigUpdateRequest = Pick<
+  ProductLandingPageConfig,
+  'marketingDescription' | 'heroLayout' | 'visibleSections' | 'sectionOrder'
+>;

--- a/src/core/api/services/index.ts
+++ b/src/core/api/services/index.ts
@@ -5,6 +5,7 @@ export * from './calendar';
 export * from './customers';
 export * from './dashboard';
 export * from './membership';
+export * from './product-landing-page';
 export * from './products';
 export * from './user';
 export * from './reviews';

--- a/src/core/api/services/product-landing-page/index.ts
+++ b/src/core/api/services/product-landing-page/index.ts
@@ -1,0 +1,1 @@
+export * from './product-landing-page-api';

--- a/src/core/api/services/product-landing-page/product-landing-page-api.ts
+++ b/src/core/api/services/product-landing-page/product-landing-page-api.ts
@@ -1,0 +1,42 @@
+import httpClient from 'core/api/http-client';
+import {
+  ProductLandingPageConfig,
+  ProductLandingPageConfigUpdateRequest,
+} from 'core/api/models';
+
+// BACKEND CONTRACT NOT YET IMPLEMENTED: public Product Landing Page config.
+export const getPublicProductLandingPageConfigAPI = async (
+  productId: string,
+): Promise<ProductLandingPageConfig> => {
+  const response = await httpClient.get<ProductLandingPageConfig>(
+    `api/products/${productId}/landing-page`,
+  );
+
+  return response.data;
+};
+
+// BACKEND CONTRACT NOT YET IMPLEMENTED: Creator Product Landing Page config.
+export const getCreatorProductLandingPageConfigAPI = async (
+  productId: string,
+): Promise<ProductLandingPageConfig> => {
+  const response = await httpClient.get<ProductLandingPageConfig>(
+    `api/creator/products/${productId}/landing-page`,
+    { withCredentials: true },
+  );
+
+  return response.data;
+};
+
+// BACKEND CONTRACT NOT YET IMPLEMENTED: Creator Product Landing Page config update.
+export const updateCreatorProductLandingPageConfigAPI = async (
+  productId: string,
+  payload: ProductLandingPageConfigUpdateRequest,
+): Promise<ProductLandingPageConfig> => {
+  const response = await httpClient.patch<ProductLandingPageConfig>(
+    `api/creator/products/${productId}/landing-page`,
+    payload,
+    { withCredentials: true },
+  );
+
+  return response.data;
+};

--- a/src/core/constants/routes.ts
+++ b/src/core/constants/routes.ts
@@ -78,4 +78,11 @@ export const appRoutes: Route[] = [
     hideFromSidebar: true,
     collapseSidebarOnLoad: true,
   },
+  {
+    path: '/app/products/:productId/landing-page',
+    label: 'Landing Page',
+    icon: IoSettingsOutline,
+    hideFromSidebar: true,
+    collapseSidebarOnLoad: true,
+  },
 ];

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -5,6 +5,7 @@ export * from './customers-store';
 export * from './dashboard-store';
 export * from './membership-store';
 export * from './notifications';
+export * from './product-landing-page-store';
 export * from './product-store';
 export * from './sales-store';
 export * from './storefront-store';

--- a/src/core/store/product-landing-page-store/index.ts
+++ b/src/core/store/product-landing-page-store/index.ts
@@ -1,0 +1,3 @@
+export { default as productLandingPageReducer } from './product-landing-page.slice';
+export * from './product-landing-page.slice';
+export * from './product-landing-page.selectors';

--- a/src/core/store/product-landing-page-store/product-landing-page.selectors.ts
+++ b/src/core/store/product-landing-page-store/product-landing-page.selectors.ts
@@ -1,0 +1,37 @@
+import { RootState } from 'core/api/models';
+
+export const selectPublicProductLandingPageConfigByProductId = (
+  state: RootState,
+  productId?: string,
+) =>
+  productId
+    ? (state.productLandingPage.publicByProductId[productId] ?? null)
+    : null;
+
+export const selectPublicProductLandingPageConfigLoading = (state: RootState) =>
+  state.productLandingPage.publicLoading;
+
+export const selectPublicProductLandingPageConfigError = (state: RootState) =>
+  state.productLandingPage.publicError;
+
+export const selectCreatorProductLandingPageConfigByProductId = (
+  state: RootState,
+  productId?: string,
+) =>
+  productId
+    ? (state.productLandingPage.creatorByProductId[productId] ?? null)
+    : null;
+
+export const selectCreatorProductLandingPageConfigLoading = (state: RootState) =>
+  state.productLandingPage.creatorLoading;
+
+export const selectCreatorProductLandingPageConfigError = (state: RootState) =>
+  state.productLandingPage.creatorError;
+
+export const selectCreatorProductLandingPageConfigSaveLoading = (
+  state: RootState,
+) => state.productLandingPage.creatorSaveLoading;
+
+export const selectCreatorProductLandingPageConfigSaveError = (
+  state: RootState,
+) => state.productLandingPage.creatorSaveError;

--- a/src/core/store/product-landing-page-store/product-landing-page.slice.ts
+++ b/src/core/store/product-landing-page-store/product-landing-page.slice.ts
@@ -1,0 +1,142 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import {
+  ProductLandingPageConfig,
+  ProductLandingPageConfigUpdateRequest,
+} from 'core/api/models';
+import {
+  getCreatorProductLandingPageConfigAPI,
+  getPublicProductLandingPageConfigAPI,
+  updateCreatorProductLandingPageConfigAPI,
+} from 'core/api/services';
+import { extractErrorMessage } from '@shared/utils';
+
+interface ProductLandingPageState {
+  publicByProductId: Record<string, ProductLandingPageConfig>;
+  publicLoading: boolean;
+  publicError: string | null;
+  creatorByProductId: Record<string, ProductLandingPageConfig>;
+  creatorLoading: boolean;
+  creatorError: string | null;
+  creatorSaveLoading: boolean;
+  creatorSaveError: string | null;
+}
+
+const initialState: ProductLandingPageState = {
+  publicByProductId: {},
+  publicLoading: false,
+  publicError: null,
+  creatorByProductId: {},
+  creatorLoading: false,
+  creatorError: null,
+  creatorSaveLoading: false,
+  creatorSaveError: null,
+};
+
+export const fetchPublicProductLandingPageConfig = createAsyncThunk<
+  ProductLandingPageConfig,
+  string,
+  { rejectValue: string }
+>(
+  'productLandingPage/fetchPublicProductLandingPageConfig',
+  async (productId, { rejectWithValue }) => {
+    try {
+      return await getPublicProductLandingPageConfigAPI(productId);
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error));
+    }
+  },
+);
+
+export const fetchCreatorProductLandingPageConfig = createAsyncThunk<
+  ProductLandingPageConfig,
+  string,
+  { rejectValue: string }
+>(
+  'productLandingPage/fetchCreatorProductLandingPageConfig',
+  async (productId, { rejectWithValue }) => {
+    try {
+      return await getCreatorProductLandingPageConfigAPI(productId);
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error));
+    }
+  },
+);
+
+export const updateCreatorProductLandingPageConfig = createAsyncThunk<
+  ProductLandingPageConfig,
+  {
+    productId: string;
+    config: ProductLandingPageConfigUpdateRequest;
+  },
+  { rejectValue: string }
+>(
+  'productLandingPage/updateCreatorProductLandingPageConfig',
+  async ({ productId, config }, { rejectWithValue }) => {
+    try {
+      return await updateCreatorProductLandingPageConfigAPI(productId, config);
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error));
+    }
+  },
+);
+
+const productLandingPageSlice = createSlice({
+  name: 'productLandingPage',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchPublicProductLandingPageConfig.pending, (state) => {
+        state.publicLoading = true;
+        state.publicError = null;
+      })
+      .addCase(
+        fetchPublicProductLandingPageConfig.fulfilled,
+        (state, action: PayloadAction<ProductLandingPageConfig>) => {
+          state.publicLoading = false;
+          state.publicByProductId[action.payload.productId] = action.payload;
+        },
+      )
+      .addCase(fetchPublicProductLandingPageConfig.rejected, (state, action) => {
+        state.publicLoading = false;
+        state.publicError =
+          action.payload ?? 'Failed to load Product Landing Page configuration';
+      })
+      .addCase(fetchCreatorProductLandingPageConfig.pending, (state) => {
+        state.creatorLoading = true;
+        state.creatorError = null;
+      })
+      .addCase(
+        fetchCreatorProductLandingPageConfig.fulfilled,
+        (state, action: PayloadAction<ProductLandingPageConfig>) => {
+          state.creatorLoading = false;
+          state.creatorByProductId[action.payload.productId] = action.payload;
+        },
+      )
+      .addCase(fetchCreatorProductLandingPageConfig.rejected, (state, action) => {
+        state.creatorLoading = false;
+        state.creatorError =
+          action.payload ?? 'Failed to load Product Landing Page configuration';
+      })
+      .addCase(updateCreatorProductLandingPageConfig.pending, (state) => {
+        state.creatorSaveLoading = true;
+        state.creatorSaveError = null;
+      })
+      .addCase(
+        updateCreatorProductLandingPageConfig.fulfilled,
+        (state, action: PayloadAction<ProductLandingPageConfig>) => {
+          state.creatorSaveLoading = false;
+          state.creatorByProductId[action.payload.productId] = action.payload;
+          state.publicByProductId[action.payload.productId] = action.payload;
+        },
+      )
+      .addCase(updateCreatorProductLandingPageConfig.rejected, (state, action) => {
+        state.creatorSaveLoading = false;
+        state.creatorSaveError =
+          action.payload ?? 'Failed to save Product Landing Page configuration';
+      });
+  },
+});
+
+export default productLandingPageSlice.reducer;

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -7,6 +7,7 @@ import customersReducer from './customers-store/customers.slice';
 import dashboardReducer from './dashboard-store/dashboard.slice';
 import membershipReducer from './membership-store/membership.slice';
 import notificationsReducer from './notifications/notifications.slice';
+import productLandingPageReducer from './product-landing-page-store/product-landing-page.slice';
 import salesReducer from './sales-store/sales.slice';
 import storefrontReducer from './storefront-store/storefront.slice';
 import shopCartReducer, {
@@ -34,6 +35,7 @@ export const store = configureStore({
     dashboard: dashboardReducer,
     membership: membershipReducer,
     notifications: notificationsReducer,
+    productLandingPage: productLandingPageReducer,
     sales: salesReducer,
     storefront: storefrontReducer,
     shopCart: shopCartReducer,

--- a/src/domains/app/features/index.ts
+++ b/src/domains/app/features/index.ts
@@ -1,6 +1,7 @@
 export * from './onboarding';
 export * from './password-change';
 export * from './product-form';
+export * from './product-landing-page';
 export * from './settings';
 export * from './smart-search';
 export * from './storefront';

--- a/src/domains/app/features/product-landing-page/index.ts
+++ b/src/domains/app/features/product-landing-page/index.ts
@@ -1,0 +1,3 @@
+export { default as ProductLandingPage } from './product-landing-page.component';
+export * from './product-landing-page.types';
+export * from './product-landing-page.utils';

--- a/src/domains/app/features/product-landing-page/product-landing-page.component.tsx
+++ b/src/domains/app/features/product-landing-page/product-landing-page.component.tsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import clsx from 'clsx';
+
+import { ProductLandingPageViewModel } from './product-landing-page.types';
+
+import './product-landing-page.styles.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const placeholderImage = require('../../../../assets/image-placeholder.png');
+
+interface ProductLandingPageProps {
+  product: ProductLandingPageViewModel;
+}
+
+const pluralize = (count: number, singular: string, plural = `${singular}s`) =>
+  `${count} ${count === 1 ? singular : plural}`;
+
+const ProductLandingPage: React.FC<ProductLandingPageProps> = ({ product }) => {
+  const priceLabel = product.price.cadence
+    ? `${product.price.label} / ${product.price.cadence}`
+    : product.price.label;
+
+  const renderTypeSummary = () => {
+    if (product.summary.type === 'COURSE') {
+      return (
+        <section className="product-landing__section" aria-labelledby="product-course-heading">
+          <div className="product-landing__section-heading">
+            <span>Course content</span>
+            <h2 id="product-course-heading">What&apos;s inside</h2>
+            <p>
+              {pluralize(product.summary.sectionCount, 'module')} and{' '}
+              {pluralize(product.summary.lessonCount, 'lesson')} from the current curriculum.
+            </p>
+          </div>
+          {product.summary.sections.length > 0 ? (
+            <div className="product-landing__outline">
+              {product.summary.sections.map((section, index) => (
+                <article key={section.id ?? `${section.title}-${index}`}>
+                  <div>
+                    <span>Module {index + 1}</span>
+                    <h3>{section.title}</h3>
+                    {section.description && <p>{section.description}</p>}
+                  </div>
+                  <strong>{pluralize(section.lessonCount, 'lesson')}</strong>
+                  {section.lessons.length > 0 && (
+                    <ul>
+                      {section.lessons.map((lesson) => (
+                        <li key={lesson.id ?? lesson.title}>
+                          <span>{lesson.title}</span>
+                          {lesson.type && <em>{lesson.type.toLowerCase()}</em>}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="product-landing__empty">
+              Curriculum details are not available yet.
+            </p>
+          )}
+        </section>
+      );
+    }
+
+    if (product.summary.type === 'DOWNLOAD') {
+      return (
+        <section className="product-landing__section" aria-labelledby="product-download-heading">
+          <div className="product-landing__section-heading">
+            <span>Download package</span>
+            <h2 id="product-download-heading">Included resources</h2>
+            <p>
+              {pluralize(product.summary.sectionCount, 'section')} and{' '}
+              {pluralize(product.summary.fileCount, 'file')} from the loaded product package.
+            </p>
+          </div>
+          {product.summary.sections.length > 0 ? (
+            <div className="product-landing__outline">
+              {product.summary.sections.map((section, index) => (
+                <article key={section.id ?? `${section.title}-${index}`}>
+                  <div>
+                    <span>Section {index + 1}</span>
+                    <h3>{section.title}</h3>
+                    {section.description && <p>{section.description}</p>}
+                  </div>
+                  <strong>{pluralize(section.fileCount, 'file')}</strong>
+                  {section.files.length > 0 && (
+                    <ul>
+                      {section.files.map((file) => (
+                        <li key={file.id ?? file.fileName}>
+                          <span>{file.fileName}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="product-landing__empty">
+              Resource details are not available yet.
+            </p>
+          )}
+        </section>
+      );
+    }
+
+    if (product.summary.type === 'CONSULTATION') {
+      return (
+        <section className="product-landing__section" aria-labelledby="product-consultation-heading">
+          <div className="product-landing__section-heading">
+            <span>Consultation details</span>
+            <h2 id="product-consultation-heading">Session format</h2>
+            <p>Configured public-relevant details for this consultation.</p>
+          </div>
+          {product.summary.details.length > 0 ? (
+            <dl className="product-landing__details">
+              {product.summary.details.map((detail) => (
+                <div key={detail.label}>
+                  <dt>{detail.label}</dt>
+                  <dd>{detail.value}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : (
+            <p className="product-landing__empty">
+              Session details are not available yet.
+            </p>
+          )}
+        </section>
+      );
+    }
+
+    return (
+      <section className="product-landing__section" aria-labelledby="product-membership-heading">
+        <div className="product-landing__section-heading">
+          <span>Membership</span>
+          <h2 id="product-membership-heading">Ongoing access product</h2>
+          <p>
+            {product.summary.recurringLabel
+              ? `${product.summary.recurringLabel} is configured on this Product.`
+              : 'Membership pricing details are not available yet.'}
+          </p>
+        </div>
+      </section>
+    );
+  };
+
+  const renderPageSection = (section: string) => {
+    if (section === 'ABOUT' && product.marketingDescription) {
+      return (
+        <section className="product-landing__section" aria-labelledby="product-about-heading">
+          <div className="product-landing__section-heading">
+            <span>About</span>
+            <h2 id="product-about-heading">A closer look</h2>
+          </div>
+          <p>{product.marketingDescription}</p>
+        </section>
+      );
+    }
+
+    if (section === 'CONTENTS') {
+      return <React.Fragment key="contents">{renderTypeSummary()}</React.Fragment>;
+    }
+
+    if (section === 'CREATOR' && product.creator) {
+      return (
+        <section className="product-landing__creator" aria-labelledby="product-creator-heading">
+          {product.creator.imageUrl ? (
+            <img src={product.creator.imageUrl} alt="" />
+          ) : (
+            <span aria-hidden="true">
+              {product.creator.displayName.slice(0, 2).toUpperCase()}
+            </span>
+          )}
+          <div>
+            <span>Creator</span>
+            <h2 id="product-creator-heading">{product.creator.displayName}</h2>
+            {product.creator.title && <p>{product.creator.title}</p>}
+            {product.creator.bio && <p>{product.creator.bio}</p>}
+            <div className="product-landing__creator-links">
+              {product.creator.website && (
+                <a href={product.creator.website} target="_blank" rel="noreferrer">
+                  Website
+                </a>
+              )}
+              {product.creator.publicEmail && (
+                <a href={`mailto:${product.creator.publicEmail}`}>
+                  Contact
+                </a>
+              )}
+            </div>
+          </div>
+        </section>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <article
+      className={clsx(
+        'product-landing',
+        `product-landing--${product.theme.appearance.toLowerCase()}`,
+        `product-landing--type-${product.theme.typography.toLowerCase()}`,
+      )}
+      style={
+        {
+          '--product-landing-accent': product.theme.accentColor,
+        } as React.CSSProperties
+      }
+    >
+      <header
+        className={clsx(
+          'product-landing__hero',
+          `product-landing__hero--${product.heroLayout.toLowerCase().replace('_', '-')}`,
+        )}
+      >
+        <div className="product-landing__hero-copy">
+          <span className="product-landing__eyebrow">{product.typeLabel}</span>
+          <h1>{product.name}</h1>
+          {product.description && <p>{product.description}</p>}
+          <div className="product-landing__hero-facts" aria-label="Product summary">
+            <span>{product.typeLabel}</span>
+            <strong>{priceLabel}</strong>
+          </div>
+        </div>
+
+        <aside className="product-landing__commerce" aria-labelledby="product-purchase-heading">
+          <img
+            src={product.imageUrl || placeholderImage}
+            alt={product.imageAlt}
+          />
+          <div>
+            <span>Price</span>
+            <h2 id="product-purchase-heading">{priceLabel}</h2>
+            <div className="product-landing__unavailable" role="status">
+              <strong>{product.cta.label}</strong>
+              <p>{product.cta.description}</p>
+            </div>
+          </div>
+        </aside>
+      </header>
+
+      <main className="product-landing__body">
+        {product.sections.map((section) => (
+          <React.Fragment key={section}>
+            {renderPageSection(section)}
+          </React.Fragment>
+        ))}
+      </main>
+    </article>
+  );
+};
+
+export default ProductLandingPage;

--- a/src/domains/app/features/product-landing-page/product-landing-page.styles.scss
+++ b/src/domains/app/features/product-landing-page/product-landing-page.styles.scss
@@ -1,0 +1,375 @@
+@use '../../../../styles/breakpoints' as *;
+@use '../../../../styles/radius' as *;
+@use '../../../../styles/spacing' as *;
+
+.product-landing {
+  --product-landing-bg: #0f1724;
+  --product-landing-panel: rgba(255, 255, 255, 0.07);
+  --product-landing-panel-strong: rgba(255, 255, 255, 0.11);
+  --product-landing-border: rgba(255, 255, 255, 0.14);
+  --product-landing-text: #f8fafc;
+  --product-landing-muted: rgba(248, 250, 252, 0.72);
+
+  min-height: 100vh;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.05), transparent 42%),
+    var(--product-landing-bg);
+  color: var(--product-landing-text);
+}
+
+.product-landing--light {
+  --product-landing-bg: #f8fafc;
+  --product-landing-panel: rgba(15, 23, 36, 0.06);
+  --product-landing-panel-strong: rgba(15, 23, 36, 0.09);
+  --product-landing-border: rgba(15, 23, 36, 0.14);
+  --product-landing-text: #111827;
+  --product-landing-muted: rgba(17, 24, 39, 0.72);
+}
+
+.product-landing--type-classic {
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.product-landing--type-friendly {
+  font-family: 'Trebuchet MS', Arial, sans-serif;
+}
+
+.product-landing__hero,
+.product-landing__body {
+  width: min(1120px, calc(100% - #{$spacing-7}));
+  margin: 0 auto;
+}
+
+.product-landing__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  gap: $spacing-7;
+  align-items: center;
+  min-height: min(760px, calc(100vh - 64px));
+  padding: $spacing-8 0 $spacing-7;
+}
+
+.product-landing__hero--media-left {
+  grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+
+  .product-landing__hero-copy {
+    order: 2;
+  }
+
+  .product-landing__commerce {
+    order: 1;
+  }
+}
+
+.product-landing__hero-copy {
+  display: grid;
+  gap: $spacing-4;
+
+  h1 {
+    max-width: 860px;
+    margin: 0;
+    font-size: clamp(3rem, 4.8rem, 5.8rem);
+    line-height: 0.95;
+    letter-spacing: 0;
+  }
+
+  p {
+    max-width: 680px;
+    margin: 0;
+    color: var(--product-landing-muted);
+    font-size: 1.1rem;
+    line-height: 1.7;
+  }
+}
+
+.product-landing__eyebrow,
+.product-landing__section-heading > span,
+.product-landing__commerce span,
+.product-landing__creator > div > span,
+.product-landing__outline article > div > span {
+  color: var(--product-landing-accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.product-landing__hero-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-3;
+  align-items: center;
+
+  span,
+  strong {
+    border: 1px solid var(--product-landing-border);
+    border-radius: $radius-pill;
+    padding: $spacing-2 $spacing-4;
+    background: var(--product-landing-panel);
+  }
+}
+
+.product-landing__commerce {
+  display: grid;
+  gap: $spacing-4;
+  align-self: stretch;
+  border: 1px solid var(--product-landing-border);
+  border-radius: $radius-md;
+  padding: $spacing-4;
+  background: var(--product-landing-panel);
+
+  img {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    border-radius: $radius-sm;
+    background: var(--product-landing-panel-strong);
+  }
+
+  h2 {
+    margin: $spacing-1 0 $spacing-3;
+    font-size: 2rem;
+    letter-spacing: 0;
+  }
+}
+
+.product-landing__unavailable {
+  border: 1px solid color-mix(in srgb, var(--product-landing-accent) 45%, transparent);
+  border-radius: $radius-md;
+  padding: $spacing-4;
+  background: color-mix(in srgb, var(--product-landing-accent) 12%, transparent);
+
+  strong {
+    display: block;
+    margin-bottom: $spacing-2;
+  }
+
+  p {
+    margin: 0;
+    color: var(--product-landing-muted);
+    line-height: 1.55;
+  }
+}
+
+.product-landing__body {
+  display: grid;
+  gap: $spacing-6;
+  padding: 0 0 $spacing-8;
+}
+
+.product-landing__section,
+.product-landing__creator {
+  border-top: 1px solid var(--product-landing-border);
+  padding-top: $spacing-6;
+}
+
+.product-landing__section {
+  display: grid;
+  gap: $spacing-5;
+
+  > p {
+    max-width: 760px;
+    margin: 0;
+    color: var(--product-landing-muted);
+    font-size: 1.05rem;
+    line-height: 1.7;
+  }
+}
+
+.product-landing__section-heading {
+  display: grid;
+  gap: $spacing-2;
+
+  h2 {
+    margin: 0;
+    font-size: 2rem;
+    letter-spacing: 0;
+  }
+
+  p {
+    max-width: 700px;
+    margin: 0;
+    color: var(--product-landing-muted);
+    line-height: 1.6;
+  }
+}
+
+.product-landing__outline {
+  display: grid;
+  gap: $spacing-3;
+
+  article {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: $spacing-4;
+    border: 1px solid var(--product-landing-border);
+    border-radius: $radius-md;
+    padding: $spacing-4;
+    background: var(--product-landing-panel);
+
+    h3 {
+      margin: $spacing-1 0;
+      font-size: 1.1rem;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0;
+      color: var(--product-landing-muted);
+      line-height: 1.55;
+    }
+
+    strong {
+      white-space: nowrap;
+    }
+
+    ul {
+      grid-column: 1 / -1;
+      display: grid;
+      gap: $spacing-2;
+      margin: 0;
+      padding: $spacing-3 0 0;
+      list-style: none;
+    }
+
+    li {
+      display: flex;
+      justify-content: space-between;
+      gap: $spacing-3;
+      border-top: 1px solid var(--product-landing-border);
+      padding-top: $spacing-2;
+      color: var(--product-landing-muted);
+    }
+
+    em {
+      font-style: normal;
+      text-transform: capitalize;
+    }
+  }
+}
+
+.product-landing__details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: $spacing-3;
+  margin: 0;
+
+  div {
+    border: 1px solid var(--product-landing-border);
+    border-radius: $radius-md;
+    padding: $spacing-4;
+    background: var(--product-landing-panel);
+  }
+
+  dt {
+    margin-bottom: $spacing-2;
+    color: var(--product-landing-muted);
+    font-size: 0.85rem;
+  }
+
+  dd {
+    margin: 0;
+    font-weight: 700;
+    line-height: 1.45;
+  }
+}
+
+.product-landing__empty {
+  margin: 0;
+  color: var(--product-landing-muted);
+}
+
+.product-landing__creator {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: $spacing-5;
+  align-items: start;
+
+  img,
+  > span {
+    width: 96px;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--product-landing-panel-strong);
+  }
+
+  > span {
+    display: grid;
+    place-items: center;
+    color: var(--product-landing-accent);
+    font-weight: 900;
+  }
+
+  h2 {
+    margin: $spacing-1 0;
+    font-size: 1.7rem;
+    letter-spacing: 0;
+  }
+
+  p {
+    max-width: 720px;
+    margin: 0 0 $spacing-2;
+    color: var(--product-landing-muted);
+    line-height: 1.6;
+  }
+}
+
+.product-landing__creator-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-3;
+  margin-top: $spacing-3;
+
+  a {
+    color: var(--product-landing-text);
+    text-decoration-color: var(--product-landing-accent);
+  }
+}
+
+@media (max-width: $bp-tablet) {
+  .product-landing__hero,
+  .product-landing__body {
+    width: min(100% - #{$spacing-5}, 720px);
+  }
+
+  .product-landing__hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    padding-top: $spacing-7;
+  }
+
+  .product-landing__hero-copy h1 {
+    font-size: 3.2rem;
+  }
+
+  .product-landing__details {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: $bp-mobile) {
+  .product-landing__hero,
+  .product-landing__body {
+    width: min(100% - #{$spacing-4}, 520px);
+  }
+
+  .product-landing__hero {
+    gap: $spacing-5;
+    padding-top: $spacing-6;
+  }
+
+  .product-landing__hero-copy h1 {
+    font-size: 2.55rem;
+  }
+
+  .product-landing__outline article,
+  .product-landing__creator {
+    grid-template-columns: 1fr;
+  }
+
+  .product-landing__outline article li {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/domains/app/features/product-landing-page/product-landing-page.types.ts
+++ b/src/domains/app/features/product-landing-page/product-landing-page.types.ts
@@ -1,0 +1,95 @@
+import {
+  ProductLandingPageHeroLayout,
+  ProductLandingPageSectionId,
+  ProductType,
+  StorefrontTheme,
+} from 'core/api/models';
+
+export interface ProductLandingCreatorViewModel {
+  displayName: string;
+  title?: string;
+  bio?: string;
+  imageUrl?: string;
+  website?: string;
+  publicEmail?: string;
+}
+
+export interface ProductLandingPriceViewModel {
+  label: string;
+  cadence?: string;
+  isFree: boolean;
+  isRecurring: boolean;
+}
+
+export interface ProductLandingCourseSection {
+  id?: string;
+  title: string;
+  description?: string;
+  lessonCount: number;
+  lessons: Array<{
+    id?: string;
+    title: string;
+    type?: string;
+  }>;
+}
+
+export interface ProductLandingDownloadSection {
+  id?: string;
+  title: string;
+  description?: string;
+  fileCount: number;
+  files: Array<{
+    id?: string;
+    fileName: string;
+  }>;
+}
+
+export interface ProductLandingDetailRow {
+  label: string;
+  value: string;
+}
+
+export type ProductLandingTypeSummary =
+  | {
+      type: 'COURSE';
+      sectionCount: number;
+      lessonCount: number;
+      sections: ProductLandingCourseSection[];
+    }
+  | {
+      type: 'DOWNLOAD';
+      sectionCount: number;
+      fileCount: number;
+      sections: ProductLandingDownloadSection[];
+    }
+  | {
+      type: 'CONSULTATION';
+      details: ProductLandingDetailRow[];
+    }
+  | {
+      type: 'MEMBERSHIP';
+      recurringLabel?: string;
+    };
+
+export interface ProductLandingCtaViewModel {
+  label: string;
+  description: string;
+}
+
+export interface ProductLandingPageViewModel {
+  id: string;
+  type: ProductType;
+  typeLabel: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  imageAlt: string;
+  price: ProductLandingPriceViewModel;
+  cta: ProductLandingCtaViewModel;
+  theme: StorefrontTheme;
+  creator?: ProductLandingCreatorViewModel;
+  heroLayout: ProductLandingPageHeroLayout;
+  marketingDescription?: string;
+  sections: ProductLandingPageSectionId[];
+  summary: ProductLandingTypeSummary;
+}

--- a/src/domains/app/features/product-landing-page/product-landing-page.utils.ts
+++ b/src/domains/app/features/product-landing-page/product-landing-page.utils.ts
@@ -1,0 +1,404 @@
+import {
+  AbstractProduct,
+  ProductLandingPageConfig,
+  ProductLandingPageConfigUpdateRequest,
+  ProductLandingPageSectionId,
+  ProductBillingInterval,
+  ProductCurrency,
+  PublicStorefront,
+  StorefrontTheme,
+  User,
+} from 'core/api/models';
+import { PRODUCT_TYPE_REGISTRY } from 'core/constants';
+import {
+  DEFAULT_STOREFRONT_THEME,
+  getProfileFromUser,
+  isPublishedProductStatus,
+} from 'domains/app/features/storefront';
+
+import {
+  ProductLandingCreatorViewModel,
+  ProductLandingPageViewModel,
+  ProductLandingPriceViewModel,
+  ProductLandingTypeSummary,
+} from './product-landing-page.types';
+
+export const PRODUCT_LANDING_PAGE_SECTIONS: ProductLandingPageSectionId[] = [
+  'ABOUT',
+  'CONTENTS',
+  'CREATOR',
+];
+
+export const DEFAULT_PRODUCT_LANDING_PAGE_CONFIG: ProductLandingPageConfigUpdateRequest = {
+  marketingDescription: '',
+  heroLayout: 'MEDIA_RIGHT',
+  visibleSections: ['CONTENTS', 'CREATOR'],
+  sectionOrder: PRODUCT_LANDING_PAGE_SECTIONS,
+};
+
+export const productLandingPageSectionLabels: Record<
+  ProductLandingPageSectionId,
+  string
+> = {
+  ABOUT: 'About',
+  CONTENTS: 'What\'s included',
+  CREATOR: 'Creator',
+};
+
+const billingIntervalLabels: Record<ProductBillingInterval, string> = {
+  MONTH: 'month',
+  YEAR: 'year',
+};
+
+const meetingMethodLabels: Record<string, string> = {
+  ZOOM: 'Zoom',
+  GOOGLE_MEET: 'Google Meet',
+  PHONE: 'Phone',
+  OTHER: 'Other',
+};
+
+export const normalizeProductLandingPageConfig = (
+  productId: string,
+  config?: Partial<ProductLandingPageConfig> | null,
+): ProductLandingPageConfig => {
+  const visibleSections = (
+    config?.visibleSections ??
+    DEFAULT_PRODUCT_LANDING_PAGE_CONFIG.visibleSections
+  ).filter((section): section is ProductLandingPageSectionId =>
+    PRODUCT_LANDING_PAGE_SECTIONS.includes(section as ProductLandingPageSectionId),
+  );
+  const orderedKnownSections = (
+    config?.sectionOrder ?? DEFAULT_PRODUCT_LANDING_PAGE_CONFIG.sectionOrder
+  ).filter((section): section is ProductLandingPageSectionId =>
+    PRODUCT_LANDING_PAGE_SECTIONS.includes(section as ProductLandingPageSectionId),
+  );
+  const sectionOrder = [
+    ...orderedKnownSections,
+    ...PRODUCT_LANDING_PAGE_SECTIONS.filter(
+      (section) => !orderedKnownSections.includes(section),
+    ),
+  ];
+
+  return {
+    id: config?.id,
+    productId: config?.productId ?? productId,
+    marketingDescription: config?.marketingDescription ?? '',
+    heroLayout:
+      config?.heroLayout ?? DEFAULT_PRODUCT_LANDING_PAGE_CONFIG.heroLayout,
+    visibleSections:
+      visibleSections.length > 0
+        ? visibleSections
+        : DEFAULT_PRODUCT_LANDING_PAGE_CONFIG.visibleSections,
+    sectionOrder,
+    updatedAt: config?.updatedAt,
+  };
+};
+
+const getVisibleLandingSections = ({
+  config,
+  hasCreator,
+}: {
+  config: ProductLandingPageConfig;
+  hasCreator: boolean;
+}) =>
+  config.sectionOrder.filter((section) => {
+    if (!config.visibleSections.includes(section)) {
+      return false;
+    }
+
+    if (section === 'ABOUT') {
+      return Boolean(config.marketingDescription?.trim());
+    }
+
+    if (section === 'CREATOR') {
+      return hasCreator;
+    }
+
+    return true;
+  });
+
+export const isPublicProductLandingPageProduct = (product: AbstractProduct) =>
+  isPublishedProductStatus(product.status);
+
+const formatCurrency = (
+  amount: number,
+  currency: ProductCurrency = 'EUR',
+) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: amount % 1 === 0 ? 0 : 2,
+  }).format(amount);
+
+export const getProductLandingPrice = (
+  product: AbstractProduct,
+): ProductLandingPriceViewModel => {
+  const isFree = product.price === 'free' || product.price === 0;
+  const isRecurring = product.pricingModel === 'RECURRING';
+  const cadence = isRecurring && product.billingInterval
+    ? billingIntervalLabels[product.billingInterval]
+    : undefined;
+
+  if (isFree) {
+    return {
+      label: 'Free',
+      cadence,
+      isFree: true,
+      isRecurring,
+    };
+  }
+
+  if (typeof product.price === 'number') {
+    return {
+      label: formatCurrency(product.price, product.currency),
+      cadence,
+      isFree: false,
+      isRecurring,
+    };
+  }
+
+  return {
+    label: 'Price unavailable',
+    cadence,
+    isFree: false,
+    isRecurring,
+  };
+};
+
+const getProductLandingCta = (price: ProductLandingPriceViewModel) => {
+  if (price.isRecurring) {
+    return {
+      label: 'Membership checkout unavailable',
+      description:
+        'Membership subscriptions are not connected yet. This page is available for product information only.',
+    };
+  }
+
+  if (price.isFree) {
+    return {
+      label: 'Access currently unavailable',
+      description:
+        'Free access is not connected yet. This page is available for product information only.',
+    };
+  }
+
+  return {
+    label: 'Purchase currently unavailable',
+    description:
+      'Checkout is not connected yet. This page is available for product information only.',
+  };
+};
+
+const getProductLandingCreator = ({
+  product,
+  currentUser,
+  publicStorefront,
+}: {
+  product: AbstractProduct;
+  currentUser?: User | null;
+  publicStorefront?: PublicStorefront | null;
+}): ProductLandingCreatorViewModel | undefined => {
+  if (publicStorefront?.creator) {
+    return {
+      displayName: publicStorefront.creator.displayName,
+      title: publicStorefront.creator.title,
+      bio: publicStorefront.creator.bio,
+      imageUrl: publicStorefront.creator.imageUrl,
+      website: publicStorefront.creator.website,
+      publicEmail:
+        publicStorefront.creator.publicEmail ?? publicStorefront.creator.email,
+    };
+  }
+
+  if (currentUser?.id && currentUser.id === product.userId) {
+    const profile = getProfileFromUser(currentUser);
+
+    return {
+      displayName: profile.displayName,
+      title: profile.title,
+      bio: profile.bio,
+      imageUrl: profile.imageUrl,
+      website: profile.website,
+      publicEmail: profile.publicEmail,
+    };
+  }
+
+  return undefined;
+};
+
+const getProductLandingSummary = (
+  product: AbstractProduct,
+  price: ProductLandingPriceViewModel,
+): ProductLandingTypeSummary => {
+  if (product.type === 'COURSE') {
+    const sections = product.sections ?? [];
+    const mappedSections = sections.map((section, index) => ({
+      id: section.id,
+      title: section.title || `Module ${index + 1}`,
+      description: section.description,
+      lessonCount: section.lessons?.length ?? 0,
+      lessons:
+        section.lessons?.map((lesson) => ({
+          id: lesson.id,
+          title: lesson.title || 'Untitled lesson',
+          type: lesson.type,
+        })) ?? [],
+    }));
+
+    return {
+      type: 'COURSE',
+      sectionCount: mappedSections.length,
+      lessonCount: mappedSections.reduce(
+        (total, section) => total + section.lessonCount,
+        0,
+      ),
+      sections: mappedSections,
+    };
+  }
+
+  if (product.type === 'DOWNLOAD') {
+    const sections = product.sections ?? [];
+    const mappedSections = sections.map((section, index) => ({
+      id: section.id,
+      title: section.title || `Section ${index + 1}`,
+      description: section.description,
+      fileCount: section.files?.length ?? 0,
+      files:
+        section.files?.map((file) => ({
+          id: file.id,
+          fileName: file.fileName || 'Untitled file',
+        })) ?? [],
+    }));
+
+    return {
+      type: 'DOWNLOAD',
+      sectionCount: mappedSections.length,
+      fileCount: mappedSections.reduce(
+        (total, section) => total + section.fileCount,
+        0,
+      ),
+      sections: mappedSections,
+    };
+  }
+
+  if (product.type === 'CONSULTATION') {
+    const details = product.consultationDetails;
+    const rows: Array<{ label: string; value: string }> = [];
+
+    if (details?.durationMinutes) {
+      rows.push({
+        label: 'Session duration',
+        value: `${details.durationMinutes} minutes`,
+      });
+    }
+
+    if (details?.meetingMethod) {
+      rows.push({
+        label: 'Meeting method',
+        value:
+          meetingMethodLabels[details.meetingMethod] ?? details.meetingMethod,
+      });
+    }
+
+    if (details?.customLocation) {
+      rows.push({ label: 'Meeting details', value: details.customLocation });
+    }
+
+    if (details?.bufferBeforeMinutes || details?.bufferAfterMinutes) {
+      rows.push({
+        label: 'Session buffer',
+        value: [
+          details.bufferBeforeMinutes
+            ? `${details.bufferBeforeMinutes} min before`
+            : undefined,
+          details.bufferAfterMinutes
+            ? `${details.bufferAfterMinutes} min after`
+            : undefined,
+        ].filter(Boolean).join(', '),
+      });
+    }
+
+    if (details?.maxSessionsPerDay) {
+      rows.push({
+        label: 'Daily availability',
+        value: `${details.maxSessionsPerDay} sessions per day`,
+      });
+    }
+
+    if (details?.confirmationMessage) {
+      rows.push({ label: 'After booking', value: details.confirmationMessage });
+    }
+
+    if (details?.cancellationPolicy) {
+      rows.push({
+        label: 'Cancellation policy',
+        value: details.cancellationPolicy,
+      });
+    }
+
+    if (details?.connectedCalendars?.length) {
+      rows.push({ label: 'Calendar availability', value: 'Connected' });
+    }
+
+    return {
+      type: 'CONSULTATION',
+      details: rows,
+    };
+  }
+
+  return {
+    type: 'MEMBERSHIP',
+    recurringLabel: price.cadence ? `${price.label} / ${price.cadence}` : price.label,
+  };
+};
+
+export const getProductLandingPageViewModel = ({
+  product,
+  currentUser,
+  publicStorefront,
+  creatorStorefrontTheme,
+  landingPageConfig,
+}: {
+  product: AbstractProduct;
+  currentUser?: User | null;
+  publicStorefront?: PublicStorefront | null;
+  creatorStorefrontTheme?: StorefrontTheme;
+  landingPageConfig?: Partial<ProductLandingPageConfig> | null;
+}): ProductLandingPageViewModel => {
+  const price = getProductLandingPrice(product);
+  const typeLabel = PRODUCT_TYPE_REGISTRY[product.type].label;
+  const theme =
+    publicStorefront?.theme ?? creatorStorefrontTheme ?? DEFAULT_STOREFRONT_THEME;
+  const config = normalizeProductLandingPageConfig(product.id, landingPageConfig);
+  const creator = getProductLandingCreator({
+    product,
+    currentUser,
+    publicStorefront,
+  });
+
+  // Transitional composition: the route currently maps the general Product read
+  // plus optional Storefront/User data into this public-facing shape. A future
+  // public Product read model should be able to hydrate this boundary directly.
+  return {
+    id: product.id,
+    type: product.type,
+    typeLabel,
+    name: product.name || 'Untitled product',
+    description: product.description,
+    imageUrl: product.imageUrl,
+    imageAlt: product.imageUrl
+      ? `${product.name || 'Product'} thumbnail`
+      : '',
+    price,
+    cta: getProductLandingCta(price),
+    theme,
+    creator,
+    heroLayout: config.heroLayout,
+    marketingDescription: config.marketingDescription?.trim(),
+    sections: getVisibleLandingSections({
+      config,
+      hasCreator: Boolean(creator),
+    }),
+    summary: getProductLandingSummary(product, price),
+  };
+};

--- a/src/domains/app/features/storefront/storefront.utils.ts
+++ b/src/domains/app/features/storefront/storefront.utils.ts
@@ -33,8 +33,11 @@ export const DEFAULT_STOREFRONT_THEME: StorefrontTheme = {
   typography: 'MODERN',
 };
 
+export const isPublishedProductStatus = (status?: ProductStatus) =>
+  status === 'PUBLISHED';
+
 export const isPublicStorefrontProduct = (product: ProductMinimised) =>
-  product.status === 'PUBLISHED';
+  isPublishedProductStatus(product.status);
 
 export const formatStorefrontPrice = (price?: number | 'free') => {
   if (price === 'free') {

--- a/src/domains/app/pages/app-layout/app-layout.component.tsx
+++ b/src/domains/app/pages/app-layout/app-layout.component.tsx
@@ -15,6 +15,7 @@ const CREATOR_ROUTES = [
   '/app',
   '/app/admin/*',
   '/app/products',
+  '/app/products/:productId/landing-page',
   '/app/products/:productId',
   '/app/customers/*',
   '/app/sales',

--- a/src/domains/app/pages/creator-specific/products/index.ts
+++ b/src/domains/app/pages/creator-specific/products/index.ts
@@ -1,3 +1,4 @@
 export * from './product-overview';
+export * from './product-landing-page-builder';
 export * from './product-form';
 export * from './products-list';

--- a/src/domains/app/pages/creator-specific/products/product-landing-page-builder/index.ts
+++ b/src/domains/app/pages/creator-specific/products/product-landing-page-builder/index.ts
@@ -1,0 +1,1 @@
+export { default as ProductLandingPageBuilder } from './product-landing-page-builder.component';

--- a/src/domains/app/pages/creator-specific/products/product-landing-page-builder/product-landing-page-builder.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-landing-page-builder/product-landing-page-builder.component.test.tsx
@@ -1,0 +1,225 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import MockAdapter from 'axios-mock-adapter';
+import { Provider } from 'react-redux';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import httpClient from 'core/api/http-client';
+import { AbstractProduct, UserRole } from 'core/api/models';
+import authReducer from 'core/store/auth-store/auth.slice';
+import productLandingPageReducer from 'core/store/product-landing-page-store/product-landing-page.slice';
+import productReducer from 'core/store/product-store/product.slice';
+import storefrontReducer from 'core/store/storefront-store/storefront.slice';
+
+import ProductLandingPageBuilder from './product-landing-page-builder.component';
+
+jest.mock('../../../../../../assets/image-placeholder.png', () => 'placeholder.png');
+
+const courseProduct: AbstractProduct = {
+  id: 'course-1',
+  type: 'COURSE',
+  name: 'Creator Product Growth System',
+  description: 'Package and launch a stronger creator offer.',
+  status: 'PUBLISHED',
+  price: 149,
+  currency: 'EUR',
+  userId: 'creator-1',
+  imageUrl: 'https://cdn.example.com/course.jpg',
+  sections: [
+    {
+      id: 'section-1',
+      title: 'Positioning foundations',
+      description: 'Clarify the buyer and promise.',
+      position: 1,
+      lessons: [
+        {
+          id: 'lesson-1',
+          sectionId: 'section-1',
+          title: 'Define the transformation',
+          description: '',
+          type: 'VIDEO',
+        },
+      ],
+    },
+  ],
+};
+
+const renderBuilder = (initialEntry = '/app/products/course-1/landing-page') => {
+  const testStore = configureStore({
+    reducer: {
+      auth: authReducer,
+      productLandingPage: productLandingPageReducer,
+      products: productReducer,
+      storefront: storefrontReducer,
+    },
+    preloadedState: {
+      auth: {
+        user: {
+          id: 'creator-1',
+          firstName: 'Maya',
+          lastName: 'Chen',
+          email: 'maya@example.test',
+          roles: [UserRole.CREATOR],
+          onboardingCompleted: true,
+          title: 'Creator strategist',
+          bio: 'Helps creators package useful products.',
+        },
+        loading: false,
+        error: null,
+        isUserLoggedIn: true,
+      },
+    },
+  });
+
+  return render(
+    <Provider store={testStore}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/app/products/:productId/landing-page"
+            element={<ProductLandingPageBuilder />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+describe('<ProductLandingPageBuilder />', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(httpClient, { delayResponse: 0 });
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+    mock.onGet('api/creator/storefront').reply(200, {
+      id: 'creator-storefront-config',
+      featuredProductId: null,
+      productOrderIds: [],
+      theme: {
+        appearance: 'LIGHT',
+        accentColor: '#0ea5e9',
+        typography: 'FRIENDLY',
+      },
+    });
+    mock.onGet('api/creator/products/course-1/landing-page').reply(200, {
+      id: 'landing-course-1',
+      productId: 'course-1',
+      marketingDescription: 'Persisted public marketing copy.',
+      heroLayout: 'MEDIA_LEFT',
+      visibleSections: ['ABOUT', 'CONTENTS', 'CREATOR'],
+      sectionOrder: ['ABOUT', 'CONTENTS', 'CREATOR'],
+    });
+    mock.onPatch('api/creator/products/course-1/landing-page').reply((request) => [
+      200,
+      {
+        id: 'landing-course-1',
+        productId: 'course-1',
+        ...JSON.parse(request.data ?? '{}'),
+        updatedAt: '2026-08-13T12:00:00.000Z',
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('renders Product-owned fields read-only and previews persisted config', async () => {
+    const { container } = renderBuilder();
+
+    expect(
+      await screen.findAllByRole('heading', {
+        name: 'Creator Product Growth System',
+      }),
+    ).not.toHaveLength(0);
+    expect(screen.getAllByText('Persisted public marketing copy.').length)
+      .toBeGreaterThan(1);
+    expect(screen.getByText('Maya Chen')).toBeInTheDocument();
+    expect(screen.getAllByText('€149').length).toBeGreaterThan(1);
+    expect(container.querySelector('.product-landing__hero'))
+      .toHaveClass('product-landing__hero--media-left');
+    expect(screen.queryByDisplayValue('Creator Product Growth System')).toBeNull();
+  });
+
+  it('updates the shared preview from a local draft before saving', async () => {
+    const { container } = renderBuilder();
+
+    const textarea = await screen.findByRole('textbox');
+    fireEvent.change(textarea, {
+      target: { value: 'Live draft marketing copy.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Media right' }));
+
+    expect(screen.getAllByText('Live draft marketing copy.').length)
+      .toBeGreaterThan(1);
+    expect(container.querySelector('.product-landing__hero'))
+      .toHaveClass('product-landing__hero--media-right');
+    expect(mock.history.patch).toHaveLength(0);
+  });
+
+  it('toggles and reorders supported secondary sections', async () => {
+    renderBuilder();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Persisted public marketing copy.').length)
+        .toBeGreaterThan(1);
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Creator' }));
+    expect(screen.queryByText('Maya Chen')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Creator up' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mock.history.patch).toHaveLength(1));
+    const payload = JSON.parse(mock.history.patch[0].data);
+    expect(payload.visibleSections).toEqual(['ABOUT', 'CONTENTS']);
+    expect(payload.sectionOrder).toEqual(['ABOUT', 'CREATOR', 'CONTENTS']);
+  });
+
+  it('resets local changes to the last persisted config', async () => {
+    renderBuilder();
+
+    const textarea = await screen.findByRole('textbox');
+    fireEvent.change(textarea, {
+      target: { value: 'Temporary draft copy.' },
+    });
+    expect(screen.getAllByText('Temporary draft copy.').length)
+      .toBeGreaterThan(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    expect(screen.getAllByText('Persisted public marketing copy.').length)
+      .toBeGreaterThan(1);
+    expect(screen.queryByText('Temporary draft copy.')).toBeNull();
+  });
+
+  it('opens customization controls in the shared Drawer on mobile', async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(max-width: 768px)',
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+
+    renderBuilder();
+
+    await screen.findAllByRole('heading', {
+      name: 'Creator Product Growth System',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Customize' }));
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Customize landing page');
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+});

--- a/src/domains/app/pages/creator-specific/products/product-landing-page-builder/product-landing-page-builder.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-landing-page-builder/product-landing-page-builder.component.tsx
@@ -1,0 +1,493 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  FiArrowLeft,
+  FiArrowUp,
+  FiArrowDown,
+  FiExternalLink,
+  FiRefreshCw,
+  FiSave,
+  FiSettings,
+  FiSliders,
+} from 'react-icons/fi';
+
+import {
+  AppDispatch,
+  ProductLandingPageConfigUpdateRequest,
+  ProductLandingPageHeroLayout,
+  ProductLandingPageSectionId,
+  RootState,
+} from 'core/api/models';
+import { Button, Drawer, Icon, StatusBadge, Textarea } from '@shared/ui';
+import { appRoutes } from 'domains/app/routes/routes';
+import {
+  clearCurrentProduct,
+  getProductById,
+  selectCurrentProduct,
+  selectProductsError,
+  selectProductsLoading,
+} from 'core/store/product-store';
+import { selectAuthUser } from 'core/store/auth-store';
+import {
+  fetchCreatorProductLandingPageConfig,
+  selectCreatorProductLandingPageConfigByProductId,
+  selectCreatorProductLandingPageConfigError,
+  selectCreatorProductLandingPageConfigLoading,
+  selectCreatorProductLandingPageConfigSaveError,
+  selectCreatorProductLandingPageConfigSaveLoading,
+  updateCreatorProductLandingPageConfig,
+} from 'core/store/product-landing-page-store';
+import {
+  fetchCreatorStorefrontConfig,
+  selectCreatorStorefrontConfig,
+} from 'core/store/storefront-store';
+import {
+  DEFAULT_PRODUCT_LANDING_PAGE_CONFIG,
+  getProductLandingPageViewModel,
+  normalizeProductLandingPageConfig,
+  ProductLandingPage,
+  productLandingPageSectionLabels,
+} from 'domains/app/features/product-landing-page';
+import {
+  formatProductPrice,
+  getProductStatusLabel,
+  getProductTypeLabel,
+} from '../products-list/products-list.utils';
+
+import './product-landing-page-builder.styles.scss';
+
+type DraftConfig = ProductLandingPageConfigUpdateRequest;
+
+const heroLayoutOptions: Array<{
+  label: string;
+  value: ProductLandingPageHeroLayout;
+}> = [
+  { label: 'Media right', value: 'MEDIA_RIGHT' },
+  { label: 'Media left', value: 'MEDIA_LEFT' },
+];
+
+const getDraftFromConfig = (
+  productId: string,
+  config?: Partial<DraftConfig> | null,
+): DraftConfig => {
+  const normalized = normalizeProductLandingPageConfig(productId, {
+    productId,
+    ...config,
+  });
+
+  return {
+    marketingDescription: normalized.marketingDescription ?? '',
+    heroLayout: normalized.heroLayout,
+    visibleSections: normalized.visibleSections,
+    sectionOrder: normalized.sectionOrder,
+  };
+};
+
+const areDraftsEqual = (left: DraftConfig | null, right: DraftConfig) =>
+  left !== null &&
+  left.marketingDescription === right.marketingDescription &&
+  left.heroLayout === right.heroLayout &&
+  left.visibleSections.join('|') === right.visibleSections.join('|') &&
+  left.sectionOrder.join('|') === right.sectionOrder.join('|');
+
+const moveSection = (
+  sections: ProductLandingPageSectionId[],
+  section: ProductLandingPageSectionId,
+  direction: -1 | 1,
+) => {
+  const currentIndex = sections.indexOf(section);
+  const nextIndex = currentIndex + direction;
+
+  if (currentIndex < 0 || nextIndex < 0 || nextIndex >= sections.length) {
+    return sections;
+  }
+
+  const nextSections = [...sections];
+  [nextSections[currentIndex], nextSections[nextIndex]] = [
+    nextSections[nextIndex],
+    nextSections[currentIndex],
+  ];
+
+  return nextSections;
+};
+
+const ProductLandingPageBuilder: React.FC = () => {
+  const { productId } = useParams();
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const user = useSelector(selectAuthUser);
+  const product = useSelector(selectCurrentProduct);
+  const productLoading = useSelector(selectProductsLoading);
+  const productError = useSelector(selectProductsError);
+  const creatorStorefrontConfig = useSelector(selectCreatorStorefrontConfig);
+  const persistedConfig = useSelector((state: RootState) =>
+    selectCreatorProductLandingPageConfigByProductId(state, productId),
+  );
+  const configLoading = useSelector(selectCreatorProductLandingPageConfigLoading);
+  const configError = useSelector(selectCreatorProductLandingPageConfigError);
+  const saveLoading = useSelector(selectCreatorProductLandingPageConfigSaveLoading);
+  const saveError = useSelector(selectCreatorProductLandingPageConfigSaveError);
+  const [draftConfig, setDraftConfig] = useState<DraftConfig | null>(null);
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  const [isMobileCustomize, setIsMobileCustomize] = useState(false);
+
+  useEffect(() => {
+    dispatch(fetchCreatorStorefrontConfig());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!window.matchMedia) {
+      return undefined;
+    }
+
+    const query = window.matchMedia('(max-width: 768px)');
+    const update = () => setIsMobileCustomize(query.matches);
+    update();
+    query.addEventListener?.('change', update);
+
+    return () => query.removeEventListener?.('change', update);
+  }, []);
+
+  useEffect(() => {
+    dispatch(clearCurrentProduct());
+
+    if (productId) {
+      dispatch(getProductById({ productId }));
+      dispatch(fetchCreatorProductLandingPageConfig(productId));
+    }
+  }, [dispatch, productId]);
+
+  useEffect(() => {
+    if (productId) {
+      setDraftConfig(getDraftFromConfig(productId, persistedConfig));
+      setSavedMessage(null);
+    }
+  }, [persistedConfig, productId]);
+
+  const loadedProduct = product?.id === productId ? product : null;
+  const baselineConfig = useMemo(() => {
+    if (!productId) {
+      return DEFAULT_PRODUCT_LANDING_PAGE_CONFIG;
+    }
+
+    return getDraftFromConfig(productId, persistedConfig);
+  }, [persistedConfig, productId]);
+  const hasChanges = !areDraftsEqual(draftConfig, baselineConfig);
+  const previewModel = useMemo(() => {
+    if (!loadedProduct || !draftConfig) {
+      return null;
+    }
+
+    return getProductLandingPageViewModel({
+      product: loadedProduct,
+      currentUser: user,
+      creatorStorefrontTheme: creatorStorefrontConfig?.theme,
+      landingPageConfig: {
+        ...draftConfig,
+        productId: loadedProduct.id,
+      },
+    });
+  }, [creatorStorefrontConfig?.theme, draftConfig, loadedProduct, user]);
+
+  const updateDraft = (patch: Partial<DraftConfig>) => {
+    setSavedMessage(null);
+    setDraftConfig((current) => {
+      if (!current) {
+        return current;
+      }
+
+      return {
+        ...current,
+        ...patch,
+      };
+    });
+  };
+
+  const toggleSection = (section: ProductLandingPageSectionId) => {
+    if (!draftConfig) {
+      return;
+    }
+
+    const visibleSections = draftConfig.visibleSections.includes(section)
+      ? draftConfig.visibleSections.filter((item) => item !== section)
+      : [...draftConfig.visibleSections, section];
+
+    updateDraft({ visibleSections });
+  };
+
+  const save = async () => {
+    if (!productId || !draftConfig) {
+      return;
+    }
+
+    await dispatch(
+      updateCreatorProductLandingPageConfig({
+        productId,
+        config: draftConfig,
+      }),
+    ).unwrap();
+    setSavedMessage('Landing page saved.');
+  };
+
+  const reset = () => {
+    setDraftConfig(baselineConfig);
+    setSavedMessage(null);
+  };
+
+  if (!productId) {
+    return (
+      <main className="product-landing-builder product-landing-builder--state">
+        <h1>Landing page unavailable</h1>
+        <p>This route is missing a Product ID.</p>
+        <Button type="button" variant="secondary" onClick={() => navigate(appRoutes.products)}>
+          Back to Products
+        </Button>
+      </main>
+    );
+  }
+
+  if ((productLoading || configLoading) && !loadedProduct) {
+    return (
+      <main className="product-landing-builder product-landing-builder--state" aria-busy="true">
+        <h1>Loading landing page</h1>
+        <p>Preparing the live editor.</p>
+      </main>
+    );
+  }
+
+  if (productError || !loadedProduct) {
+    return (
+      <main className="product-landing-builder product-landing-builder--state" role="alert">
+        <h1>Landing page unavailable</h1>
+        <p>{productError ?? 'This Product could not be loaded.'}</p>
+        <Button type="button" variant="secondary" onClick={() => navigate(appRoutes.products)}>
+          Back to Products
+        </Button>
+      </main>
+    );
+  }
+
+  const customizationControls = (
+    <>
+      <section>
+        <div className="product-landing-builder__section-heading">
+          <h2>Landing content</h2>
+          <p>Product details and Creator profile stay read-only here.</p>
+        </div>
+        <Textarea
+          label="Marketing description"
+          value={draftConfig?.marketingDescription ?? ''}
+          onChange={(event) =>
+            updateDraft({ marketingDescription: event.target.value })
+          }
+          maxLength={1200}
+          isMaxLengthShown
+          block
+        />
+      </section>
+
+      <section>
+        <div className="product-landing-builder__section-heading">
+          <h2>Hero layout</h2>
+        </div>
+        <div className="product-landing-builder__segmented">
+          {heroLayoutOptions.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              variant={
+                draftConfig?.heroLayout === option.value ? 'primary' : 'secondary'
+              }
+              onClick={() => updateDraft({ heroLayout: option.value })}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="product-landing-builder__section-heading">
+          <h2>Sections</h2>
+        </div>
+        <div className="product-landing-builder__section-list">
+          {draftConfig?.sectionOrder.map((section, index) => (
+            <article key={section}>
+              <label>
+                <input
+                  type="checkbox"
+                  name={`section-${section}`}
+                  checked={draftConfig.visibleSections.includes(section)}
+                  onChange={() => toggleSection(section)}
+                />
+                <span>{productLandingPageSectionLabels[section]}</span>
+              </label>
+              <div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Move ${productLandingPageSectionLabels[section]} up`}
+                  disabled={index === 0}
+                  onClick={() =>
+                    updateDraft({
+                      sectionOrder: moveSection(
+                        draftConfig.sectionOrder,
+                        section,
+                        -1,
+                      ),
+                    })
+                  }
+                >
+                  <Icon icon={FiArrowUp} color="currentColor" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Move ${productLandingPageSectionLabels[section]} down`}
+                  disabled={index === draftConfig.sectionOrder.length - 1}
+                  onClick={() =>
+                    updateDraft({
+                      sectionOrder: moveSection(
+                        draftConfig.sectionOrder,
+                        section,
+                        1,
+                      ),
+                    })
+                  }
+                >
+                  <Icon icon={FiArrowDown} color="currentColor" />
+                </Button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="product-landing-builder__section-heading">
+          <h2>Read-only Product source</h2>
+        </div>
+        <dl className="product-landing-builder__facts">
+          <div>
+            <dt>Status</dt>
+            <dd>
+              <StatusBadge
+                label={getProductStatusLabel(loadedProduct.status)}
+                tone={loadedProduct.status === 'PUBLISHED' ? 'success' : 'neutral'}
+                size="sm"
+              />
+            </dd>
+          </div>
+          <div>
+            <dt>Price</dt>
+            <dd>{formatProductPrice(loadedProduct)}</dd>
+          </div>
+        </dl>
+      </section>
+
+      {(configError || saveError || savedMessage) && (
+        <p
+          className="product-landing-builder__feedback"
+          role={saveError ? 'alert' : 'status'}
+        >
+          {saveError ?? savedMessage ?? configError}
+        </p>
+      )}
+    </>
+  );
+
+  return (
+    <main className="product-landing-builder">
+      <header className="product-landing-builder__topbar">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => navigate(appRoutes.productsOverview(loadedProduct.id))}
+          leadingIcon={<Icon icon={FiArrowLeft} color="currentColor" />}
+        >
+          Product Overview
+        </Button>
+        <div>
+          <span>{getProductTypeLabel(loadedProduct.type)}</span>
+          <h1>{loadedProduct.name || 'Untitled product'}</h1>
+        </div>
+        <div className="product-landing-builder__actions">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate(appRoutes.productsEdit(loadedProduct.id))}
+            leadingIcon={<Icon icon={FiSettings} color="currentColor" />}
+          >
+            Edit product details
+          </Button>
+          {loadedProduct.status === 'PUBLISHED' && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => navigate(appRoutes.product(loadedProduct.id))}
+              leadingIcon={<Icon icon={FiExternalLink} color="currentColor" />}
+            >
+              View public page
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!hasChanges || saveLoading}
+            onClick={reset}
+            leadingIcon={<Icon icon={FiRefreshCw} color="currentColor" />}
+          >
+            Reset
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            loading={saveLoading}
+            disabled={!hasChanges}
+            onClick={save}
+            leadingIcon={<Icon icon={FiSave} color="currentColor" />}
+          >
+            Save
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            className="product-landing-builder__mobile-customize"
+            aria-expanded={customizeOpen && isMobileCustomize}
+            onClick={() => setCustomizeOpen(true)}
+            leadingIcon={<Icon icon={FiSliders} color="currentColor" />}
+          >
+            Customize
+          </Button>
+        </div>
+      </header>
+
+      <section className="product-landing-builder__workspace">
+        <aside className="product-landing-builder__controls" aria-label="Landing page controls">
+          {customizationControls}
+        </aside>
+
+        <section className="product-landing-builder__preview" aria-label="Landing page preview">
+          {previewModel && <ProductLandingPage product={previewModel} />}
+        </section>
+      </section>
+
+      <Drawer
+        open={customizeOpen && isMobileCustomize}
+        title={<h2>Customize landing page</h2>}
+        onClose={() => setCustomizeOpen(false)}
+        className="product-landing-builder__drawer"
+      >
+        <div className="product-landing-builder__controls product-landing-builder__controls--drawer">
+          {customizationControls}
+        </div>
+      </Drawer>
+    </main>
+  );
+};
+
+export default ProductLandingPageBuilder;

--- a/src/domains/app/pages/creator-specific/products/product-landing-page-builder/product-landing-page-builder.styles.scss
+++ b/src/domains/app/pages/creator-specific/products/product-landing-page-builder/product-landing-page-builder.styles.scss
@@ -1,0 +1,249 @@
+@use '../../../../../../styles/breakpoints' as *;
+@use '../../../../../../styles/radius' as *;
+@use '../../../../../../styles/spacing' as *;
+
+.product-landing-builder {
+  min-height: 100vh;
+  background: var(--surface-canvas);
+  color: var(--text-primary);
+}
+
+.product-landing-builder--state {
+  display: grid;
+  place-content: center;
+  gap: $spacing-4;
+  padding: $spacing-7;
+  text-align: center;
+
+  h1,
+  p {
+    margin: 0;
+  }
+
+  p {
+    color: var(--text-secondary);
+  }
+}
+
+.product-landing-builder__topbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: $spacing-4;
+  align-items: center;
+  border-bottom: 1px solid var(--border-primary);
+  padding: $spacing-4 $spacing-5;
+  background: color-mix(in srgb, var(--surface-panel) 94%, transparent);
+  backdrop-filter: blur(18px);
+
+  > div:nth-child(2) {
+    min-width: 0;
+
+    span {
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+  }
+
+  h1 {
+    overflow: hidden;
+    margin: $spacing-1 0 0;
+    font-size: 1.2rem;
+    letter-spacing: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.product-landing-builder__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+  justify-content: flex-end;
+}
+
+.product-landing-builder__mobile-customize {
+  display: none;
+}
+
+.product-landing-builder__workspace {
+  display: grid;
+  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  min-height: calc(100vh - 81px);
+}
+
+.product-landing-builder__controls {
+  display: grid;
+  align-content: start;
+  gap: $spacing-5;
+  border-right: 1px solid var(--border-primary);
+  padding: $spacing-5;
+  background: var(--surface-panel);
+
+  > section {
+    display: grid;
+    gap: $spacing-3;
+    border-bottom: 1px solid var(--border-primary);
+    padding-bottom: $spacing-5;
+  }
+
+  > section:last-of-type {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+}
+
+.product-landing-builder__controls--drawer {
+  border-right: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.product-landing-builder__section-heading {
+  display: grid;
+  gap: $spacing-1;
+
+  h2,
+  p {
+    margin: 0;
+  }
+
+  h2 {
+    font-size: 1rem;
+    letter-spacing: 0;
+  }
+
+  p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+}
+
+.product-landing-builder__segmented {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: $spacing-2;
+}
+
+.product-landing-builder__section-list {
+  display: grid;
+  gap: $spacing-2;
+
+  article {
+    display: flex;
+    gap: $spacing-2;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid var(--border-primary);
+    border-radius: $radius-sm;
+    padding: $spacing-2;
+    background: var(--surface-panel-elevated);
+  }
+
+  label {
+    display: flex;
+    gap: $spacing-2;
+    align-items: center;
+    min-width: 0;
+    color: var(--text-primary);
+    font-weight: 700;
+  }
+
+  input[type='checkbox'] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--brand-primary);
+  }
+
+  label span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  article > div {
+    display: flex;
+    gap: $spacing-1;
+  }
+}
+
+.product-landing-builder__facts {
+  display: grid;
+  gap: $spacing-2;
+  margin: 0;
+
+  div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-3;
+  }
+
+  dt {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+  }
+
+  dd {
+    margin: 0;
+    color: var(--text-primary);
+    font-weight: 700;
+  }
+}
+
+.product-landing-builder__feedback {
+  margin: 0;
+  border: 1px solid var(--border-primary);
+  border-radius: $radius-sm;
+  padding: $spacing-3;
+  background: var(--surface-panel-elevated);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.product-landing-builder__preview {
+  min-width: 0;
+  background: #0f1724;
+  overflow: auto;
+
+  .product-landing {
+    min-height: 100%;
+  }
+}
+
+@media (max-width: $bp-tablet) {
+  .product-landing-builder__topbar {
+    position: static;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .product-landing-builder__actions {
+    justify-content: flex-start;
+  }
+
+  .product-landing-builder__workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .product-landing-builder__controls {
+    display: none;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-primary);
+  }
+
+  .product-landing-builder__controls--drawer {
+    display: grid;
+    border-bottom: 0;
+  }
+
+  .product-landing-builder__mobile-customize {
+    display: inline-flex;
+  }
+}

--- a/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.test.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.test.tsx
@@ -163,6 +163,18 @@ describe('<ProductOverview />', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/app/products/edit/course-1');
   });
 
+  it('navigates to Product Landing Page Builder from Edit landing page', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderOverview();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Edit landing page' }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/products/course-1/landing-page');
+  });
+
   it('shows the public page action only for published products', async () => {
     mock.onGet('api/products/course-1').reply(200, courseProduct);
 

--- a/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.tsx
+++ b/src/domains/app/pages/creator-specific/products/product-overview/product-overview.component.tsx
@@ -487,6 +487,15 @@ const ProductOverview: React.FC = () => {
           >
             Edit product
           </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() =>
+              navigate(appRoutes.productsLandingPage(loadedProduct.id))
+            }
+          >
+            Edit landing page
+          </Button>
           {loadedProduct.status === 'PUBLISHED' && (
             <Button
               type="button"

--- a/src/domains/app/pages/product-page/product-page.component.test.tsx
+++ b/src/domains/app/pages/product-page/product-page.component.test.tsx
@@ -1,0 +1,354 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import MockAdapter from 'axios-mock-adapter';
+import { Provider } from 'react-redux';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import httpClient from 'core/api/http-client';
+import { AbstractProduct, PublicStorefront } from 'core/api/models';
+import authReducer from 'core/store/auth-store/auth.slice';
+import productLandingPageReducer from 'core/store/product-landing-page-store/product-landing-page.slice';
+import productReducer from 'core/store/product-store/product.slice';
+import storefrontReducer from 'core/store/storefront-store/storefront.slice';
+
+import ProductPage from './product-page.component';
+
+jest.mock('../../../../assets/image-placeholder.png', () => 'placeholder.png');
+
+const courseProduct: AbstractProduct = {
+  id: 'course-1',
+  type: 'COURSE',
+  name: 'Creator Product Growth System',
+  description: 'Package and launch a stronger creator offer.',
+  status: 'PUBLISHED',
+  price: 149,
+  currency: 'EUR',
+  userId: 'creator-1',
+  imageUrl: 'https://cdn.example.com/course.jpg',
+  sections: [
+    {
+      id: 'section-1',
+      title: 'Positioning foundations',
+      description: 'Clarify the buyer and promise.',
+      position: 1,
+      lessons: [
+        {
+          id: 'lesson-1',
+          sectionId: 'section-1',
+          title: 'Define the transformation',
+          description: '',
+          type: 'VIDEO',
+        },
+        {
+          id: 'lesson-2',
+          sectionId: 'section-1',
+          title: 'Price the offer',
+          description: '',
+          type: 'ARTICLE',
+        },
+      ],
+    },
+  ],
+};
+
+const downloadProduct: AbstractProduct = {
+  id: 'download-1',
+  type: 'DOWNLOAD',
+  name: 'Launch Assets Pack',
+  description: 'Templates for a focused launch.',
+  status: 'PUBLISHED',
+  price: 'free',
+  userId: 'creator-1',
+  sections: [
+    {
+      id: 'section-download',
+      title: 'Planning templates',
+      position: 1,
+      files: [
+        {
+          id: 'file-1',
+          fileName: 'launch-calendar.pdf',
+        },
+      ],
+    },
+  ],
+};
+
+const consultationProduct: AbstractProduct = {
+  id: 'consultation-1',
+  type: 'CONSULTATION',
+  name: 'Launch Strategy Session',
+  description: 'A focused session for your next launch.',
+  status: 'PUBLISHED',
+  price: 250,
+  userId: 'creator-1',
+  consultationDetails: {
+    durationMinutes: 60,
+    meetingMethod: 'ZOOM',
+    cancellationPolicy: 'Cancel up to 24 hours before the session.',
+  },
+};
+
+const membershipProduct: AbstractProduct = {
+  id: 'membership-1',
+  type: 'MEMBERSHIP',
+  name: 'Creator Lab Membership',
+  description: 'Ongoing creator systems support.',
+  status: 'PUBLISHED',
+  price: 19,
+  pricingModel: 'RECURRING',
+  billingInterval: 'MONTH',
+  currency: 'EUR',
+  userId: 'creator-1',
+};
+
+const publicStorefront: PublicStorefront = {
+  id: 'storefront-1',
+  creator: {
+    id: 'creator-1',
+    displayName: 'Maya Chen',
+    title: 'Creator strategist',
+    bio: 'Helps creators package useful products.',
+  },
+  products: [],
+  theme: {
+    appearance: 'LIGHT',
+    accentColor: '#0ea5e9',
+    typography: 'FRIENDLY',
+  },
+};
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <span data-testid="location">{location.pathname}</span>;
+};
+
+const renderProductPage = (initialEntry = '/app/product/course-1') => {
+  const testStore = configureStore({
+    reducer: {
+      auth: authReducer,
+      productLandingPage: productLandingPageReducer,
+      products: productReducer,
+      storefront: storefrontReducer,
+    },
+    preloadedState: {
+      auth: {
+        user: null,
+        loading: false,
+        error: null,
+        isUserLoggedIn: false,
+      },
+    },
+  });
+
+  return render(
+    <Provider store={testStore}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/app/product/:id"
+            element={
+              <>
+                <LocationProbe />
+                <ProductPage />
+              </>
+            }
+          />
+          <Route
+            path="/app/product/:id/:type"
+            element={
+              <>
+                <LocationProbe />
+                <ProductPage />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+describe('<ProductPage />', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(httpClient, { delayResponse: 0 });
+    mock.onGet('api/storefronts/creator-1').reply(200, publicStorefront);
+    mock.onGet(/api\/products\/[^/]+\/landing-page$/).reply((request) => {
+      const parts = request.url?.split('/') ?? [];
+      const productId = parts[parts.length - 2] ?? '';
+
+      return [
+        200,
+        {
+          id: `config-${productId}`,
+          productId,
+          marketingDescription: '',
+          heroLayout: 'MEDIA_RIGHT',
+          visibleSections: ['CONTENTS', 'CREATOR'],
+          sectionOrder: ['ABOUT', 'CONTENTS', 'CREATOR'],
+        },
+      ];
+    });
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('renders a published Product through the shared landing page with real data', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    const { container } = renderProductPage();
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Creator Product Growth System',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Package and launch a stronger creator offer.').length)
+      .toBeGreaterThan(0);
+    expect(screen.getAllByText('Course').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('€149').length).toBeGreaterThan(0);
+    expect(screen.getByText('Purchase currently unavailable')).toBeInTheDocument();
+    expect(screen.getByAltText('Creator Product Growth System thumbnail'))
+      .toHaveAttribute('src', 'https://cdn.example.com/course.jpg');
+
+    await waitFor(() => {
+      expect(screen.getByText('Maya Chen')).toBeInTheDocument();
+    });
+
+    const landing = container.querySelector('.product-landing');
+    expect(landing).toHaveClass('product-landing--light');
+    expect(landing).toHaveClass('product-landing--type-friendly');
+    expect(landing).toHaveStyle('--product-landing-accent: #0ea5e9');
+  });
+
+  it('applies persisted public landing-page config when available', async () => {
+    mock.resetHandlers();
+    mock.onGet('api/storefronts/creator-1').reply(200, publicStorefront);
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+    mock.onGet('api/products/course-1/landing-page').reply(200, {
+      id: 'config-course-1',
+      productId: 'course-1',
+      marketingDescription: 'A deeper promise for the public landing page.',
+      heroLayout: 'MEDIA_LEFT',
+      visibleSections: ['ABOUT', 'CONTENTS'],
+      sectionOrder: ['ABOUT', 'CONTENTS', 'CREATOR'],
+    });
+
+    const { container } = renderProductPage();
+
+    expect(
+      await screen.findByText('A deeper promise for the public landing page.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Maya Chen')).toBeNull();
+    expect(container.querySelector('.product-landing__hero'))
+      .toHaveClass('product-landing__hero--media-left');
+  });
+
+  it('does not render Draft Products as public Product pages', async () => {
+    mock.onGet('api/products/course-1').reply(200, {
+      ...courseProduct,
+      status: 'DRAFT',
+    });
+
+    renderProductPage();
+
+    expect(await screen.findByRole('heading', { name: 'Product unavailable' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('This Product is not publicly available.')).toBeInTheDocument();
+    expect(screen.queryByText('Purchase currently unavailable')).toBeNull();
+  });
+
+  it('does not render Hidden Products as public Product pages', async () => {
+    mock.onGet('api/products/course-1').reply(200, {
+      ...courseProduct,
+      status: 'HIDDEN',
+    });
+
+    renderProductPage();
+
+    expect(await screen.findByRole('heading', { name: 'Product unavailable' }))
+      .toBeInTheDocument();
+    expect(screen.queryByText('Creator Product Growth System')).toBeNull();
+  });
+
+  it('does not preserve legacy fake public Product content', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderProductPage();
+
+    expect(await screen.findByText('Purchase currently unavailable')).toBeInTheDocument();
+    expect(screen.queryByText(/Rating:/i)).toBeNull();
+    expect(screen.queryByText(/Swahili/i)).toBeNull();
+    expect(screen.queryByText(/4733 hours/i)).toBeNull();
+    expect(screen.queryByText(/This product includes/i)).toBeNull();
+    expect(screen.queryByText(/The One Handed Man/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Buy Now/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Add to Cart/i })).toBeNull();
+  });
+
+  it('renders free Product access as unavailable instead of wiring fake access', async () => {
+    mock.onGet('api/products/download-1').reply(200, downloadProduct);
+
+    renderProductPage('/app/product/download-1');
+
+    expect(await screen.findByRole('heading', { name: 'Launch Assets Pack' }))
+      .toBeInTheDocument();
+    expect(screen.getAllByText('Free').length).toBeGreaterThan(0);
+    expect(screen.getByText('Access currently unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Planning templates')).toBeInTheDocument();
+    expect(screen.getByText('launch-calendar.pdf')).toBeInTheDocument();
+  });
+
+  it('renders Membership recurring pricing and unavailable checkout', async () => {
+    mock.onGet('api/products/membership-1').reply(200, membershipProduct);
+
+    renderProductPage('/app/product/membership-1/MEMBERSHIP');
+
+    expect(await screen.findByRole('heading', { name: 'Creator Lab Membership' }))
+      .toBeInTheDocument();
+    expect(screen.getAllByText('€19 / month').length).toBeGreaterThan(0);
+    expect(screen.getByText('Membership checkout unavailable')).toBeInTheDocument();
+  });
+
+  it('renders representative Course content from loaded sections and lessons', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderProductPage();
+
+    expect(await screen.findByText('1 module and 2 lessons from the current curriculum.'))
+      .toBeInTheDocument();
+    expect(screen.getByText('Positioning foundations')).toBeInTheDocument();
+    expect(screen.getByText('Define the transformation')).toBeInTheDocument();
+    expect(screen.getByText('Price the offer')).toBeInTheDocument();
+  });
+
+  it('renders representative Consultation details without fake duration claims', async () => {
+    mock.onGet('api/products/consultation-1').reply(200, consultationProduct);
+
+    renderProductPage('/app/product/consultation-1');
+
+    expect(await screen.findByRole('heading', { name: 'Launch Strategy Session' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('60 minutes')).toBeInTheDocument();
+    expect(screen.getByText('Zoom')).toBeInTheDocument();
+    expect(screen.getByText('Cancel up to 24 hours before the session.')).toBeInTheDocument();
+    expect(screen.queryByText(/4733 hours/i)).toBeNull();
+  });
+
+  it('keeps type-bearing routes as compatibility paths and redirects mismatches', async () => {
+    mock.onGet('api/products/course-1').reply(200, courseProduct);
+
+    renderProductPage('/app/product/course-1/DOWNLOAD');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/app/product/course-1');
+    });
+  });
+});

--- a/src/domains/app/pages/product-page/product-page.component.tsx
+++ b/src/domains/app/pages/product-page/product-page.component.tsx
@@ -1,13 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { AbstractProduct, AppDispatch } from 'core/api/models';
-import { Button, LegacyExpansionPanel } from '@shared/ui';
+import { AppDispatch, RootState } from 'core/api/models';
 import { selectAuthUser } from 'core/store/auth-store';
-import { getProductById } from 'core/store/product-store';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const placeholderImage = require('../../../../assets/image-placeholder.png');
+import {
+  clearCurrentProduct,
+  getProductById,
+  selectCurrentProduct,
+  selectProductsError,
+  selectProductsLoading,
+} from 'core/store/product-store';
+import {
+  fetchPublicProductLandingPageConfig,
+  selectPublicProductLandingPageConfigByProductId,
+} from 'core/store/product-landing-page-store';
+import {
+  fetchPublicStorefront,
+  selectCreatorStorefrontConfig,
+  selectPublicStorefrontByCreatorId,
+} from 'core/store/storefront-store';
+import {
+  getProductLandingPageViewModel,
+  isPublicProductLandingPageProduct,
+  ProductLandingPage,
+} from 'domains/app/features/product-landing-page';
 
 import './product-page.styles.scss';
 
@@ -16,140 +33,100 @@ const ProductPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const user = useSelector(selectAuthUser);
-  const [product, setProduct] = useState<AbstractProduct | null>(null);
-  const [numberOfSections, setNumberOfSections] = useState<number>(0);
-  const [numberOfLessons, setNumberOfLessons] = useState<number>(0);
-  const [isOwner, setIsOwner] = useState<boolean>(false);
+  const currentProduct = useSelector(selectCurrentProduct);
+  const loading = useSelector(selectProductsLoading);
+  const error = useSelector(selectProductsError);
+  const creatorStorefrontConfig = useSelector(selectCreatorStorefrontConfig);
+  const loadedProduct =
+    currentProduct?.id && currentProduct.id === id ? currentProduct : null;
+  const publicStorefront = useSelector((state: RootState) =>
+    selectPublicStorefrontByCreatorId(state, loadedProduct?.userId),
+  );
+  const landingPageConfig = useSelector((state: RootState) =>
+    selectPublicProductLandingPageConfigByProductId(state, loadedProduct?.id),
+  );
+  const isOwner = Boolean(user?.id && user.id === loadedProduct?.userId);
 
   useEffect(() => {
     if (id) {
-      dispatch(getProductById({ productId: id }))
-        .unwrap()
-        .then((product) => {
-          if (type && product.type !== type) {
-            navigate(`/app/product/${product.id}`, { replace: true });
-          }
-          getProductInformation(product);
-          setProduct(product);
-        });
+      dispatch(clearCurrentProduct());
+      dispatch(getProductById({ productId: id }));
     }
-  }, [dispatch, id, navigate, type]);
+  }, [dispatch, id]);
 
   useEffect(() => {
-    if (user && user.id === product?.userId) {
-      setIsOwner(true);
-    } else {
-      setIsOwner(false);
+    if (loadedProduct && type && loadedProduct.type !== type) {
+      navigate(`/app/product/${loadedProduct.id}`, { replace: true });
     }
-  }, [product, user]);
+  }, [loadedProduct, navigate, type]);
 
-  const getProductInformation = (product: AbstractProduct) => {
-    let numOfSections = 0;
-    let numOfLessons = 0;
+  useEffect(() => {
+    if (
+      loadedProduct?.userId &&
+      isPublicProductLandingPageProduct(loadedProduct) &&
+      !publicStorefront
+    ) {
+      dispatch(fetchPublicStorefront(loadedProduct.userId));
+    }
+  }, [dispatch, loadedProduct, publicStorefront]);
 
-    product.type === 'COURSE' &&
-      product.sections?.forEach((section) => {
-        numOfSections++;
-        section.lessons?.forEach(() => {
-          numOfLessons++;
-        });
-      });
-    setNumberOfLessons(numOfLessons);
-    setNumberOfSections(numOfSections);
-  };
+  useEffect(() => {
+    if (loadedProduct && isPublicProductLandingPageProduct(loadedProduct)) {
+      dispatch(fetchPublicProductLandingPageConfig(loadedProduct.id));
+    }
+  }, [dispatch, loadedProduct]);
 
-  return (
-    <div className="product-page">
-      {!product ? (
-        <p>Product not found</p>
-      ) : (
-        <>
-          <div className="product-banner">
-            <div className="product-main-info">
-              <h1>{product?.name}</h1>
-              <p>{product?.type}</p>
-              <p>
-                Short description, with some kinda lorem ipsum dolor sit amet,
-                consectetur adipiscing elit. Sed euismod, urna eu tincidunt
-                consectetur, nisi nisl aliquam nunc, vitae dictum.
-              </p>
-              <p>Rating: 4.7/5 (196,043 customers)</p>
-              <p>Created by: The One Handed Man</p>
-              <p>{product?.price}</p>
-              <div className="cta-buttons">
-                {isOwner ? (
-                  <Button
-                    type="button"
-                    variant="primary"
-                    onClick={() =>
-                      navigate(
-                        `/app/products/edit/${product.id}`,
-                      )
-                    }
-                  >
-                    Edit
-                  </Button>
-                ) : (
-                  <>
-                    <Button type="button" variant="primary">
-                      Add to Cart
-                    </Button>
-                    <Button type="button" variant="secondary">
-                      Buy Now
-                    </Button>
-                  </>
-                )}
-              </div>
-              <p>Last updated: 2 days ago</p>
-              <p>Language: Swahili</p>
-            </div>
-            <div className="product-image">
-              <img
-                src={placeholderImage}
-                alt={product?.name}
-                className="product-card-image"
-                width={300}
-              />
-            </div>
-          </div>
-          <div className="product-details">
-            <p>{product.description}</p>
-            <p>This product includes:</p>
-            <ul>
-              <li>some few hours of video, if it&apos;s a course</li>
-              <li>Maybe some assignments or quizzes, for the same reason</li>
-              <li>Some reading material and documentation</li>
-              <li>Some few hours of video, if it&apos;s a download as well</li>
-              <li>
-                Some minutes of alone time with the creator for a consultation
-              </li>
-            </ul>
-            <p>The product&apos;s content</p>
-            <p>
-              {numberOfSections} sections, {numberOfLessons} lessons, 4733 hours
-              of total length
-            </p>
-            {product.type === 'COURSE' &&
-              product.sections?.map((section) => (
-                <LegacyExpansionPanel
-                  key={section.id}
-                  header={section.title || ''}
-                >
-                  <p>Duration: 2 min</p>
-                  <p>{section.description}</p>
-                  {section.lessons?.map((lesson) => (
-                    <div key={lesson.id} className="lesson-line">
-                      <h3>{lesson.title}</h3>
-                      <p>Type: {lesson.type}</p>
-                    </div>
-                  ))}
-                </LegacyExpansionPanel>
-              ))}
-          </div>
-        </>
-      )}
-    </div>
-  );
+  const viewModel = useMemo(() => {
+    if (!loadedProduct || !isPublicProductLandingPageProduct(loadedProduct)) {
+      return null;
+    }
+
+    return getProductLandingPageViewModel({
+      product: loadedProduct,
+      currentUser: user,
+      publicStorefront,
+      creatorStorefrontTheme: isOwner
+        ? creatorStorefrontConfig?.theme
+        : undefined,
+      landingPageConfig,
+    });
+  }, [
+    creatorStorefrontConfig?.theme,
+    isOwner,
+    landingPageConfig,
+    loadedProduct,
+    publicStorefront,
+    user,
+  ]);
+
+  if (loading && !loadedProduct) {
+    return (
+      <main className="product-page-state" aria-busy="true">
+        <h1>Loading Product</h1>
+        <p>Preparing this Product page.</p>
+      </main>
+    );
+  }
+
+  if (error || !loadedProduct) {
+    return (
+      <main className="product-page-state" role="alert">
+        <h1>Product unavailable</h1>
+        <p>{error ?? 'This Product page could not be loaded.'}</p>
+      </main>
+    );
+  }
+
+  if (!viewModel) {
+    return (
+      <main className="product-page-state" role="alert">
+        <h1>Product unavailable</h1>
+        <p>This Product is not publicly available.</p>
+      </main>
+    );
+  }
+
+  return <ProductLandingPage product={viewModel} />;
 };
 
 export default ProductPage;

--- a/src/domains/app/pages/product-page/product-page.styles.scss
+++ b/src/domains/app/pages/product-page/product-page.styles.scss
@@ -1,18 +1,21 @@
-.product-page {
-  padding: 50px 0;
+.product-page-state {
+  display: grid;
+  place-content: center;
+  min-height: 70vh;
+  padding: 48px 24px;
+  text-align: center;
 
-  .product-banner {
-    display: flex;
-    flex-wrap: nowrap;
-    width: 80%;
-    margin: auto;
-    gap: 40px;
-    justify-content: space-between;
+  h1 {
+    margin: 0 0 12px;
+    color: var(--text-primary);
+    font-size: 2rem;
+    letter-spacing: 0;
   }
 
-  .product-details {
-    width: 80%;
-    margin: auto;
-    padding-top: 50px;
+  p {
+    max-width: 520px;
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.6;
   }
 }

--- a/src/domains/app/routes/app-router.test.tsx
+++ b/src/domains/app/routes/app-router.test.tsx
@@ -46,6 +46,7 @@ jest.mock('../pages', () => {
     LibraryPage: MockOutletPage,
     Onboarding: makePage('Onboarding'),
     ProductForm: makePage('Product form'),
+    ProductLandingPageBuilder: makePage('Product landing page builder'),
     ProductOverview: makePage('Product overview'),
     ProductPage: makePage('Product page'),
     ProductsList: makePage('Products list'),
@@ -122,6 +123,10 @@ describe('AppRouter role routing', () => {
     renderRouter([UserRole.CREATOR], '/products/product-1');
 
     expect(screen.getByText('Product overview')).toBeInTheDocument();
+
+    renderRouter([UserRole.CREATOR], '/products/product-1/landing-page');
+
+    expect(screen.getByText('Product landing page builder')).toBeInTheDocument();
 
     renderRouter([UserRole.CREATOR], '/products/edit/product-1');
 

--- a/src/domains/app/routes/app-router.tsx
+++ b/src/domains/app/routes/app-router.tsx
@@ -21,6 +21,7 @@ import {
   LibraryPage,
   Onboarding,
   ProductForm,
+  ProductLandingPageBuilder,
   ProductOverview,
   ProductPage,
   ProductsList,
@@ -115,6 +116,7 @@ const AppRouter: React.FC = () => (
           <Route path="create" element={<ProductForm />} />
           <Route path="edit/:id" element={<ProductForm />} />
           <Route path="edit/:type/:id" element={<ProductForm />} />
+          <Route path=":productId/landing-page" element={<ProductLandingPageBuilder />} />
           <Route path=":productId" element={<ProductOverview />} />
         </Route>
 

--- a/src/domains/app/routes/routes.ts
+++ b/src/domains/app/routes/routes.ts
@@ -8,6 +8,8 @@ export const appRoutes = {
 
   products: '/app/products',
   productsOverview: (productId = ':productId') => `/app/products/${productId}`,
+  productsLandingPage: (productId = ':productId') =>
+    `/app/products/${productId}/landing-page`,
   productsCreate: '/app/products/create',
   productsEdit: (id = ':id') => `/app/products/edit/${id}`,
   customers: '/app/customers',


### PR DESCRIPTION
Adds Product Landing Page V2 with a shared public presentation and Creator live builder.

- Replaces the legacy placeholder-heavy Product page with a real shared ProductLandingPage presentation
- Adds /app/products/:productId/landing-page as the Creator/Admin landing-page builder
- Adds Edit landing page from Product Overview while preserving Product Workspace and public-page actions
- Adds Product Landing Page configuration for marketing copy, hero layout, section visibility, and section ordering
- Adds backend-pending API/service/Redux/mock architecture for landing-page configuration
- Uses local draft state with explicit Save/Reset behavior and live preview updates
- Keeps Product fields Product-owned, Creator profile fields User/Profile-owned, and theme inherited from Storefront
- Applies public-safe landing-page config to the public Product route
- Preserves PUBLISHED-only public rendering
- Keeps checkout/access honestly unavailable until real backend commerce exists
- Adds responsive builder controls with mobile Drawer behavior and accessibility coverage
- Updates PROJECT_CONTEXT.md with the new landing-page architecture and boundaries

Verification

- TypeScript passed
- Lint passed with existing warnings only
- 82 test suites passed
- 461 tests passed

Intentionally deferred

- Production landing-page persistence
- dedicated public Product read model
- server-enforced visibility
- checkout/subscriptions/free fulfillment/waitlists
- media galleries/promo media
- reviews/analytics
- SEO/slugs/custom domains
- arbitrary page-builder blocks